### PR TITLE
Append ignored url path configuration for the data plane

### DIFF
--- a/Rudder/Classes/RSConfigBuilder.m
+++ b/Rudder/Classes/RSConfigBuilder.m
@@ -22,6 +22,9 @@
     } else {
       config.dataPlaneUrl = [[NSString alloc] initWithFormat:@"%@://%@", [url scheme], [url host]];
     }
+    if (![[url path] isEqualToString:@"/"]) {
+      config.dataPlaneUrl = [config.dataPlaneUrl stringByAppendingString: [url path]];
+    }
     return self;
 }
 
@@ -36,6 +39,9 @@
     } else {
       config.dataPlaneUrl = [[NSString alloc] initWithFormat:@"%@://%@", [url scheme], [url host]];
     }
+    if (![[url path] isEqualToString:@"/"]) {
+      config.dataPlaneUrl = [config.dataPlaneUrl stringByAppendingString: [url path]];
+    }
     return self;
 }
 
@@ -47,6 +53,9 @@
       config.dataPlaneUrl = [[NSString alloc] initWithFormat:@"%@://%@:%@", [dataPlaneURL scheme], [dataPlaneURL host] ,[dataPlaneURL port]];
     } else {
       config.dataPlaneUrl = [[NSString alloc] initWithFormat:@"%@://%@", [dataPlaneURL scheme], [dataPlaneURL host]];
+    }
+    if (![[dataPlaneURL path] isEqualToString:@"/"]) {
+      config.dataPlaneUrl = [config.dataPlaneUrl stringByAppendingString: [dataPlaneURL path]];
     }
     return self;
 }


### PR DESCRIPTION
Append ignored url path configuration for the data plane

Unhandled use case:

`
<scheme>//:<host>:<port>/<path>
`
Ex.

https://my.dataplane.com/dataplane_path

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/rudderlabs/rudder-sdk-ios/39)
<!-- Reviewable:end -->
