### PR TITLE
Add imports to fix SPM build

### DIFF
--- a/Rudder/Classes/RSPreferenceManager.m
+++ b/Rudder/Classes/RSPreferenceManager.m
@@ -6,6 +6,7 @@
 //
 
 #import "RSPreferenceManager.h"
+#import <UIKit/UIKit.h>
 
 static RSPreferenceManager *instance;
 


### PR DESCRIPTION
## Description of the change

Actually if add Rudder SDK via SPM it fails to build with "Use of undeclared identifier 'UIDevice'".

## Type of change
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklists

### Development

- [x] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests
- [ ] All tests related to the changed code pass in development

### Code review 

- [x]  This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] "Ready for review" label attached to the PR and reviewers mentioned in a comment
- [ ] Changes have been reviewed by at least one other engineer
- [ ] Issue from task tracker has a link to this pull request 

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/rudderlabs/rudder-sdk-ios/54)
<!-- Reviewable:end -->
