### PR TITLE
[WIP] Add setAnonymousIdOnce and delete anonymous id on reset

### DIFF
--- a/Rudder/RSClient.m
+++ b/Rudder/RSClient.m
@@ -240,6 +240,8 @@ static RSOption* _defaultOptions = nil;
     if (_repository != nil) {
         [_repository reset];
     }
+    
+    [[RSPreferenceManager getInstance] clearAnonymousId];
 }
 
 - (void)flush {

--- a/Rudder/RSPreferenceManager.h
+++ b/Rudder/RSPreferenceManager.h
@@ -39,6 +39,7 @@ extern NSString *const RSExternalIdKey;
 
 - (NSString* __nullable) getAnonymousId;
 - (void) saveAnonymousId: (NSString* __nullable) anonymousId;
+- (void) clearAnonymousId;
 
 @end
 

--- a/Rudder/RSPreferenceManager.m
+++ b/Rudder/RSPreferenceManager.m
@@ -98,4 +98,19 @@ NSString *const RSAnonymousIdKey =  @"rl_anonymous_id";
     [[NSUserDefaults standardUserDefaults] synchronize];
 }
 
+- (void)saveAnonymousIdOnce:(NSString *)anonymousId {
+    NSString *storedKey = [[NSUserDefaults standardUserDefaults] valueForKey:RSAnonymousIdKey];
+    
+    // if anonymousId has not been set, then set new one
+    // else use existing
+    if (storedKey == nil) {
+        [[NSUserDefaults standardUserDefaults] setValue:anonymousId forKey:RSAnonymousIdKey];
+        [[NSUserDefaults standardUserDefaults] synchronize];
+    }
+}
+
+- (void)clearAnonymousId {
+    [self saveAnonymousId:nil];
+}
+
 @end


### PR DESCRIPTION
## Description of the change

Feedloop needs an SDK to store UUID from the application side, when it’s adjusted once, it needs to be stored locally once, subsequent sets will be ignored. 

In order to make the SDK's API to be consistent, I develop new **setAnonymousIdOnce** for above requirements.

Also, **RSClient.reset** method needs to be deleted to update the AnonymousID with a new random UUID, when the user logs in again.

## Type of change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related issues

N/A

## Checklists

### Development

- [x] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests
- [ ] All tests related to the changed code pass in development

Notes:

- No unit test in the SDK found

### Code review 

- [ ]  This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] "Ready for review" label attached to the PR and reviewers mentioned in a comment
- [ ] Changes have been reviewed by at least one other engineer
- [ ] Issue from task tracker has a link to this pull request

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/rudderlabs/rudder-sdk-ios/79)
<!-- Reviewable:end -->
