### PR TITLE
Prevent long blocking of main thread

### DIFF
--- a/Sources/Classes/Client/Plugins/RudderDestinationPlugin.swift
+++ b/Sources/Classes/Client/Plugins/RudderDestinationPlugin.swift
@@ -129,7 +129,7 @@ extension RudderDestinationPlugin {
     }
     
     func periodicFlush() {
-        uploadsQueue.sync { [weak self] in
+        uploadsQueue.async { [weak self] in
             guard let self = self else { return }
             self.prepareEventsToFlush()
         }


### PR DESCRIPTION
## Type of change
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
## Checklist:
- [ ] Version updated in `README`
- [ ] Version updated in `RSConstants.m`(v1)/`RSConstant.swift`(v2)
- [ ] Version updated in `Rudder.xcodeproj`
- [ ] Version updated in `Rudder.podspec`
- [ ] `CHANGELOG` Updated
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added unit tests for the code
- [ ] I have made corresponding changes to the documentation
- [ ] Passed `pod lib lint --no-clean --allow-warnings`


## Description

The periodic flush in `RudderDestinationPlugin` blocks the main thread, sometimes for a very long time (I've seen 10 seconds once). The series of events that lead to this are:

* `RudderDestinationPlugin.initialSetup()` sets up a `RSRepeatingTimer` which default to the main queue. (BTW, as far as I can see that's a retain cycle there as the block strong-captures self.)
* The timer then calls `periodicFlush()` on the main thread.
* It dispatches a block to the `uploadsQueue`, but does so _synchronously_, thus blocking the main thread until the block finally finishes.

There are multiple ways to solve this (have the timer dispatch to the upload queue and call `prepareEventsToFlush()` in the handler, for example). This pull request just changes the synchronous dispatch to an asynchronous one.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/rudderlabs/rudder-sdk-ios/171)
<!-- Reviewable:end -->
