### PR TITLE
[Bugfix] Missing `properties.name` in screen calls for device modes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -77,3 +77,7 @@ All notable changes to this project will be documented in this file.
 ## Version - 2.2.1 - 2022-07-07
 ### Fix
 - Missing `properties.name` in screen calls.
+
+## Version - 2.2.2 - 2022-07-08
+### Fix
+- Missing `properties.name` in screen calls for device modes.

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 <p align="center">
   <a href="https://cocoapods.org/pods/Rudder">
-    <img src="https://img.shields.io/static/v1?label=pod&message=v2.2.1&color=blue&style=flat">
+    <img src="https://img.shields.io/static/v1?label=pod&message=v2.2.2&color=blue&style=flat">
     </a>
 </p>
 
@@ -47,7 +47,7 @@ The iOS SDK is available through [**CocoaPods**](https://cocoapods.org), [**Cart
 To install the SDK, simply add the following line to your Podfile:
 
 ```xcode
-pod 'Rudder', '2.2.1'
+pod 'Rudder', '2.2.2'
 ```
 
 ### Carthage
@@ -55,7 +55,7 @@ pod 'Rudder', '2.2.1'
 For Carthage support, add the following line to your `Cartfile`:
 
 ```xcode
-github "rudderlabs/rudder-sdk-ios" "v2.2.1"
+github "rudderlabs/rudder-sdk-ios" "v2.2.2"
 ```
 
 > Remember to include the following code where you want to refer to or use the RudderStack SDK classes, as shown:
@@ -86,7 +86,7 @@ You can also add the RudderStack SDK using the Swift Package Mangaer in one of t
 ![Adding a package](https://user-images.githubusercontent.com/59817155/140903027-286a1d64-f5d5-4041-9827-47b6cef76a46.png)
 
 2. Enter the package repository (`git@github.com:rudderlabs/rudder-sdk-ios.git`) in the search bar.
-3. In **Dependency Rule**, select **Up to Next Major Version**, and enter `2.2.1` as the value, as shown:
+3. In **Dependency Rule**, select **Up to Next Major Version**, and enter `2.2.2` as the value, as shown:
 
 ![Setting the dependency](https://user-images.githubusercontent.com/59817155/145574696-8c849749-13e0-40d5-aacb-3fccb5c8e67d.png)
 
@@ -113,7 +113,7 @@ let package = Package(
     ],
     dependencies: [
         // Dependencies declare other packages that this package depends on.
-        .package(url: "git@github.com:rudderlabs/rudder-sdk-ios.git", from: "2.2.1")
+        .package(url: "git@github.com:rudderlabs/rudder-sdk-ios.git", from: "2.2.2")
     ],
     targets: [
         // Targets are the basic building blocks of a package. A target can define a module or a test suite.

--- a/Rudder.podspec
+++ b/Rudder.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'Rudder'
-  s.version          = "2.2.1"
+  s.version          = "2.2.2"
   s.summary          = "Privacy and Security focused Segment-alternative. iOS, tvOS, watchOS & macOS SDK"
   s.description      = <<-DESC
   Rudder is a platform for collecting, storing and routing customer event data to dozens of tools. Rudder is open-source, can run in your cloud environment (AWS, GCP, Azure or even your data-centre) and provides a powerful transformation framework to process your event data on the fly.

--- a/Rudder.xcodeproj/project.pbxproj
+++ b/Rudder.xcodeproj/project.pbxproj
@@ -877,7 +877,7 @@
 				BUILD_LIBRARY_FOR_DISTRIBUTION = YES;
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 6;
+				CURRENT_PROJECT_VERSION = 7;
 				DEFINES_MODULE = YES;
 				DEVELOPMENT_TEAM = GTGKNDBD23;
 				DYLIB_COMPATIBILITY_VERSION = 1;
@@ -891,7 +891,7 @@
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
-				MARKETING_VERSION = 2.2.1;
+				MARKETING_VERSION = 2.2.2;
 				PRODUCT_BUNDLE_IDENTIFIER = com.rudderstack.RudderStack;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				SKIP_INSTALL = YES;
@@ -911,7 +911,7 @@
 				BUILD_LIBRARY_FOR_DISTRIBUTION = YES;
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 6;
+				CURRENT_PROJECT_VERSION = 7;
 				DEFINES_MODULE = YES;
 				DEVELOPMENT_TEAM = GTGKNDBD23;
 				DYLIB_COMPATIBILITY_VERSION = 1;
@@ -926,7 +926,7 @@
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
-				MARKETING_VERSION = 2.2.1;
+				MARKETING_VERSION = 2.2.2;
 				PRODUCT_BUNDLE_IDENTIFIER = com.rudderstack.RudderStack;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				SKIP_INSTALL = YES;

--- a/Sources/Classes/Client/RSClient.swift
+++ b/Sources/Classes/Client/RSClient.swift
@@ -203,7 +203,12 @@ extension RSClient {
             log(message: "screenName can not be empty", logLevel: .warning)
             return
         }
-        let message = ScreenMessage(title: screenName, category: category, properties: properties, option: option)
+        var screenProperties = ScreenProperties()
+        if let properties = properties {
+            screenProperties = properties
+        }
+        screenProperties["name"] = screenName
+        let message = ScreenMessage(title: screenName, category: category, properties: screenProperties, option: option)
             .applyRawEventData()
         process(message: message)
     }

--- a/Sources/Classes/Common/Constants/RSConstants.swift
+++ b/Sources/Classes/Common/Constants/RSConstants.swift
@@ -31,4 +31,4 @@ let MAX_EVENT_SIZE: UInt = 32 * 1024
 let MAX_BATCH_SIZE: UInt = 500 * 1024
 
 // don't move this line
-let RSVersion = "2.2.1"
+let RSVersion = "2.2.2"

--- a/Sources/Classes/Domain/Protocols/RSMessage.swift
+++ b/Sources/Classes/Domain/Protocols/RSMessage.swift
@@ -106,7 +106,6 @@ public struct ScreenMessage: RSMessage {
     
     private func dynamicDictionary(dictionary: inout [String: Any]) {
         dictionary["properties"] = properties
-        dictionary[keyPath: "properties.name"] = name
         dictionary["event"] = name
         dictionary["category"] = category
     }


### PR DESCRIPTION
## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
## Checklist:
- [x] Version updated in `README`
- [x] Version updated in `RSConstants.m`(v1)/`RSConstant.swift`(v2)
- [x] Version updated in `Rudder.xcodeproj`
- [x] Version updated in `Rudder.podspec`
- [x] `CHANGELOG` Updated
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added unit tests for the code
- [ ] I have made corresponding changes to the documentation
- [x] Passed `pod lib lint --no-clean --allow-warnings`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/rudderlabs/rudder-sdk-ios/178)
<!-- Reviewable:end -->
