### PR TITLE
Make `checkServerConfig` asynchronous

### DIFF
--- a/Sources/Classes/Client/RSClient.swift
+++ b/Sources/Classes/Client/RSClient.swift
@@ -13,7 +13,7 @@ open class RSClient: NSObject {
     var config: RSConfig?
     var controller: RSController
     var serverConfig: RSServerConfig?
-    var error: NSError?
+	internal var checkServerConfigInProgress = false
     static let shared = RSClient()
     
     private override init() {


### PR DESCRIPTION
Relates to #182.

## Type of change
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
## Checklist:
- [ ] Version updated in `README`
- [ ] Version updated in `RSConstants.m`(v1)/`RSConstant.swift`(v2)
- [ ] Version updated in `Rudder.xcodeproj`
- [ ] Version updated in `Rudder.podspec`
- [ ] `CHANGELOG` Updated
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added unit tests for the code
- [ ] I have made corresponding changes to the documentation
- [ ] Passed `pod lib lint --no-clean --allow-warnings`


This makes `checkServerConfig` asynchronous and avoids blocking the main thread. Relates to https://github.com/rudderlabs/rudder-sdk-ios/issues/182.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/rudderlabs/rudder-sdk-ios/185)
<!-- Reviewable:end -->
