### PR TITLE
Enhanced option and reset feature

### DIFF
--- a/Sources/Classes/Client/Plugins/RSContextPlugin.swift
+++ b/Sources/Classes/Client/Plugins/RSContextPlugin.swift
@@ -10,11 +10,20 @@ import Foundation
 
 class RSContextPlugin: RSPlatformPlugin {
     let type: PluginType = .before
-    weak var client: RSClient?
+    weak var client: RSClient? {
+        didSet {
+            initialSetup()
+        }
+    }
     
     private var staticContext = staticContextData()
     private static var device = Vendor.current
-    internal let userDefaults = RSUserDefaults()
+    private var userDefaults: RSUserDefaults?
+    
+    func initialSetup() {
+        guard let client = self.client else { return }
+        userDefaults = client.userDefaults
+    }
     
     func execute<T: RSMessage>(message: T?) -> T? {
         guard var workingMessage = message else { return message }
@@ -142,7 +151,7 @@ class RSContextPlugin: RSPlatformPlugin {
                 }
             }
             /// Fetch `externalIds` set using identify API.
-            if let externalIds: [[String: String]] = userDefaults.read(.externalId) {
+            if let externalIds: [[String: String]] = userDefaults?.read(.externalId) {
                 context["externalId"] = externalIds
             }
         }

--- a/Sources/Classes/Client/Plugins/RSContextPlugin.swift
+++ b/Sources/Classes/Client/Plugins/RSContextPlugin.swift
@@ -120,11 +120,8 @@ class RSContextPlugin: RSPlatformPlugin {
         }
     }
     
-    /**
-     * First priority will be of the `option` which is passed along with the event
-     * If above case didn't satisfy then `externalId` and / or `customContexts` will be set.
-     */
     func insertDynamicOptionData(message: RSMessage, context: inout [String: Any]) {
+        /// First priority will given to the `option` passed along with the event
         if let option = message.option {
             if let externalIds = option.externalIds {
                 context["externalId"] = externalIds
@@ -136,17 +133,17 @@ class RSContextPlugin: RSPlatformPlugin {
             }
         }
         else {
+            /// Fetch `customContexts` set using setOption API.
             if let globalOption: RSOption = RSSessionStorage.shared.read(.option) {
-                /// Fetch `externalIds` set using identify API.
-                if let externalIds: [[String: String]] = userDefaults.read(.externalId) {
-                    context["externalId"] = externalIds
-                }
-                /// Fetch `customContexts` set using setOption API.
                 if let customContexts = globalOption.customContexts {
                     for (key, value) in customContexts {
                         context[key] = value
                     }
                 }
+            }
+            /// Fetch `externalIds` set using identify API.
+            if let externalIds: [[String: String]] = userDefaults.read(.externalId) {
+                context["externalId"] = externalIds
             }
         }
     }

--- a/Sources/Classes/Client/RSClient.swift
+++ b/Sources/Classes/Client/RSClient.swift
@@ -288,6 +288,9 @@ extension RSClient {
             userDefaults.write(.traits, value: try? JSON(traits))
         }
         userDefaults.write(.userId, value: userId)
+        if let externalIds = option?.externalIds {
+            userDefaults.write(.externalId, value: try? JSON(externalIds))
+        }
         let message = IdentifyMessage(userId: userId, traits: traits, option: option)
             .applyRawEventData(userInfo: userInfo)
         process(message: message)

--- a/Sources/Classes/Helpers/RSUserDefaults.swift
+++ b/Sources/Classes/Helpers/RSUserDefaults.swift
@@ -19,6 +19,7 @@ class RSUserDefaults {
         case optInTime
         case optOutTime
         case context
+        case externalId
     }
     
     enum ApplicationKeys: String {
@@ -70,9 +71,9 @@ class RSUserDefaults {
     
     func reset() {
         syncQueue.sync {
-            for key in RSUserDefaults.Keys.allCases {
-                userDefaults.removeObject(forKey: key.rawValue)
-            }
+            // Generate new traits object with only anonymousId
+            // Overwrite old traits with new
+            // Reset externalIds
         }
     }
 }

--- a/Sources/Classes/Helpers/RSUserDefaults.swift
+++ b/Sources/Classes/Helpers/RSUserDefaults.swift
@@ -71,9 +71,9 @@ class RSUserDefaults {
     
     func reset() {
         syncQueue.sync {
-            // Generate new traits object with only anonymousId
-            // Overwrite old traits with new
-            // Reset externalIds
+            userDefaults.removeObject(forKey: RSUserDefaults.Keys.traits.rawValue)
+            userDefaults.removeObject(forKey: RSUserDefaults.Keys.externalId.rawValue)
+            userDefaults.removeObject(forKey: RSUserDefaults.Keys.userId.rawValue)
         }
     }
 }


### PR DESCRIPTION
## Description
> Enhanced the `option` feature: Now if `option` is set using `setOption` API then `integration` and `customContext` value will be persisted for the successive calls. Also if any event API contains any `option` then that will completely override the `global option` (which is set using setOption API).
> Now, RESET API will reset only three things: `traits`, `externalId` (this two are same as in v1) and `userId` (newly added in v2).

## Type of change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
## Checklist:
- [ ] Version updated in `README`
- [ ] Version updated in `RSConstants.m`(v1)/`RSConstant.swift`(v2)
- [ ] Version updated in `Rudder.xcodeproj`
- [ ] Version updated in `Rudder.podspec`
- [ ] `CHANGELOG` Updated
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added unit tests for the code
- [ ] I have made corresponding changes to the documentation
- [ ] Passed `pod lib lint --no-clean --allow-warnings`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/rudderlabs/rudder-sdk-ios/193)
<!-- Reviewable:end -->
