### PR TITLE
chore(release): pulling hotfix-release/1.7.1 into master

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
-All notable changes to this project will be documented in this file.
+
+All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
+
+### 1.7.1 (2022-11-04)
 
 ### [1.7.0](https://github.com/rudderlabs/rudder-sdk-ios/compare/v1.6.4...v1.7.0) (2022-09-22)
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 <p align="center">
   <a href="https://cocoapods.org/pods/Rudder">
-    <img src="https://img.shields.io/static/v1?label=pod&message=v1.7.0&color=blue&style=flat">
+    <img src="https://img.shields.io/static/v1?label=pod&message=v1.7.1&color=blue&style=flat">
     </a>
 </p>
 
@@ -39,7 +39,7 @@ The iOS SDK is available through [**CocoaPods**](https://cocoapods.org), [**Cart
 To install the SDK, simply add the following line to your Podfile:
 
 ```xcode
-pod 'Rudder', '1.7.0'
+pod 'Rudder', '1.7.1'
 ```
 
 ### Carthage
@@ -47,7 +47,7 @@ pod 'Rudder', '1.7.0'
 For Carthage support, add the following line to your `Cartfile`:
 
 ```xcode
-github "rudderlabs/rudder-sdk-ios" "v1.7.0"
+github "rudderlabs/rudder-sdk-ios" "v1.7.1"
 ```
 
 > Remember to include the following code in all `.m` and `.h` files where you want to refer to or use the RudderStack SDK classes, as shown:
@@ -71,7 +71,7 @@ You can also add the RudderStack iOS SDK via Swift Package Mangaer, via one of t
 
 * Enter the package repository (`git@github.com:rudderlabs/rudder-sdk-ios.git`) in the search bar.
 
-* In **Dependency Rule**, select **Up to Next Major Version** and enter `1.7.0` as the value, as shown:
+* In **Dependency Rule**, select **Up to Next Major Version** and enter `1.7.1` as the value, as shown:
 
 ![Setting dependency](https://user-images.githubusercontent.com/59817155/145574696-8c849749-13e0-40d5-aacb-3fccb5c8e67d.png)
 
@@ -99,7 +99,7 @@ let package = Package(
     ],
     dependencies: [
         // Dependencies declare other packages that this package depends on.
-        .package(url: "git@github.com:rudderlabs/rudder-sdk-ios.git", from: "1.7.0")
+        .package(url: "git@github.com:rudderlabs/rudder-sdk-ios.git", from: "1.7.1")
     ],
     targets: [
         // Targets are the basic building blocks of a package. A target can define a module or a test suite.

--- a/Sources/Classes/Public/RSVersion.h
+++ b/Sources/Classes/Public/RSVersion.h
@@ -8,6 +8,6 @@
 #ifndef RSVersion_h
 #define RSVersion_h
 
-NSString *const SDK_VERSION = @"1.7.0";
+NSString *const SDK_VERSION = @"1.7.1";
 
 #endif /* RSVersion_h */

--- a/Sources/Classes/RSPreferenceManager.m
+++ b/Sources/Classes/RSPreferenceManager.m
@@ -195,7 +195,7 @@ NSString *const RSSessionAutoTrackStatus = @"rl_session_auto_track_status";
 - (long) getSessionId {
     NSNumber* sessionId =  [[NSUserDefaults standardUserDefaults] valueForKey:RSSessionIdKey];
     if(sessionId == nil) {
-        return -1;
+        return nil;
     }
     return [sessionId longValue];
 }
@@ -213,7 +213,7 @@ NSString *const RSSessionAutoTrackStatus = @"rl_session_auto_track_status";
 - (long) getLastEventTimeStamp {
     NSNumber *lastEventTimeStamp = [[NSUserDefaults standardUserDefaults] valueForKey:RSLastEventTimeStamp];
     if(lastEventTimeStamp == nil) {
-        return -1;
+        return nil;
     }
     return [lastEventTimeStamp longValue];
 }

--- a/package.json
+++ b/package.json
@@ -1,4 +1,4 @@
 {
-    "version": "1.7.0",
+    "version": "1.7.1",
     "description": "Rudder is a platform for collecting, storing and routing customer event data to dozens of tools"
 }


### PR DESCRIPTION
:crown: *An automated PR*

   1.7.0 (2022-11-04)<br> * Fixed issues with session generation on reset api even when session is disabled ([ffb5eec](https://github.com/rudderlabs/rudder-sdk-ios/commit/ffb5eec))<br> * ci: added CI/CD pipeline ([6f5124e](https://github.com/rudderlabs/rudder-sdk-ios/commit/6f5124e))