### PR TITLE
fix: initialise `eventFiltering` object even when `destinations` is `…

### DIFF
--- a/.github/workflows/slack-notify.yml
+++ b/.github/workflows/slack-notify.yml
@@ -16,7 +16,7 @@ jobs:
           SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
           PROJECT_NAME: 'iOS SDK'
         with:
-          channel-id: ${{ secrets.SLACK_RELEASE_CHANNEL_ID }}
+          channel-id: "${{ secrets.SLACK_RELEASE_CHANNEL_ID }}"
           payload: |
             {
               "blocks": [

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -79,7 +79,7 @@ PODS:
   - nanopb/encode (1.30906.0)
   - PromisesObjC (1.2.12)
   - Protobuf (3.21.5)
-  - Rudder (1.7.0)
+  - Rudder (1.7.1)
 
 DEPENDENCIES:
   - Firebase/Analytics
@@ -120,7 +120,7 @@ SPEC CHECKSUMS:
   nanopb: 59317e09cf1f1a0af72f12af412d54edf52603fc
   PromisesObjC: 3113f7f76903778cf4a0586bd1ab89329a0b7b97
   Protobuf: 7504b04fffcf6662ad629694db8231f5e744327f
-  Rudder: b87d9230533ca42a5f48d20d605485cee69e663f
+  Rudder: 61568212171ddc2efe7785d0a6a0de589d181370
 
 PODFILE CHECKSUM: 33b0e9f1b94a028aa8a3b4aecf718a44c9b6265e
 

--- a/Sources/Classes/RSEventRepository.m
+++ b/Sources/Classes/RSEventRepository.m
@@ -156,8 +156,8 @@ typedef enum {
                         [strongSelf __initiateFactories: serverConfig.destinations];
                         [RSLogger logDebug:@"EventRepository: initiating event filtering plugin for device mode destinations"];
                         strongSelf->eventFilteringPlugin = [[RSEventFilteringPlugin alloc] init:serverConfig.destinations];
-                        
                     } else {
+                        strongSelf->eventFilteringPlugin = [[RSEventFilteringPlugin alloc] init];
                         [RSLogger logDebug:@"EventRepository: no device mode present"];
                     }
                     


### PR DESCRIPTION
# Description

> There is an issue with the customFactory, which is caused when `sourceConfig.destinations` list is `nil`, due to this `eventFiltering` object is not initialised and causing to drop all the events sent to customFactory `dump` method.
> As already mentioned this issue happens when mobile source doesn't have any single destinations attached to it because of this `sourceConfig.destinations` list is `nil`.
> Fix: Is to initialise the eventFiltering object event when `sourceConfig.destinations` list is `nil`.