### PR TITLE
chore(release): pulling release/2.2.5 into master

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
-All notable changes to this project will be documented in this file.
+
+All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
+
+### [2.2.5](https://github.com/rudderlabs/rudder-sdk-ios/compare/v2.1.0...v2.2.5) (2022-11-16)
 
 ### [2.2.4](https://github.com/rudderlabs/rudder-sdk-ios/compare/v2.2.3...v2.2.4) (2022-08-02)
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 <p align="center">
   <a href="https://cocoapods.org/pods/Rudder">
-    <img src="https://img.shields.io/static/v1?label=pod&message=v2.2.4&color=blue&style=flat">
+    <img src="https://img.shields.io/static/v1?label=pod&message=v2.2.5&color=blue&style=flat">
     </a>
 </p>
 
@@ -47,7 +47,7 @@ The iOS SDK is available through [**CocoaPods**](https://cocoapods.org), [**Cart
 To install the SDK, simply add the following line to your Podfile:
 
 ```xcode
-pod 'Rudder', '2.2.4'
+pod 'Rudder', '2.2.5'
 ```
 
 ### Carthage
@@ -55,7 +55,7 @@ pod 'Rudder', '2.2.4'
 For Carthage support, add the following line to your `Cartfile`:
 
 ```xcode
-github "rudderlabs/rudder-sdk-ios" "v2.2.4"
+github "rudderlabs/rudder-sdk-ios" "v2.2.5"
 ```
 
 > Remember to include the following code where you want to refer to or use the RudderStack SDK classes, as shown:
@@ -86,7 +86,7 @@ You can also add the RudderStack SDK using the Swift Package Mangaer in one of t
 ![Adding a package](https://user-images.githubusercontent.com/59817155/140903027-286a1d64-f5d5-4041-9827-47b6cef76a46.png)
 
 2. Enter the package repository (`git@github.com:rudderlabs/rudder-sdk-ios.git`) in the search bar.
-3. In **Dependency Rule**, select **Up to Next Major Version**, and enter `2.2.4` as the value, as shown:
+3. In **Dependency Rule**, select **Up to Next Major Version**, and enter `2.2.5` as the value, as shown:
 
 ![Setting the dependency](https://user-images.githubusercontent.com/59817155/145574696-8c849749-13e0-40d5-aacb-3fccb5c8e67d.png)
 
@@ -113,7 +113,7 @@ let package = Package(
     ],
     dependencies: [
         // Dependencies declare other packages that this package depends on.
-        .package(url: "git@github.com:rudderlabs/rudder-sdk-ios.git", from: "2.2.4")
+        .package(url: "git@github.com:rudderlabs/rudder-sdk-ios.git", from: "2.2.5")
     ],
     targets: [
         // Targets are the basic building blocks of a package. A target can define a module or a test suite.

--- a/Sources/Classes/Common/Constants/RSVersion.swift
+++ b/Sources/Classes/Common/Constants/RSVersion.swift
@@ -9,4 +9,4 @@
 import Foundation
 
 // don't edit this line
-let RSVersion = "2.2.4"
+let RSVersion = "2.2.5"

--- a/package.json
+++ b/package.json
@@ -1,4 +1,4 @@
 {
-    "version": "2.2.4",
+    "version": "2.2.5",
     "description": "Rudder is a platform for collecting, storing and routing customer event data to dozens of tools"
 }

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -6,7 +6,7 @@ sonar.qualitygate.wait=false
 sonar.projectKey=rudderlabs_rudder-sdk-ios-v2
 sonar.organization=rudderlabs
 sonar.projectName=RudderStack iOS SDK(v2)
-sonar.projectVersion=2.2.4
+sonar.projectVersion=2.2.5
 
 # Meta-data for the project
 sonar.links.scm=https://github.com/rudderlabs/rudder-sdk-ios


### PR DESCRIPTION
:crown: *An automated PR*

   <small>2.2.4 (2022-11-16)</small><br> * ci: added CI/CD pipeline ([b7d9e78](https://github.com/rudderlabs/rudder-sdk-ios/commit/b7d9e78))<br> * ci: added CI/CD pipeline ([885b057](https://github.com/rudderlabs/rudder-sdk-ios/commit/885b057))<br> * [Bugfix] Missing  in screen calls ([b4f84e8](https://github.com/rudderlabs/rudder-sdk-ios/commit/b4f84e8))<br> * [Bugfix] Missing  in screen calls for device modes ([2663e99](https://github.com/rudderlabs/rudder-sdk-ios/commit/2663e99))<br> * [Bugfix] RSClient no longer blocks the main thread in checkServerConfig() ([83a0854](https://github.com/rudderlabs/rudder-sdk-ios/commit/83a0854))<br> * [Enhancement] Added new keys and push notification API ([123c0eb](https://github.com/rudderlabs/rudder-sdk-ios/commit/123c0eb))<br> * [Enhancement] Added new set of keys in RSKeysAndEvents class ([44153c7](https://github.com/rudderlabs/rudder-sdk-ios/commit/44153c7))<br> * [Feature] Added support for AppsFlyer ([67512e5](https://github.com/rudderlabs/rudder-sdk-ios/commit/67512e5))<br> * [Feature] Added support for Facebook App Events ([c7d6604](https://github.com/rudderlabs/rudder-sdk-ios/commit/c7d6604))<br> * [Release] Version 2.2.3  ([11bcd79](https://github.com/rudderlabs/rudder-sdk-ios/commit/11bcd79))