### PR TITLE
chore(release): pulling release/2.2.5 into master

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
-All notable changes to this project will be documented in this file.
+
+All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
+
+### [2.2.5](https://github.com/rudderlabs/rudder-sdk-ios/compare/v2.1.0...v2.2.5) (2022-11-16)
+
+
+### Bug Fixes
+
+* **macOS:** life cycle events were not tracking properly ([8879ff4](https://github.com/rudderlabs/rudder-sdk-ios/commit/8879ff40af77aabe3e3f842a52eb38f52576e83f))
 
 ### [2.2.4](https://github.com/rudderlabs/rudder-sdk-ios/compare/v2.2.3...v2.2.4) (2022-08-02)
 

--- a/Examples/SampleSwift-macOS/SampleSwift-macOS.xcodeproj/project.pbxproj
+++ b/Examples/SampleSwift-macOS/SampleSwift-macOS.xcodeproj/project.pbxproj
@@ -7,7 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
-		1965266D87FC3005F1CB2108 /* Pods_SampleSwift_macOS.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = F8D6AE9FC3BAAEC29630C9B4 /* Pods_SampleSwift_macOS.framework */; };
+		BB7A81AEAC1E1E32842A5617 /* Pods_SampleSwift_macOS.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 5A1F90AE8C5AADAC7AC56EDA /* Pods_SampleSwift_macOS.framework */; };
 		EDF3FF46284643E2002B2D46 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = EDF3FF45284643E2002B2D46 /* AppDelegate.swift */; };
 		EDF3FF48284643E2002B2D46 /* ViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = EDF3FF47284643E2002B2D46 /* ViewController.swift */; };
 		EDF3FF4A284643E4002B2D46 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = EDF3FF49284643E4002B2D46 /* Assets.xcassets */; };
@@ -15,15 +15,15 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
-		0DF097F34093E162CB2B9A95 /* Pods-SampleSwift-macOS.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-SampleSwift-macOS.release.xcconfig"; path = "Target Support Files/Pods-SampleSwift-macOS/Pods-SampleSwift-macOS.release.xcconfig"; sourceTree = "<group>"; };
-		24E837A12908DA4BAB6C54B5 /* Pods-SampleSwift-macOS.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-SampleSwift-macOS.debug.xcconfig"; path = "Target Support Files/Pods-SampleSwift-macOS/Pods-SampleSwift-macOS.debug.xcconfig"; sourceTree = "<group>"; };
+		2E4BE82ECE41ED4426C90567 /* Pods-SampleSwift-macOS.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-SampleSwift-macOS.debug.xcconfig"; path = "Target Support Files/Pods-SampleSwift-macOS/Pods-SampleSwift-macOS.debug.xcconfig"; sourceTree = "<group>"; };
+		5A1F90AE8C5AADAC7AC56EDA /* Pods_SampleSwift_macOS.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_SampleSwift_macOS.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		C606C26BE7939B9E2CC982FB /* Pods-SampleSwift-macOS.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-SampleSwift-macOS.release.xcconfig"; path = "Target Support Files/Pods-SampleSwift-macOS/Pods-SampleSwift-macOS.release.xcconfig"; sourceTree = "<group>"; };
 		EDF3FF42284643E2002B2D46 /* SampleSwift-macOS.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "SampleSwift-macOS.app"; sourceTree = BUILT_PRODUCTS_DIR; };
 		EDF3FF45284643E2002B2D46 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		EDF3FF47284643E2002B2D46 /* ViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ViewController.swift; sourceTree = "<group>"; };
 		EDF3FF49284643E4002B2D46 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		EDF3FF4C284643E4002B2D46 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/Main.storyboard; sourceTree = "<group>"; };
 		EDF3FF4E284643E4002B2D46 /* SampleSwift_macOS.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = SampleSwift_macOS.entitlements; sourceTree = "<group>"; };
-		F8D6AE9FC3BAAEC29630C9B4 /* Pods_SampleSwift_macOS.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_SampleSwift_macOS.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -31,27 +31,27 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				1965266D87FC3005F1CB2108 /* Pods_SampleSwift_macOS.framework in Frameworks */,
+				BB7A81AEAC1E1E32842A5617 /* Pods_SampleSwift_macOS.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
-		2B95605BC1E682199F863286 /* Pods */ = {
+		167EE0F862D91675C62ED9E3 /* Pods */ = {
 			isa = PBXGroup;
 			children = (
-				24E837A12908DA4BAB6C54B5 /* Pods-SampleSwift-macOS.debug.xcconfig */,
-				0DF097F34093E162CB2B9A95 /* Pods-SampleSwift-macOS.release.xcconfig */,
+				2E4BE82ECE41ED4426C90567 /* Pods-SampleSwift-macOS.debug.xcconfig */,
+				C606C26BE7939B9E2CC982FB /* Pods-SampleSwift-macOS.release.xcconfig */,
 			);
 			name = Pods;
 			path = ../../Pods;
 			sourceTree = "<group>";
 		};
-		E6190C787E771B7D1BFF8ED1 /* Frameworks */ = {
+		6AB87F2D1E74341BB6A9BB1D /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
-				F8D6AE9FC3BAAEC29630C9B4 /* Pods_SampleSwift_macOS.framework */,
+				5A1F90AE8C5AADAC7AC56EDA /* Pods_SampleSwift_macOS.framework */,
 			);
 			name = Frameworks;
 			sourceTree = "<group>";
@@ -61,8 +61,8 @@
 			children = (
 				EDF3FF44284643E2002B2D46 /* SampleSwift-macOS */,
 				EDF3FF43284643E2002B2D46 /* Products */,
-				2B95605BC1E682199F863286 /* Pods */,
-				E6190C787E771B7D1BFF8ED1 /* Frameworks */,
+				167EE0F862D91675C62ED9E3 /* Pods */,
+				6AB87F2D1E74341BB6A9BB1D /* Frameworks */,
 			);
 			sourceTree = "<group>";
 		};
@@ -93,11 +93,11 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = EDF3FF51284643E4002B2D46 /* Build configuration list for PBXNativeTarget "SampleSwift-macOS" */;
 			buildPhases = (
-				463EFB3DB4B9C72732809A29 /* [CP] Check Pods Manifest.lock */,
+				E00151CD0BCABBD2DF3611B6 /* [CP] Check Pods Manifest.lock */,
 				EDF3FF3E284643E2002B2D46 /* Sources */,
 				EDF3FF3F284643E2002B2D46 /* Frameworks */,
 				EDF3FF40284643E2002B2D46 /* Resources */,
-				693568794FC4F529C6824403 /* [CP] Embed Pods Frameworks */,
+				09DEE64C2E547B40821423C2 /* [CP] Embed Pods Frameworks */,
 			);
 			buildRules = (
 			);
@@ -154,7 +154,24 @@
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXShellScriptBuildPhase section */
-		463EFB3DB4B9C72732809A29 /* [CP] Check Pods Manifest.lock */ = {
+		09DEE64C2E547B40821423C2 /* [CP] Embed Pods Frameworks */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-SampleSwift-macOS/Pods-SampleSwift-macOS-frameworks-${CONFIGURATION}-input-files.xcfilelist",
+			);
+			name = "[CP] Embed Pods Frameworks";
+			outputFileListPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-SampleSwift-macOS/Pods-SampleSwift-macOS-frameworks-${CONFIGURATION}-output-files.xcfilelist",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-SampleSwift-macOS/Pods-SampleSwift-macOS-frameworks.sh\"\n";
+			showEnvVarsInLog = 0;
+		};
+		E00151CD0BCABBD2DF3611B6 /* [CP] Check Pods Manifest.lock */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -174,23 +191,6 @@
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
 			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
-			showEnvVarsInLog = 0;
-		};
-		693568794FC4F529C6824403 /* [CP] Embed Pods Frameworks */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputFileListPaths = (
-				"${PODS_ROOT}/Target Support Files/Pods-SampleSwift-macOS/Pods-SampleSwift-macOS-frameworks-${CONFIGURATION}-input-files.xcfilelist",
-			);
-			name = "[CP] Embed Pods Frameworks";
-			outputFileListPaths = (
-				"${PODS_ROOT}/Target Support Files/Pods-SampleSwift-macOS/Pods-SampleSwift-macOS-frameworks-${CONFIGURATION}-output-files.xcfilelist",
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-SampleSwift-macOS/Pods-SampleSwift-macOS-frameworks.sh\"\n";
 			showEnvVarsInLog = 0;
 		};
 /* End PBXShellScriptBuildPhase section */
@@ -334,12 +334,13 @@
 		};
 		EDF3FF52284643E4002B2D46 /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 24E837A12908DA4BAB6C54B5 /* Pods-SampleSwift-macOS.debug.xcconfig */;
+			baseConfigurationReference = 2E4BE82ECE41ED4426C90567 /* Pods-SampleSwift-macOS.debug.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_ENTITLEMENTS = "SampleSwift-macOS/SampleSwift_macOS.entitlements";
 				CODE_SIGN_IDENTITY = "Apple Development";
+				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
 				CURRENT_PROJECT_VERSION = 1;
@@ -356,6 +357,7 @@
 				MARKETING_VERSION = 1.0.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.rudderstack.macos.test.swift;
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				PROVISIONING_PROFILE_SPECIFIER = "";
 				SWIFT_EMIT_LOC_STRINGS = YES;
 				SWIFT_VERSION = 5.0;
 			};
@@ -363,12 +365,13 @@
 		};
 		EDF3FF53284643E4002B2D46 /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 0DF097F34093E162CB2B9A95 /* Pods-SampleSwift-macOS.release.xcconfig */;
+			baseConfigurationReference = C606C26BE7939B9E2CC982FB /* Pods-SampleSwift-macOS.release.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_ENTITLEMENTS = "SampleSwift-macOS/SampleSwift_macOS.entitlements";
 				CODE_SIGN_IDENTITY = "Apple Development";
+				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
 				CURRENT_PROJECT_VERSION = 1;
@@ -385,6 +388,7 @@
 				MARKETING_VERSION = 1.0.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.rudderstack.macos.test.swift;
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				PROVISIONING_PROFILE_SPECIFIER = "";
 				SWIFT_EMIT_LOC_STRINGS = YES;
 				SWIFT_VERSION = 5.0;
 			};

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 <p align="center">
   <a href="https://cocoapods.org/pods/Rudder">
-    <img src="https://img.shields.io/static/v1?label=pod&message=v2.2.4&color=blue&style=flat">
+    <img src="https://img.shields.io/static/v1?label=pod&message=v2.2.5&color=blue&style=flat">
     </a>
 </p>
 
@@ -47,7 +47,7 @@ The iOS SDK is available through [**CocoaPods**](https://cocoapods.org), [**Cart
 To install the SDK, simply add the following line to your Podfile:
 
 ```xcode
-pod 'Rudder', '2.2.4'
+pod 'Rudder', '2.2.5'
 ```
 
 ### Carthage
@@ -55,7 +55,7 @@ pod 'Rudder', '2.2.4'
 For Carthage support, add the following line to your `Cartfile`:
 
 ```xcode
-github "rudderlabs/rudder-sdk-ios" "v2.2.4"
+github "rudderlabs/rudder-sdk-ios" "v2.2.5"
 ```
 
 > Remember to include the following code where you want to refer to or use the RudderStack SDK classes, as shown:
@@ -86,7 +86,7 @@ You can also add the RudderStack SDK using the Swift Package Mangaer in one of t
 ![Adding a package](https://user-images.githubusercontent.com/59817155/140903027-286a1d64-f5d5-4041-9827-47b6cef76a46.png)
 
 2. Enter the package repository (`git@github.com:rudderlabs/rudder-sdk-ios.git`) in the search bar.
-3. In **Dependency Rule**, select **Up to Next Major Version**, and enter `2.2.4` as the value, as shown:
+3. In **Dependency Rule**, select **Up to Next Major Version**, and enter `2.2.5` as the value, as shown:
 
 ![Setting the dependency](https://user-images.githubusercontent.com/59817155/145574696-8c849749-13e0-40d5-aacb-3fccb5c8e67d.png)
 
@@ -113,7 +113,7 @@ let package = Package(
     ],
     dependencies: [
         // Dependencies declare other packages that this package depends on.
-        .package(url: "git@github.com:rudderlabs/rudder-sdk-ios.git", from: "2.2.4")
+        .package(url: "git@github.com:rudderlabs/rudder-sdk-ios.git", from: "2.2.5")
     ],
     targets: [
         // Targets are the basic building blocks of a package. A target can define a module or a test suite.

--- a/Sources/Classes/Common/Constants/RSVersion.swift
+++ b/Sources/Classes/Common/Constants/RSVersion.swift
@@ -9,4 +9,4 @@
 import Foundation
 
 // don't edit this line
-let RSVersion = "2.2.4"
+let RSVersion = "2.2.5"

--- a/Sources/Classes/Domain/Enums/JSON.swift
+++ b/Sources/Classes/Domain/Enums/JSON.swift
@@ -35,7 +35,6 @@ public enum JSON: Equatable {
     }
     
     // For primitives??
-    // swiftlint:disable cyclomatic_complexity
     public init(_ value: Any) throws { 
         switch value {
         // handle NS values

--- a/Sources/Classes/Helpers/Platforms/Mac/RSmacOSLifecycleMonitor.swift
+++ b/Sources/Classes/Helpers/Platforms/Mac/RSmacOSLifecycleMonitor.swift
@@ -10,12 +10,10 @@
 import Cocoa
 
 class RSmacOSLifecycleMonitor: RSPlatformPlugin {
-    static var specificName = "Rudder_macOSLifecycleMonitor"
     let type = PluginType.utility
-    let name = specificName
     var client: RSClient?
     
-    private var application: NSApplication
+    private var application: NSApplication = NSApplication.shared
     private var appNotifications: [NSNotification.Name] =
         [NSApplication.didFinishLaunchingNotification,
          NSApplication.didResignActiveNotification,
@@ -33,7 +31,6 @@ class RSmacOSLifecycleMonitor: RSPlatformPlugin {
          NSApplication.didChangeScreenParametersNotification]
     
     required init() {
-        self.application = NSApplication.shared        
         setupListeners()
     }
     
@@ -76,9 +73,8 @@ class RSmacOSLifecycleMonitor: RSPlatformPlugin {
     
     func setupListeners() {
         // Configure the current life cycle events
-        let notificationCenter = NotificationCenter.default
         for notification in appNotifications {
-            notificationCenter.addObserver(self, selector: #selector(notificationResponse(notification:)), name: notification, object: application)
+            NotificationCenter.default.addObserver(self, selector: #selector(notificationResponse(notification:)), name: notification, object: application)
         }
     }
     

--- a/package.json
+++ b/package.json
@@ -1,4 +1,4 @@
 {
-    "version": "2.2.4",
+    "version": "2.2.5",
     "description": "Rudder is a platform for collecting, storing and routing customer event data to dozens of tools"
 }

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -6,7 +6,7 @@ sonar.qualitygate.wait=false
 sonar.projectKey=rudderlabs_rudder-sdk-ios-v2
 sonar.organization=rudderlabs
 sonar.projectName=RudderStack iOS SDK(v2)
-sonar.projectVersion=2.2.4
+sonar.projectVersion=2.2.5
 
 # Meta-data for the project
 sonar.links.scm=https://github.com/rudderlabs/rudder-sdk-ios


### PR DESCRIPTION
:crown: *An automated PR*

   <small>2.2.4 (2022-11-16)</small><br> * fix(macOS): life cycle events were not tracking properly ([8879ff4](https://github.com/rudderlabs/rudder-sdk-ios/commit/8879ff4))<br> * ci: added CI/CD pipeline ([b7d9e78](https://github.com/rudderlabs/rudder-sdk-ios/commit/b7d9e78))<br> * ci: added CI/CD pipeline ([885b057](https://github.com/rudderlabs/rudder-sdk-ios/commit/885b057))<br> * [Bugfix] Missing  in screen calls ([b4f84e8](https://github.com/rudderlabs/rudder-sdk-ios/commit/b4f84e8))<br> * [Bugfix] Missing  in screen calls for device modes ([2663e99](https://github.com/rudderlabs/rudder-sdk-ios/commit/2663e99))<br> * [Bugfix] RSClient no longer blocks the main thread in checkServerConfig() ([83a0854](https://github.com/rudderlabs/rudder-sdk-ios/commit/83a0854))<br> * [Enhancement] Added new keys and push notification API ([123c0eb](https://github.com/rudderlabs/rudder-sdk-ios/commit/123c0eb))<br> * [Enhancement] Added new set of keys in RSKeysAndEvents class ([44153c7](https://github.com/rudderlabs/rudder-sdk-ios/commit/44153c7))<br> * [Feature] Added support for AppsFlyer ([67512e5](https://github.com/rudderlabs/rudder-sdk-ios/commit/67512e5))<br> * [Feature] Added support for Facebook App Events ([c7d6604](https://github.com/rudderlabs/rudder-sdk-ios/commit/c7d6604))<br> * [Release] Version 2.2.3  ([11bcd79](https://github.com/rudderlabs/rudder-sdk-ios/commit/11bcd79))