### PR TITLE
chore(release): pulling release/1.8.0 into master

### DIFF
--- a/.github/workflows/create-hotfix-branch-v2.yml
+++ b/.github/workflows/create-hotfix-branch-v2.yml
@@ -14,7 +14,7 @@ jobs:
     if: github.ref == 'refs/heads/master-v2'
     steps:
       - name: Create branch
-        uses: peterjgrainger/action-create-branch@v2.2.0
+        uses: peterjgrainger/action-create-branch@v2.3.0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:

--- a/.github/workflows/create-hotfix-branch.yml
+++ b/.github/workflows/create-hotfix-branch.yml
@@ -14,7 +14,7 @@ jobs:
     if: github.ref == 'refs/heads/master'
     steps:
       - name: Create branch
-        uses: peterjgrainger/action-create-branch@v2.2.0
+        uses: peterjgrainger/action-create-branch@v2.3.0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+## [1.8.0](https://github.com/rudderlabs/rudder-sdk-ios/compare/v1.7.1...v1.8.0) (2022-12-08)
+
+
+### Features
+
+* remove timestamp from messageId ([a0f89fc](https://github.com/rudderlabs/rudder-sdk-ios/commit/a0f89fcb20d0bb0c76919d78a3e19585e489bbed))
+
+
+### Bug Fixes
+
+* initialise `eventFiltering` object even when `destinations` is empty ([3a5c1c4](https://github.com/rudderlabs/rudder-sdk-ios/commit/3a5c1c412c63c4ca0a9c57538135fbfde238a69a))
+
 ### [1.7.2](https://github.com/rudderlabs/rudder-sdk-ios/compare/v1.7.1...v1.7.2) (2022-11-17)
 
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 <p align="center">
   <a href="https://cocoapods.org/pods/Rudder">
-    <img src="https://img.shields.io/static/v1?label=pod&message=v1.7.2&color=blue&style=flat">
+    <img src="https://img.shields.io/static/v1?label=pod&message=v1.8.0&color=blue&style=flat">
     </a>
 </p>
 
@@ -39,7 +39,7 @@ The iOS SDK is available through [**CocoaPods**](https://cocoapods.org), [**Cart
 To install the SDK, simply add the following line to your Podfile:
 
 ```xcode
-pod 'Rudder', '1.7.2'
+pod 'Rudder', '1.8.0'
 ```
 
 ### Carthage
@@ -47,7 +47,7 @@ pod 'Rudder', '1.7.2'
 For Carthage support, add the following line to your `Cartfile`:
 
 ```xcode
-github "rudderlabs/rudder-sdk-ios" "v1.7.2"
+github "rudderlabs/rudder-sdk-ios" "v1.8.0"
 ```
 
 > Remember to include the following code in all `.m` and `.h` files where you want to refer to or use the RudderStack SDK classes, as shown:
@@ -71,7 +71,7 @@ You can also add the RudderStack iOS SDK via Swift Package Mangaer, via one of t
 
 * Enter the package repository (`git@github.com:rudderlabs/rudder-sdk-ios.git`) in the search bar.
 
-* In **Dependency Rule**, select **Up to Next Major Version** and enter `1.7.2` as the value, as shown:
+* In **Dependency Rule**, select **Up to Next Major Version** and enter `1.8.0` as the value, as shown:
 
 ![Setting dependency](https://user-images.githubusercontent.com/59817155/145574696-8c849749-13e0-40d5-aacb-3fccb5c8e67d.png)
 
@@ -99,7 +99,7 @@ let package = Package(
     ],
     dependencies: [
         // Dependencies declare other packages that this package depends on.
-        .package(url: "git@github.com:rudderlabs/rudder-sdk-ios.git", from: "1.7.2")
+        .package(url: "git@github.com:rudderlabs/rudder-sdk-ios.git", from: "1.8.0")
     ],
     targets: [
         // Targets are the basic building blocks of a package. A target can define a module or a test suite.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,19 @@
+# Security Reporting
+
+Thank you in advance for helping us keep RudderStack secure!
+
+Please report any security issues or vulnerabilities to [security@rudderstack.com](mailto:security@rudderstack.com), before proceeding to post them publicly as issues on GitHub or any other public channel like the RudderStack community Slack. These issues might also affect other users, and security vulnerabilities need to be handled quickly and sometimes privately.
+
+We will triage the issue, contact you for further instructions and make sure to take any necessary measures as needed.
+
+## Supported versions
+
+We will fix any security bugs for the latest major.minor version of the SDK.
+
+| Version | Supported |
+| :-------| :---------|
+| Latest 1.x | ✅ |
+| Older 1.x | ❌ |
+| < 1.0 | ❌ |
+
+We may fix the vulnerabilities in the older versions depending on the severity of the issue and the age of the release, but we are only committing to the latest version released.

--- a/Sources/Classes/Public/RSVersion.h
+++ b/Sources/Classes/Public/RSVersion.h
@@ -8,6 +8,6 @@
 #ifndef RSVersion_h
 #define RSVersion_h
 
-NSString *const SDK_VERSION = @"1.7.2";
+NSString *const SDK_VERSION = @"1.8.0";
 
 #endif /* RSVersion_h */

--- a/Sources/Classes/RSMessage.m
+++ b/Sources/Classes/RSMessage.m
@@ -16,7 +16,7 @@
 {
     self = [super init];
     if (self) {
-        _messageId = [[NSString alloc] initWithFormat:@"%ld-%@", [RSUtils getTimeStampLong], [RSUtils getUniqueId]];
+        _messageId = [RSUtils getUniqueId];
         _channel = @"mobile";
         _context = [RSElementCache getContext];
         _originalTimestamp = [RSUtils getTimestamp];

--- a/package.json
+++ b/package.json
@@ -1,4 +1,4 @@
 {
-    "version": "1.7.2",
+    "version": "1.8.0",
     "description": "Rudder is a platform for collecting, storing and routing customer event data to dozens of tools"
 }

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -6,7 +6,7 @@ sonar.qualitygate.wait=false
 sonar.projectKey=rudderlabs_rudder-sdk-ios
 sonar.organization=rudderlabs
 sonar.projectName=RudderStack iOS SDK
-sonar.projectVersion=1.7.2
+sonar.projectVersion=1.8.0
 
 # C/C++/Objective-C related details
 sonar.cfamily.compile-commands=compile_commands.json


### PR DESCRIPTION
:crown: *An automated PR*

   <small>1.7.2 (2022-12-08)</small><br> * feat: remove timestamp from messageId ([a0f89fc](https://github.com/rudderlabs/rudder-sdk-ios/commit/a0f89fc))<br> * docs: added SECURITY.md ([30a657a](https://github.com/rudderlabs/rudder-sdk-ios/commit/30a657a))<br> * ci: added CI/CD pipeline for v2 ([e3d3acb](https://github.com/rudderlabs/rudder-sdk-ios/commit/e3d3acb))<br> * ci: added Slack Notification ci ([7fa84d7](https://github.com/rudderlabs/rudder-sdk-ios/commit/7fa84d7))<br> * ci: added Test & Coverage CI ([6bbe4b9](https://github.com/rudderlabs/rudder-sdk-ios/commit/6bbe4b9))<br> * ci: bump peterjgrainger/action-create-branch from 2.2.0 to 2.3.0 ([b80345a](https://github.com/rudderlabs/rudder-sdk-ios/commit/b80345a))<br> * ci: fix publish-new-release.yml ([b9b182a](https://github.com/rudderlabs/rudder-sdk-ios/commit/b9b182a))<br> * chore(release): pulling release/1.7.2 into master ([784679d](https://github.com/rudderlabs/rudder-sdk-ios/commit/784679d))<br> * fix: initialise  object even when  is empty ([3a5c1c4](https://github.com/rudderlabs/rudder-sdk-ios/commit/3a5c1c4))