### PR TITLE
chore(release): pulling release/2.2.6 into master

### DIFF
--- a/.github/workflows/build-and-quality-checks-v2.yml
+++ b/.github/workflows/build-and-quality-checks-v2.yml
@@ -1,39 +1,42 @@
 name: Code Quality Checks(v2)
 on:
   pull_request:
-    branches: ['master-v2', 'develop-v2']
-    types: ['opened', 'reopened', 'synchronize']
+    branches: ["master-v2", "develop-v2"]
+    types: ["opened", "reopened", "synchronize"]
 
 jobs:
   build:
     name: Code Quality Checks(v2)
     runs-on: macOS-latest
-    
+
     steps:
       - name: Checkout source branch
         uses: actions/checkout@v3
-      
+
       - name: Install xcpretty
         run: gem install xcpretty
+
+      - name: Select Xcode version
+        run: sudo xcode-select -s '/Applications/Xcode_13.2.1.app/Contents/Developer'
 
       - name: Build SDK(iOS)
         run: |
           xcodebuild build -scheme RudderSDK-iOS -workspace Rudder.xcworkspace -destination 'platform=iOS Simulator,name=iPhone 13' | xcpretty
-          
+
       - name: Build SDK(watchOS)
         run: |
           xcodebuild build -scheme RudderSDK-iOS -workspace Rudder.xcworkspace -destination 'platform=watchOS Simulator,name=Apple Watch Series 7 - 45mm' | xcpretty
-      
+
       - name: Build SDK(tvOS)
         run: |
           xcodebuild build -scheme RudderSDK-iOS -workspace Rudder.xcworkspace -destination 'platform=tvOS Simulator,name=Apple TV' | xcpretty
-          
+
       - name: Build SDK(macOS)
         run: |
           xcodebuild build -scheme RudderSDK-iOS -workspace Rudder.xcworkspace -destination 'platform=macOS,variant=Mac Catalyst' | xcpretty
-          
+
       - name: Install Cocoapods
         run: gem install cocoapods
-      
+
       - name: Execute pod lint
         run: pod lib lint --no-clean --allow-warnings

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+### [2.2.6](https://github.com/rudderlabs/rudder-sdk-ios/compare/v2.1.0...v2.2.6) (2023-01-20)
+
+
+### Bug Fixes
+
+* improper way of handling customContext ([#239](https://github.com/rudderlabs/rudder-sdk-ios/issues/239)) ([7a91754](https://github.com/rudderlabs/rudder-sdk-ios/commit/7a91754cb62f398b5ded4f933c7ab1dce7c1b5ae))
+* **macOS:** life cycle events were not tracking properly ([8879ff4](https://github.com/rudderlabs/rudder-sdk-ios/commit/8879ff40af77aabe3e3f842a52eb38f52576e83f))
+
 ### [2.2.5](https://github.com/rudderlabs/rudder-sdk-ios/compare/v2.1.0...v2.2.5) (2022-11-16)
 
 

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -1,5 +1,5 @@
 PODS:
-  - Rudder (2.2.4)
+  - Rudder (2.2.5)
 
 DEPENDENCIES:
   - Rudder (from `.`)
@@ -9,7 +9,7 @@ EXTERNAL SOURCES:
     :path: "."
 
 SPEC CHECKSUMS:
-  Rudder: 5fb72ab3d09de72cab0a949aa7b1aad2f24947f9
+  Rudder: decdbd805872e80089665333f9752c8ed317c99d
 
 PODFILE CHECKSUM: ee379229e6a0b60bc98226700ace2de002171547
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 <p align="center">
   <a href="https://cocoapods.org/pods/Rudder">
-    <img src="https://img.shields.io/static/v1?label=pod&message=v2.2.5&color=blue&style=flat">
+    <img src="https://img.shields.io/static/v1?label=pod&message=v2.2.6&color=blue&style=flat">
     </a>
 </p>
 
@@ -47,7 +47,7 @@ The iOS SDK is available through [**CocoaPods**](https://cocoapods.org), [**Cart
 To install the SDK, simply add the following line to your Podfile:
 
 ```xcode
-pod 'Rudder', '2.2.5'
+pod 'Rudder', '2.2.6'
 ```
 
 ### Carthage
@@ -55,7 +55,7 @@ pod 'Rudder', '2.2.5'
 For Carthage support, add the following line to your `Cartfile`:
 
 ```xcode
-github "rudderlabs/rudder-sdk-ios" "v2.2.5"
+github "rudderlabs/rudder-sdk-ios" "v2.2.6"
 ```
 
 > Remember to include the following code where you want to refer to or use the RudderStack SDK classes, as shown:
@@ -86,7 +86,7 @@ You can also add the RudderStack SDK using the Swift Package Mangaer in one of t
 ![Adding a package](https://user-images.githubusercontent.com/59817155/140903027-286a1d64-f5d5-4041-9827-47b6cef76a46.png)
 
 2. Enter the package repository (`git@github.com:rudderlabs/rudder-sdk-ios.git`) in the search bar.
-3. In **Dependency Rule**, select **Up to Next Major Version**, and enter `2.2.5` as the value, as shown:
+3. In **Dependency Rule**, select **Up to Next Major Version**, and enter `2.2.6` as the value, as shown:
 
 ![Setting the dependency](https://user-images.githubusercontent.com/59817155/145574696-8c849749-13e0-40d5-aacb-3fccb5c8e67d.png)
 
@@ -113,7 +113,7 @@ let package = Package(
     ],
     dependencies: [
         // Dependencies declare other packages that this package depends on.
-        .package(url: "git@github.com:rudderlabs/rudder-sdk-ios.git", from: "2.2.5")
+        .package(url: "git@github.com:rudderlabs/rudder-sdk-ios.git", from: "2.2.6")
     ],
     targets: [
         // Targets are the basic building blocks of a package. A target can define a module or a test suite.

--- a/Sources/Classes/Client/Plugins/RSContextPlugin.swift
+++ b/Sources/Classes/Client/Plugins/RSContextPlugin.swift
@@ -118,18 +118,19 @@ class RSContextPlugin: RSPlatformPlugin {
     }
     
     func insertDynamicOptionData(message: RSMessage, context: inout [String: Any]) {
+        /// First priority will given to the `option` passed along with the event
         if let option = message.option {
             if let externalIds = option.externalIds {
                 context["externalId"] = externalIds
             }
             if let customContexts = option.customContexts {
-                for key in customContexts.keys {
-                    context[key] = [key: customContexts]
+                for (key, value) in customContexts {
+                    context[key] = value
                 }
             }
         }
+        // TODO: Fetch `customContexts` set using setOption API.
     }
-
 }
 
 extension RSClient {

--- a/Sources/Classes/Common/Constants/RSVersion.swift
+++ b/Sources/Classes/Common/Constants/RSVersion.swift
@@ -9,4 +9,4 @@
 import Foundation
 
 // don't edit this line
-let RSVersion = "2.2.5"
+let RSVersion = "2.2.6"

--- a/package.json
+++ b/package.json
@@ -1,4 +1,4 @@
 {
-    "version": "2.2.5",
+    "version": "2.2.6",
     "description": "Rudder is a platform for collecting, storing and routing customer event data to dozens of tools"
 }

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -6,7 +6,7 @@ sonar.qualitygate.wait=false
 sonar.projectKey=rudderlabs_rudder-sdk-ios-v2
 sonar.organization=rudderlabs
 sonar.projectName=RudderStack iOS SDK(v2)
-sonar.projectVersion=2.2.5
+sonar.projectVersion=2.2.6
 
 # Meta-data for the project
 sonar.links.scm=https://github.com/rudderlabs/rudder-sdk-ios


### PR DESCRIPTION
:crown: *An automated PR*

   <small>2.2.5 (2023-01-20)</small><br> * fix: improper way of handling customContext ( 239) ([7a91754](https://github.com/rudderlabs/rudder-sdk-ios/commit/7a91754)), closes [ 239](https://github.com/rudderlabs/rudder-sdk-ios/issues/239)<br> * fix(macOS): life cycle events were not tracking properly ([8879ff4](https://github.com/rudderlabs/rudder-sdk-ios/commit/8879ff4))<br> * chore(release): pulling release/2.2.5 into master ([7aff1d9](https://github.com/rudderlabs/rudder-sdk-ios/commit/7aff1d9))<br> * ci: added CI/CD pipeline ([885b057](https://github.com/rudderlabs/rudder-sdk-ios/commit/885b057))<br> * [Bugfix] Missing `properties.name` in screen calls ([b4f84e8](https://github.com/rudderlabs/rudder-sdk-ios/commit/b4f84e8))<br> * [Bugfix] Missing `properties.name` in screen calls for device modes ([2663e99](https://github.com/rudderlabs/rudder-sdk-ios/commit/2663e99))<br> * [Bugfix] RSClient no longer blocks the main thread in checkServerConfig() ([83a0854](https://github.com/rudderlabs/rudder-sdk-ios/commit/83a0854))<br> * [Enhancement] Added new keys and push notification API ([123c0eb](https://github.com/rudderlabs/rudder-sdk-ios/commit/123c0eb))<br> * [Enhancement] Added new set of keys in RSKeysAndEvents class ([44153c7](https://github.com/rudderlabs/rudder-sdk-ios/commit/44153c7))<br> * [Feature] Added support for AppsFlyer ([67512e5](https://github.com/rudderlabs/rudder-sdk-ios/commit/67512e5))<br> * [Feature] Added support for Facebook App Events ([c7d6604](https://github.com/rudderlabs/rudder-sdk-ios/commit/c7d6604))<br> * [Release] Version 2.2.3  ([11bcd79](https://github.com/rudderlabs/rudder-sdk-ios/commit/11bcd79))