### PR TITLE
chore(release): pulling release/2.2.7 into master

### DIFF
--- a/.github/workflows/deploy-cocoapods-v2.yml
+++ b/.github/workflows/deploy-cocoapods-v2.yml
@@ -3,20 +3,23 @@ name: Deploy to Cocoapods(v2)
 on:
   release:
     types: [created]
-    
+
 jobs:
   build:
     name: Deploy to Cocoapods
     runs-on: macOS-latest
     steps:
-    - name: Checkout source branch
-      uses: actions/checkout@v3
-    
-    - name: Install Cocoapods
-      run: gem install cocoapods
-      
-    - name: Publish to CocoaPod
-      env:
-        COCOAPODS_TRUNK_TOKEN: ${{ secrets.COCOAPODS_TRUNK_TOKEN }}
-      run: |
-        pod trunk push --allow-warnings
+      - name: Checkout source branch
+        uses: actions/checkout@v3
+
+      - name: Select Xcode version
+        run: sudo xcode-select -s '/Applications/Xcode_13.2.1.app/Contents/Developer'
+
+      - name: Install Cocoapods
+        run: gem install cocoapods
+
+      - name: Publish to CocoaPod
+        env:
+          COCOAPODS_TRUNK_TOKEN: ${{ secrets.COCOAPODS_TRUNK_TOKEN }}
+        run: |
+          pod trunk push --allow-warnings

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+### [2.2.7](https://github.com/rudderlabs/rudder-sdk-ios/compare/v2.2.5...v2.2.7) (2023-01-24)
+
+
+### Bug Fixes
+
+* improper way of handling customContext ([#239](https://github.com/rudderlabs/rudder-sdk-ios/issues/239)) ([7a91754](https://github.com/rudderlabs/rudder-sdk-ios/commit/7a91754cb62f398b5ded4f933c7ab1dce7c1b5ae))
+
 ### [2.2.6](https://github.com/rudderlabs/rudder-sdk-ios/compare/v2.1.0...v2.2.6) (2023-01-20)
 
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 <p align="center">
   <a href="https://cocoapods.org/pods/Rudder">
-    <img src="https://img.shields.io/static/v1?label=pod&message=v2.2.6&color=blue&style=flat">
+    <img src="https://img.shields.io/static/v1?label=pod&message=v2.2.7&color=blue&style=flat">
     </a>
 </p>
 
@@ -47,7 +47,7 @@ The iOS SDK is available through [**CocoaPods**](https://cocoapods.org), [**Cart
 To install the SDK, simply add the following line to your Podfile:
 
 ```xcode
-pod 'Rudder', '2.2.6'
+pod 'Rudder', '2.2.7'
 ```
 
 ### Carthage
@@ -55,7 +55,7 @@ pod 'Rudder', '2.2.6'
 For Carthage support, add the following line to your `Cartfile`:
 
 ```xcode
-github "rudderlabs/rudder-sdk-ios" "v2.2.6"
+github "rudderlabs/rudder-sdk-ios" "v2.2.7"
 ```
 
 > Remember to include the following code where you want to refer to or use the RudderStack SDK classes, as shown:
@@ -86,7 +86,7 @@ You can also add the RudderStack SDK using the Swift Package Mangaer in one of t
 ![Adding a package](https://user-images.githubusercontent.com/59817155/140903027-286a1d64-f5d5-4041-9827-47b6cef76a46.png)
 
 2. Enter the package repository (`git@github.com:rudderlabs/rudder-sdk-ios.git`) in the search bar.
-3. In **Dependency Rule**, select **Up to Next Major Version**, and enter `2.2.6` as the value, as shown:
+3. In **Dependency Rule**, select **Up to Next Major Version**, and enter `2.2.7` as the value, as shown:
 
 ![Setting the dependency](https://user-images.githubusercontent.com/59817155/145574696-8c849749-13e0-40d5-aacb-3fccb5c8e67d.png)
 
@@ -113,7 +113,7 @@ let package = Package(
     ],
     dependencies: [
         // Dependencies declare other packages that this package depends on.
-        .package(url: "git@github.com:rudderlabs/rudder-sdk-ios.git", from: "2.2.6")
+        .package(url: "git@github.com:rudderlabs/rudder-sdk-ios.git", from: "2.2.7")
     ],
     targets: [
         // Targets are the basic building blocks of a package. A target can define a module or a test suite.

--- a/Sources/Classes/Common/Constants/RSVersion.swift
+++ b/Sources/Classes/Common/Constants/RSVersion.swift
@@ -9,4 +9,4 @@
 import Foundation
 
 // don't edit this line
-let RSVersion = "2.2.6"
+let RSVersion = "2.2.7"

--- a/package.json
+++ b/package.json
@@ -1,4 +1,4 @@
 {
-    "version": "2.2.6",
+    "version": "2.2.7",
     "description": "Rudder is a platform for collecting, storing and routing customer event data to dozens of tools"
 }

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -6,7 +6,7 @@ sonar.qualitygate.wait=false
 sonar.projectKey=rudderlabs_rudder-sdk-ios-v2
 sonar.organization=rudderlabs
 sonar.projectName=RudderStack iOS SDK(v2)
-sonar.projectVersion=2.2.6
+sonar.projectVersion=2.2.7
 
 # Meta-data for the project
 sonar.links.scm=https://github.com/rudderlabs/rudder-sdk-ios


### PR DESCRIPTION
:crown: *An automated PR*

   <small>2.2.6 (2023-01-24)</small><br> * ci: update Xcode version ([c94ecaf](https://github.com/rudderlabs/rudder-sdk-ios/commit/c94ecaf))<br> * chore(release): pulling release/2.2.6 into master ([80a9dc8](https://github.com/rudderlabs/rudder-sdk-ios/commit/80a9dc8))<br> * fix: improper way of handling customContext ( 239) ([7a91754](https://github.com/rudderlabs/rudder-sdk-ios/commit/7a91754)), closes [ 239](https://github.com/rudderlabs/rudder-sdk-ios/issues/239)