### PR TITLE
chore(release): pulling release/1.13.0 into master

### DIFF
--- a/.github/workflows/deploy-cocoapods-beta.yml
+++ b/.github/workflows/deploy-cocoapods-beta.yml
@@ -1,0 +1,24 @@
+name: Manually deploy to Cocoapods
+
+on:
+  workflow_dispatch
+
+jobs:
+  deploy-cocoapods-manual:
+    name: Manually deploy to Cocoapods
+    runs-on: macOS-latest
+    steps:
+      - name: Checkout source branch
+        uses: actions/checkout@v3
+
+      - name: Select Xcode version
+        run: sudo xcode-select -s '/Applications/Xcode_13.2.1.app/Contents/Developer'
+
+      - name: Install Cocoapods
+        run: gem install cocoapods
+
+      - name: Publish to CocoaPod
+        env:
+          COCOAPODS_TRUNK_TOKEN: ${{ secrets.COCOAPODS_TRUNK_TOKEN }}
+        run: |
+          pod trunk push --allow-warnings

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+## [1.13.0](https://github.com/rudderlabs/rudder-sdk-ios/compare/v1.12.1...v1.13.0) (2023-03-27)
+
+
+### Features
+
+* made reset and identify api's synchronous to reflect the data immediately ([#284](https://github.com/rudderlabs/rudder-sdk-ios/issues/284)) ([6047fc6](https://github.com/rudderlabs/rudder-sdk-ios/commit/6047fc6a7a2d260edc49e6d6c3ea219b5392f95c))
 
 ### [1.12.1](https://github.com/rudderlabs/rudder-sdk-ios/compare/v1.12.0...v1.12.1) (2023-03-21)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+
 ### [1.12.1](https://github.com/rudderlabs/rudder-sdk-ios/compare/v1.12.0...v1.12.1) (2023-03-21)
 
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 <p align="center">
   <a href="https://cocoapods.org/pods/Rudder">
-    <img src="https://img.shields.io/static/v1?label=pod&message=v1.12.1&color=blue&style=flat">
+    <img src="https://img.shields.io/static/v1?label=pod&message=v1.13.0&color=blue&style=flat">
     </a>
 </p>
 
@@ -39,7 +39,7 @@ The iOS SDK is available through [**CocoaPods**](https://cocoapods.org), [**Cart
 To install the SDK, simply add the following line to your Podfile:
 
 ```xcode
-pod 'Rudder', '1.12.1'
+pod 'Rudder', '1.13.0'
 ```
 
 ### Carthage
@@ -47,7 +47,7 @@ pod 'Rudder', '1.12.1'
 For Carthage support, add the following line to your `Cartfile`:
 
 ```xcode
-github "rudderlabs/rudder-sdk-ios" "v1.12.1"
+github "rudderlabs/rudder-sdk-ios" "v1.13.0"
 ```
 
 > Remember to include the following code in all `.m` and `.h` files where you want to refer to or use the RudderStack SDK classes, as shown:
@@ -71,7 +71,7 @@ You can also add the RudderStack iOS SDK via Swift Package Mangaer, via one of t
 
 * Enter the package repository (`git@github.com:rudderlabs/rudder-sdk-ios.git`) in the search bar.
 
-* In **Dependency Rule**, select **Up to Next Major Version** and enter `1.12.1` as the value, as shown:
+* In **Dependency Rule**, select **Up to Next Major Version** and enter `1.13.0` as the value, as shown:
 
 ![Setting dependency](https://user-images.githubusercontent.com/59817155/145574696-8c849749-13e0-40d5-aacb-3fccb5c8e67d.png)
 
@@ -99,7 +99,7 @@ let package = Package(
     ],
     dependencies: [
         // Dependencies declare other packages that this package depends on.
-        .package(url: "git@github.com:rudderlabs/rudder-sdk-ios.git", from: "1.12.1")
+        .package(url: "git@github.com:rudderlabs/rudder-sdk-ios.git", from: "1.13.0")
     ],
     targets: [
         // Targets are the basic building blocks of a package. A target can define a module or a test suite.

--- a/Rudder.xcodeproj/project.pbxproj
+++ b/Rudder.xcodeproj/project.pbxproj
@@ -199,6 +199,7 @@
 		ED8DB01E298E206900907EC4 /* RSConsentFilterHandler.m in Sources */ = {isa = PBXBuildFile; fileRef = ED8DB01D298E206900907EC4 /* RSConsentFilterHandler.m */; };
 		EDB3393629960F5E00706003 /* multi-dataresidency-eu-true.json in Resources */ = {isa = PBXBuildFile; fileRef = EDB3393429960F5E00706003 /* multi-dataresidency-eu-true.json */; };
 		EDB3393729960F5E00706003 /* multi-dataresidency-us-true.json in Resources */ = {isa = PBXBuildFile; fileRef = EDB3393529960F5E00706003 /* multi-dataresidency-us-true.json */; };
+		F64F9D7629BF171D009D963F /* ContextTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F64F9D7529BF171D009D963F /* ContextTests.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -419,6 +420,7 @@
 		EDB3393429960F5E00706003 /* multi-dataresidency-eu-true.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "multi-dataresidency-eu-true.json"; sourceTree = "<group>"; };
 		EDB3393529960F5E00706003 /* multi-dataresidency-us-true.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "multi-dataresidency-us-true.json"; sourceTree = "<group>"; };
 		EDEC3CDA29ADEF87007DDE07 /* github-release.config.js */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.javascript; path = "github-release.config.js"; sourceTree = "<group>"; };
+		F64F9D7529BF171D009D963F /* ContextTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContextTests.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -479,6 +481,7 @@
 				ED7DFD80298C061A00ED5A8E /* DataResidencyTests.swift */,
 				ED04A23E29839DCC0080A88D /* EventRepositoryTests.swift */,
 				ED20F4F52996083B00F3FD0E /* TestUtils.swift */,
+				F64F9D7529BF171D009D963F /* ContextTests.swift */,
 			);
 			path = Tests;
 			sourceTree = "<group>";
@@ -1067,6 +1070,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				F64F9D7629BF171D009D963F /* ContextTests.swift in Sources */,
 				ED7DFD81298C061A00ED5A8E /* DataResidencyTests.swift in Sources */,
 				ED04A247298424040080A88D /* ConserFilterHandlerTests.swift in Sources */,
 				ED04A23F29839DCC0080A88D /* EventRepositoryTests.swift in Sources */,

--- a/Sources/Classes/Headers/Public/RSContext.h
+++ b/Sources/Classes/Headers/Public/RSContext.h
@@ -44,21 +44,21 @@ extern int const RSATTAuthorize;
 @property (nonatomic, readwrite) BOOL sessionStart;
 @property (nonatomic, readwrite) NSMutableArray<NSMutableDictionary<NSString*, NSObject*>*> *externalIds;
 
-+ (dispatch_queue_t)getQueue;
-- (NSDictionary<NSString *, NSObject *>*)dict;
+- (NSDictionary<NSString*, NSObject *>*)dict;
 - (void)resetTraits;
-- (void)updateTraits:(RSTraits *_Nullable) traits;
-- (void)persistTraits;
+- (void)updateTraits:(RSTraits* _Nullable)traits;
+- (void)persistTraitsOnQueue;
 - (void)updateTraitsDict:(NSMutableDictionary<NSString*, NSObject*>*)traitsDict;
 - (void)updateTraitsAnonymousId;
 - (void)putDeviceToken:(NSString*)deviceToken;
 - (void)putAdvertisementId:(NSString *_Nonnull)idfa;
 - (void)putAppTrackingConsent:(int)att;
-- (void)updateExternalIds:(NSMutableArray *__nullable)externalIds;
-- (void)resetExternalIds;
+- (void)updateExternalIds:(NSMutableArray* __nullable)externalIds;
+- (void)resetExternalIdsOnQueue;
 - (void)persistExternalIds;
+- (NSArray<NSDictionary<NSString*, NSObject*>*>* __nullable)getExternalIds;
 - (void)setSessionData:(RSUserSession *)userSession;
-- (void)setConsentData:(NSArray <NSString *> *)deniedConsentIds;
+- (void)setConsentData:(NSArray <NSString*>*)deniedConsentIds;
 
 @end
 

--- a/Sources/Classes/Headers/Public/RSEventRepository.h
+++ b/Sources/Classes/Headers/Public/RSEventRepository.h
@@ -45,7 +45,7 @@ NS_ASSUME_NONNULL_BEGIN
     BOOL isSDKEnabled;
     NSLock* lock;
     dispatch_source_t source;
-    dispatch_queue_t queue;
+    dispatch_queue_t repositoryQueue;
     RSClient *client;
 }
 

--- a/Sources/Classes/Headers/Public/RSOption.h
+++ b/Sources/Classes/Headers/Public/RSOption.h
@@ -11,7 +11,9 @@
 NS_ASSUME_NONNULL_BEGIN
 
 @protocol RSIntegrationFactory;
-@interface RSOption : NSObject
+@interface RSOption : NSObject {
+    dispatch_queue_t optionsQueue;
+}
 
 @property (nonatomic, strong) NSMutableArray<NSMutableDictionary<NSString*, NSObject*>*>* externalIds;
 @property (nonatomic, strong) NSMutableDictionary<NSString*, NSObject*>* integrations;

--- a/Sources/Classes/Headers/Public/RSPreferenceManager.h
+++ b/Sources/Classes/Headers/Public/RSPreferenceManager.h
@@ -35,6 +35,7 @@ extern NSString *const RSSessionAutoTrackStatus;
 
 - (void) saveTraits: (NSString* __nonnull) traits;
 - (NSString* __nonnull) getTraits;
+- (void) clearTraits;
 
 - (void) saveBuildVersionCode:(NSString* __nonnull)versionCode;
 - (NSString* __nullable) getBuildVersionCode; 
@@ -54,6 +55,7 @@ extern NSString *const RSSessionAutoTrackStatus;
 
 - (NSString* __nullable) getAnonymousId;
 - (void) saveAnonymousId: (NSString* __nullable) anonymousId;
+- (void) clearAnonymousId;
 
 - (BOOL) getOptStatus;
 - (void) saveOptStatus: (BOOL) optStatus;

--- a/Sources/Classes/Headers/RSVersion.h
+++ b/Sources/Classes/Headers/RSVersion.h
@@ -8,6 +8,6 @@
 #ifndef RSVersion_h
 #define RSVersion_h
 
-NSString *const SDK_VERSION = @"1.12.1";
+NSString *const SDK_VERSION = @"1.13.0";
 
 #endif /* RSVersion_h */

--- a/Sources/Classes/RSContext.m
+++ b/Sources/Classes/RSContext.m
@@ -37,41 +37,34 @@ static dispatch_queue_t queue;
         _timezone = [[NSTimeZone localTimeZone] name];
         _externalIds = nil;
         
-        dispatch_sync(queue, ^{
-            NSString *traitsJson = [preferenceManager getTraits];
-            if (traitsJson == nil) {
-                // no persisted traits, create new and persist
-                [self createAndPersistTraits];
+        
+        NSString *traitsJson = [preferenceManager getTraits];
+        if (traitsJson == nil) {
+            // no persisted traits, create new and persist
+            [self createAndPersistTraits];
+        } else {
+            NSError *error;
+            NSDictionary *traitsDict = [NSJSONSerialization JSONObjectWithData:[traitsJson dataUsingEncoding:NSUTF8StringEncoding] options:NSJSONReadingMutableContainers error:&error];
+            if (error == nil) {
+                _traits = [traitsDict mutableCopy];
             } else {
-                NSError *error;
-                NSDictionary *traitsDict = [NSJSONSerialization JSONObjectWithData:[traitsJson dataUsingEncoding:NSUTF8StringEncoding] options:NSJSONReadingMutableContainers error:&error];
-                if (error == nil) {
-                    _traits = [traitsDict mutableCopy];
-                } else {
-                    // persisted traits persing error. initiate blank
-                    [self createAndPersistTraits];
-                }
+                // persisted traits persing error. initiate blank
+                [self createAndPersistTraits];
             }
-            
-            // get saved external Ids from prefs
-            NSString *externalIdJson = [preferenceManager getExternalIds];
-            if (externalIdJson != nil) {
-                NSError *error;
-                NSDictionary *externalIdDict = [NSJSONSerialization JSONObjectWithData:[externalIdJson dataUsingEncoding:NSUTF8StringEncoding] options:NSJSONReadingMutableContainers error:&error];
-                if (error == nil) {
-                    _externalIds = [externalIdDict mutableCopy];
-                }
+        }
+        
+        // get saved external Ids from prefs
+        NSString *externalIdJson = [preferenceManager getExternalIds];
+        if (externalIdJson != nil) {
+            NSError *error;
+            NSDictionary *externalIdDict = [NSJSONSerialization JSONObjectWithData:[externalIdJson dataUsingEncoding:NSUTF8StringEncoding] options:NSJSONReadingMutableContainers error:&error];
+            if (error == nil) {
+                _externalIds = [externalIdDict mutableCopy];
             }
-        });
+        }
+        
     }
     return self;
-}
-
-+ (dispatch_queue_t) getQueue {
-    if (queue == nil) {
-        queue = dispatch_queue_create("com.rudder.RSContext", NULL);
-    }
-    return queue;
 }
 
 - (void) createAndPersistTraits {
@@ -83,7 +76,7 @@ static dispatch_queue_t queue;
 }
 
 - (void) resetTraits {
-    dispatch_async(queue, ^{
+    dispatch_sync(queue, ^{
         RSTraits* traits = [[RSTraits alloc] init];
         traits.anonymousId = [self->preferenceManager getAnonymousId];
         [self->_traits removeAllObjects];
@@ -91,44 +84,47 @@ static dispatch_queue_t queue;
     });
 }
 
-- (void)updateTraits:(RSTraits *)traits {
-    dispatch_async(queue, ^{
+- (void) updateTraits:(RSTraits *)traits {
+    dispatch_sync(queue, ^{
         NSString* existingId = (NSString*)[self->_traits objectForKey:@"userId"];
         NSString* userId = (NSString*) traits.userId;
         
         if(existingId!=nil && userId!=nil && ![existingId isEqual:userId])
         {
-            self->_traits = [[traits dict]mutableCopy];
+            self->_traits = [[traits dict] mutableCopy];
             [self resetExternalIds];
             return;
         }
         [self->_traits setValuesForKeysWithDictionary:[traits dict]];
     });
-} 
+}
 
--(void) persistTraits {
-    dispatch_async(queue, ^{
-        NSData *traitsJsonData = [NSJSONSerialization dataWithJSONObject:[RSUtils serializeDict:self->_traits] options:0 error:nil];
-        NSString *traitsString = [[NSString alloc] initWithData:traitsJsonData encoding:NSUTF8StringEncoding];
-        
-        [self->preferenceManager saveTraits:traitsString];
+- (void) persistTraitsOnQueue {
+    dispatch_sync(queue, ^{
+        [self persistTraits];
     });
 }
 
+-(void) persistTraits {
+    NSData *traitsJsonData = [NSJSONSerialization dataWithJSONObject:[RSUtils serializeDict:self->_traits] options:0 error:nil];
+    NSString *traitsString = [[NSString alloc] initWithData:traitsJsonData encoding:NSUTF8StringEncoding];
+    [self->preferenceManager saveTraits:traitsString];
+}
+
 - (void)updateTraitsDict:(NSMutableDictionary<NSString *, NSObject *> *)traitsDict {
-    dispatch_async(queue, ^{
+    dispatch_sync(queue, ^{
         self->_traits = traitsDict;
     });
 }
 
 - (void)updateTraitsAnonymousId {
-    dispatch_async(queue, ^{
+    dispatch_sync(queue, ^{
         self->_traits[@"anonymousId"] = [self->preferenceManager getAnonymousId];
     });
 }
 
 - (void)putDeviceToken:(NSString *)deviceToken {
-    dispatch_async(queue, ^{
+    dispatch_sync(queue, ^{
         self->_device.token = deviceToken;
     });
 }
@@ -136,7 +132,7 @@ static dispatch_queue_t queue;
 - (void)putAdvertisementId:(NSString *_Nonnull)idfa {
     // This isn't ideal.  We're doing this because we can't actually check if IDFA is enabled on
     // the customer device.  Apple docs and tests show that if it is disabled, one gets back all 0's.
-    dispatch_async(queue, ^{
+    dispatch_sync(queue, ^{
         if( idfa != nil && [idfa length] != 0) {
             [RSLogger logDebug:[[NSString alloc] initWithFormat:@"IDFA: %@", idfa]];
             BOOL adTrackingEnabled = (![idfa isEqualToString:@"00000000-0000-0000-0000-000000000000"]);
@@ -150,7 +146,7 @@ static dispatch_queue_t queue;
 }
 
 - (void)updateExternalIds:(NSMutableArray *)externalIds {
-    dispatch_async(queue, ^{
+    dispatch_sync(queue, ^{
         if(self->_externalIds == nil)
         {
             self->_externalIds = [[NSMutableArray alloc] init];
@@ -178,7 +174,7 @@ static dispatch_queue_t queue;
 }
 
 - (void)persistExternalIds {
-    dispatch_async(queue, ^{
+    dispatch_sync(queue, ^{
         if (self->_externalIds != nil) {
             // update persistence storage
             NSData *externalIdJsonData = [NSJSONSerialization dataWithJSONObject:[RSUtils serializeArray:[self->_externalIds copy]] options:0 error:nil];
@@ -188,15 +184,27 @@ static dispatch_queue_t queue;
     });
 }
 
-- (void)resetExternalIds {
-    dispatch_async(queue, ^{
-        self->_externalIds = nil;
-        [self->preferenceManager clearExternalIds];
+- (NSArray<NSDictionary<NSString*, NSObject*>*>* __nullable) getExternalIds {
+    __block NSArray<NSDictionary<NSString*, NSObject*>*>* externalIdsCopy = nil;
+    dispatch_sync(queue, ^{
+        externalIdsCopy = [self->_externalIds copy];
+    });
+    return externalIdsCopy;
+}
+
+- (void) resetExternalIdsOnQueue {
+    dispatch_sync(queue, ^{
+        [self resetExternalIds];
     });
 }
 
+- (void)resetExternalIds {
+    self->_externalIds = nil;
+    [self->preferenceManager clearExternalIds];
+}
+
 - (void)putAppTrackingConsent:(int)att {
-    dispatch_async(queue, ^{
+    dispatch_sync(queue, ^{
         if (att < RSATTNotDetermined) {
             self->_device.attTrackingStatus = RSATTNotDetermined;
         } else if (att > RSATTAuthorize) {
@@ -208,7 +216,7 @@ static dispatch_queue_t queue;
 }
 
 - (void) setSessionData:(RSUserSession *) userSession {
-    dispatch_async(queue, ^{        
+    dispatch_sync(queue, ^{
         if ([userSession getSessionId] != nil) {
             self->_sessionId = [userSession getSessionId];
             if([userSession getSessionStart]) {
@@ -220,7 +228,7 @@ static dispatch_queue_t queue;
 }
 
 - (void)setConsentData:(NSArray <NSString *> *)deniedConsentIds {
-    dispatch_async(queue, ^{
+    dispatch_sync(queue, ^{
         self->consentManagement = @{@"deniedConsentIds": deniedConsentIds};
     });
 }

--- a/Sources/Classes/RSElementCache.m
+++ b/Sources/Classes/RSElementCache.m
@@ -23,36 +23,29 @@ static RSContext* cachedContext;
 }
 
 + (void)updateTraits:(RSTraits *)traits {
-    dispatch_async([RSContext getQueue], ^{
-        [cachedContext updateTraits:traits];
-        [self persistTraits];
-    });
+    [cachedContext updateTraits:traits];
+    [self persistTraits];
 }
 
+
 + (void)persistTraits {
-    [cachedContext persistTraits];
+    [cachedContext persistTraitsOnQueue];
 }
 
 + (void) reset {
-    dispatch_async([RSContext getQueue], ^{
-        [cachedContext resetTraits];
-        [cachedContext persistTraits];
-        [cachedContext resetExternalIds];
-    });
+    [cachedContext resetTraits];
+    [cachedContext persistTraitsOnQueue];
+    [cachedContext resetExternalIdsOnQueue];
 }
 
 + (void)updateTraitsDict:(NSMutableDictionary<NSString *,NSObject *> *)traitsDict {
-    dispatch_async([RSContext getQueue], ^{
-        [cachedContext updateTraitsDict: traitsDict];
-        [self persistTraits];
-    });
+    [cachedContext updateTraitsDict: traitsDict];
+    [self persistTraits];
 }
 
-+(void) updateTraitsAnonymousId {
-    dispatch_async([RSContext getQueue], ^{
-        [cachedContext updateTraitsAnonymousId];
-        [self persistTraits];
-    });
++ (void) updateTraitsAnonymousId {
+    [cachedContext updateTraitsAnonymousId];
+    [self persistTraits];
 }
 
 + (NSString *)getAnonymousId {
@@ -60,9 +53,7 @@ static RSContext* cachedContext;
 }
 
 + (void) updateExternalIds:(NSMutableArray *)externalIds {
-   dispatch_async([RSContext getQueue], ^{
-        [cachedContext updateExternalIds:externalIds];
-        [cachedContext persistExternalIds];
-    });
+    [cachedContext updateExternalIds:externalIds];
+    [cachedContext persistExternalIds];
 }
 @end

--- a/Sources/Classes/RSEventRepository.m
+++ b/Sources/Classes/RSEventRepository.m
@@ -68,6 +68,8 @@ typedef enum {
 #endif
         }
         
+        [RSLogger logVerbose:@"EventRepository: Creating EventRepository Internal Queue"];
+        repositoryQueue = dispatch_queue_create("com.rudder.EventRepository", NULL);
         [RSLogger logDebug:@"EventRepository: setting up flush"];
         [self setUpFlush];
         NSData *authData = [[[NSString alloc] initWithFormat:@"%@:", _writeKey] dataUsingEncoding:NSUTF8StringEncoding];
@@ -126,7 +128,7 @@ typedef enum {
 
 - (void) setAnonymousIdToken {
     NSData *anonymousIdData = [[[NSString alloc] initWithFormat:@"%@:", [RSElementCache getAnonymousId]] dataUsingEncoding:NSUTF8StringEncoding];
-    dispatch_sync([RSContext getQueue], ^{
+    dispatch_sync(repositoryQueue, ^{
         self->anonymousIdToken = [anonymousIdData base64EncodedStringWithOptions:0];
         [RSLogger logDebug:[[NSString alloc] initWithFormat:@"EventRepository: anonymousIdToken: %@", self->anonymousIdToken]];
     });
@@ -142,11 +144,11 @@ typedef enum {
             int receivedError =[strongSelf->configManager getError];
             if (serverConfig != nil) {
                 // initiate the processor if the source is enabled
-                dispatch_sync([RSContext getQueue], ^{
+                dispatch_sync(strongSelf->repositoryQueue, ^{
                     strongSelf->isSDKEnabled = serverConfig.isSourceEnabled;
                 });
                 if  (strongSelf->isSDKEnabled) {
-                    strongSelf->dataPlaneUrl = [RSUtils getDataPlaneUrlFrom:serverConfig andRSConfig:self->config];
+                    strongSelf->dataPlaneUrl = [RSUtils getDataPlaneUrlFrom:serverConfig andRSConfig:strongSelf->config];
                     if (strongSelf->dataPlaneUrl == nil) {
                         [RSLogger logError:DATA_PLANE_URL_ERROR];
                         return;
@@ -307,8 +309,8 @@ typedef enum {
 
 - (void) setUpFlush {
     lock = [NSLock new];
-    queue = dispatch_queue_create("com.rudder.flushQueue", NULL);
-    source = dispatch_source_create(DISPATCH_SOURCE_TYPE_DATA_ADD, 0, 0, queue);
+    dispatch_queue_t flushQueue = dispatch_queue_create("com.rudder.flushQueue", NULL);
+    source = dispatch_source_create(DISPATCH_SOURCE_TYPE_DATA_ADD, 0, 0, flushQueue);
     __weak RSEventRepository *weakSelf = self;
     dispatch_source_set_event_handler(source, ^{
         RSEventRepository* strongSelf = weakSelf;
@@ -447,7 +449,7 @@ typedef enum {
     [urlRequest setHTTPMethod:@"POST"];
     [urlRequest addValue:@"Application/json" forHTTPHeaderField:@"Content-Type"];
     [urlRequest addValue:[[NSString alloc] initWithFormat:@"Basic %@", self->authToken] forHTTPHeaderField:@"Authorization"];
-    dispatch_sync([RSContext getQueue], ^{
+    dispatch_sync(repositoryQueue, ^{
         [urlRequest addValue:self->anonymousIdToken forHTTPHeaderField:@"AnonymousId"];
     });
     NSData *httpBody = [payload dataUsingEncoding:NSUTF8StringEncoding];
@@ -487,7 +489,7 @@ typedef enum {
 }
 
 - (void) dump:(RSMessage *)message {
-    dispatch_sync([RSContext getQueue], ^{
+    dispatch_sync(repositoryQueue, ^{
         if (message == nil || !self->isSDKEnabled) {
             return;
         }

--- a/Sources/Classes/RSMessage.m
+++ b/Sources/Classes/RSMessage.m
@@ -81,8 +81,9 @@
     }
 }
 
-- (void)updateTraits:(RSTraits *)traits {
-    [_context updateTraits:traits];
+- (void) updateTraits:(RSTraits *)traits {
+    [RSElementCache updateTraits:traits];
+    [self updateContext:[RSElementCache getContext]];
 }
 
 - (void)updateTraitsDict:(NSMutableDictionary<NSString *,NSObject *>*)traits {

--- a/Sources/Classes/RSOption.m
+++ b/Sources/Classes/RSOption.m
@@ -19,6 +19,7 @@
         _externalIds = nil;
         _customContexts = nil;
         _integrations = [[NSMutableDictionary alloc] init];
+        optionsQueue = dispatch_queue_create("com.rudder.RSOption", NULL);
     }
     return self;
 }
@@ -28,7 +29,7 @@
         _externalIds = [[NSMutableArray alloc] init];
     }
     
-    dispatch_sync([RSContext getQueue], ^{
+    dispatch_sync(optionsQueue, ^{
         // find out if something is already present in the storage (PreferenceManager)
         NSMutableDictionary* externalIdDict = nil;
         int dictIndex = -1;

--- a/Sources/Classes/RSPreferenceManager.m
+++ b/Sources/Classes/RSPreferenceManager.m
@@ -71,6 +71,11 @@ NSString *const RSSessionAutoTrackStatus = @"rl_session_auto_track_status";
     return [[NSUserDefaults standardUserDefaults] valueForKey:RSTraitsKey];
 }
 
+- (void)clearTraits {
+    [[NSUserDefaults standardUserDefaults] setValue:nil forKey:RSTraitsKey];
+    [[NSUserDefaults standardUserDefaults] synchronize];
+}
+
 - (NSString* __nullable) getBuildNumber {
     return [[NSUserDefaults standardUserDefaults] valueForKey:RSApplicationBuildKey];
 }
@@ -129,8 +134,6 @@ NSString *const RSSessionAutoTrackStatus = @"rl_session_auto_track_status";
         anonymousId = [[[[WKInterfaceDevice currentDevice] identifierForVendor]UUIDString] lowercaseString];
 #endif
     }
-
-    
     [self saveAnonymousId:anonymousId];
     
     return anonymousId;
@@ -138,6 +141,11 @@ NSString *const RSSessionAutoTrackStatus = @"rl_session_auto_track_status";
 
 - (void)saveAnonymousId:(NSString *)anonymousId {
     [[NSUserDefaults standardUserDefaults] setValue:anonymousId forKey:RSAnonymousIdKey];
+    [[NSUserDefaults standardUserDefaults] synchronize];
+}
+
+- (void)clearAnonymousId {
+    [[NSUserDefaults standardUserDefaults] setValue:nil forKey:RSAnonymousIdKey];
     [[NSUserDefaults standardUserDefaults] synchronize];
 }
 

--- a/Tests/ContextTests.swift
+++ b/Tests/ContextTests.swift
@@ -1,0 +1,235 @@
+//
+//  RSContextTests.swift
+//  RudderTests
+//
+//  Created by Desu Sai Venkat on 13/03/23.
+//
+
+import Foundation
+import XCTest
+@testable import Rudder
+
+class ContextTests: XCTestCase {
+    
+    var context: RSContext!
+    var preferenceManager: RSPreferenceManager!
+    var testUtils: TestUtils!
+    var sampleTraits = ["firstname": "bravo", "lastname": "dwayne", "country": "westindies"]
+    var user1Traits = ["userId": "1", "name" : "user1", "country": "one"]
+    var user2Traits = ["userId": "2", "name" : "user2", "country": "two"]
+    let externalIds1 = [
+        [
+            "type": "type1",
+            "id": "first"
+        ] as NSMutableDictionary,
+        [
+            "type": "type2",
+            "id": "second"
+        ] as NSMutableDictionary
+    ] as NSMutableArray
+    let externalIds2 = [
+        [
+            "type": "type2",
+            "id": "second-updated"
+        ] as NSMutableDictionary,
+        [
+            "type": "type3",
+            "id": "three"
+        ] as NSMutableDictionary
+    ] as NSMutableArray
+    let finalExternalIds = [
+        [
+            "type": "type1",
+            "id": "first"
+        ] as NSMutableDictionary,
+        [
+            "type": "type2",
+            "id": "second-updated"
+        ] as NSMutableDictionary,
+        [
+            "type": "type3",
+            "id": "three"
+        ] as NSMutableDictionary
+    ] as NSMutableArray
+    
+    override func setUp() {
+        super.setUp()
+        preferenceManager = RSPreferenceManager.getInstance()
+        preferenceManager.clearAnonymousId()
+        preferenceManager.clearTraits()
+        preferenceManager.clearExternalIds()
+        preferenceManager.clearSessionId()
+        preferenceManager.clearLastEventTimeStamp()
+        preferenceManager.saveAnonymousId("testAnonymousId")
+        context = RSContext()
+        testUtils = TestUtils()
+    }
+    
+    override func tearDown() {
+        super.tearDown()
+        context = nil;
+        testUtils = nil
+    }
+    
+    func test_resetTraits() {
+        context.updateTraitsDict(NSMutableDictionary(dictionary: sampleTraits))
+        XCTAssertEqual(context.traits, NSMutableDictionary(dictionary: sampleTraits))
+        context.resetTraits()
+        XCTAssertEqual(context.traits, ["anonymousId": "testAnonymousId"])
+    }
+    
+    func test_updateTraitsWithDiffValues() {
+        let traits = RSTraits(dict: sampleTraits)
+        context.updateTraits(traits);
+        sampleTraits["anonymousId"] = "testAnonymousId";
+        XCTAssertEqual(context.traits, NSMutableDictionary(dictionary: sampleTraits))
+        context.updateTraits(RSTraits(dict: ["firstname": "johnson"]))
+        XCTAssertNotEqual(context.traits, NSMutableDictionary(dictionary: sampleTraits))
+        sampleTraits["firstname"] = "johnson";
+        XCTAssertEqual(context.traits, NSMutableDictionary(dictionary: sampleTraits))
+    }
+    
+    func test_updateTraitsWithSameUserIds() {
+        let traits = RSTraits(dict:user1Traits)
+        context.updateTraits(traits)
+        user1Traits["anonymousId"] = "testAnonymousId";
+        XCTAssertEqual(context.traits, NSMutableDictionary(dictionary: user1Traits))
+        context.updateTraits(RSTraits(dict: ["userId": "1", "rank": "1"]))
+        user1Traits["rank"] = "1"
+        XCTAssertEqual(context.traits, NSMutableDictionary(dictionary: user1Traits))
+    }
+    
+    func test_updateTraitsWithDiffUserIds() {
+        let traits1 = RSTraits(dict:user1Traits)
+        context.updateTraits(traits1)
+        user1Traits["anonymousId"] = "testAnonymousId";
+        XCTAssertEqual(context.traits, NSMutableDictionary(dictionary: user1Traits))
+        let traits2 = RSTraits(dict: user2Traits)
+        context.updateTraits(traits2)
+        user2Traits["anonymousId"] = "testAnonymousId";
+        XCTAssertEqual(context.traits, NSMutableDictionary(dictionary: user2Traits))
+        XCTAssertEqual(context.traits["userId"] as! String, user2Traits["userId"]!)
+    }
+    
+    func test_persistTraits() {
+        let traits1 = RSTraits(dict:user1Traits)
+        context.updateTraits(traits1)
+        context.persistTraitsOnQueue()
+        user1Traits["anonymousId"] = "testAnonymousId";
+        XCTAssertEqual(testUtils.convertToDictionary(text: preferenceManager.getTraits()), user1Traits)
+        context.updateTraits(RSTraits(dict: ["userId": "1", "rank": "1"]))
+        context.persistTraitsOnQueue()
+        user1Traits["rank"] = "1"
+        XCTAssertEqual(testUtils.convertToDictionary(text: preferenceManager.getTraits()), user1Traits)
+    }
+    
+    func test_updateTraitsDict() {
+        context.updateTraitsDict(NSMutableDictionary(dictionary: user1Traits))
+        XCTAssertEqual(context.traits, NSMutableDictionary(dictionary: user1Traits))
+        context.updateTraitsDict(NSMutableDictionary(dictionary: user2Traits))
+        XCTAssertEqual(context.traits, NSMutableDictionary(dictionary: user2Traits))
+    }
+    
+    func test_updateTraitsAnonymousId() {
+        context.updateTraitsAnonymousId()
+        XCTAssertEqual(context.traits["anonymousId"] as! String, "testAnonymousId")
+        preferenceManager.saveAnonymousId("test1")
+        context.updateTraitsAnonymousId()
+        XCTAssertEqual(context.traits["anonymousId"] as! String, "test1")
+        preferenceManager.saveAnonymousId("test2")
+        context.updateTraitsAnonymousId()
+        XCTAssertEqual(context.traits["anonymousId"] as! String, "test2")
+        preferenceManager.saveAnonymousId("test3")
+        context.updateTraitsAnonymousId()
+        XCTAssertEqual(context.traits["anonymousId"] as! String, "test3")
+    }
+    
+    func test_putDeviceToken() {
+        context.putDeviceToken("test1")
+        XCTAssertEqual(context.device.token, "test1")
+        context.putDeviceToken("test2")
+        XCTAssertEqual(context.device.token, "test2")
+        context.putDeviceToken("test3")
+        XCTAssertEqual(context.device.token, "test3")
+    }
+    
+    func test_putAdvertisementId() {
+        context.putAdvertisementId("00000000-0000-0000-0000-000000000000")
+        XCTAssertEqual(context.device.advertisingId, "");
+        XCTAssertFalse(context.device.adTrackingEnabled)
+        context.putAdvertisementId("some-random-uuid");
+        XCTAssertEqual(context.device.advertisingId, "some-random-uuid");
+        XCTAssertTrue(context.device.adTrackingEnabled)
+    }
+    
+    func test_updateExternalIds() {
+        context.updateExternalIds(externalIds1)
+        XCTAssertEqual(context.externalIds, externalIds1)
+        context.updateExternalIds(externalIds2)
+        XCTAssertEqual(context.externalIds, finalExternalIds)
+    }
+    
+    func test_persistExternalIds() {
+        context.updateExternalIds(externalIds1)
+        context.persistExternalIds()
+        XCTAssertEqual(preferenceManager.getExternalIds(), testUtils.convertToJSONString(arrayObject: externalIds1))
+        context.updateExternalIds(externalIds2)
+        context.persistExternalIds()
+        XCTAssertEqual(preferenceManager.getExternalIds(), testUtils.convertToJSONString(arrayObject: finalExternalIds))
+    }
+    
+    func test_resetExternalIds() {
+        context.updateExternalIds(externalIds1)
+        XCTAssertEqual(context.externalIds, externalIds1)
+        context.resetExternalIdsOnQueue()
+        XCTAssertNil(context.getExternalIds())
+        XCTAssertNil(preferenceManager.getExternalIds())
+        context.updateExternalIds(externalIds2)
+        XCTAssertEqual(context.externalIds, externalIds2)
+        context.resetExternalIdsOnQueue()
+        XCTAssertNil(context.getExternalIds())
+        XCTAssertNil(preferenceManager.getExternalIds())
+    }
+    
+    func test_putAppTrackingConsent() {
+        context.putAppTrackingConsent(-1)
+        XCTAssertEqual(context.device.attTrackingStatus, RSATTNotDetermined)
+        context.putAppTrackingConsent(0)
+        XCTAssertEqual(context.device.attTrackingStatus, RSATTNotDetermined)
+        context.putAppTrackingConsent(1)
+        XCTAssertEqual(context.device.attTrackingStatus, RSATTRestricted)
+        context.putAppTrackingConsent(2)
+        XCTAssertEqual(context.device.attTrackingStatus, RSATTDenied)
+        context.putAppTrackingConsent(3)
+        XCTAssertEqual(context.device.attTrackingStatus, RSATTAuthorize)
+        context.putAppTrackingConsent(4)
+        XCTAssertEqual(context.device.attTrackingStatus, RSATTAuthorize)
+    }
+    
+    func test_setSessionData() {
+        let userSession = RSUserSession.initiate(RSSessionInActivityDefaultTimeOut, with: preferenceManager)
+        userSession.start()
+        context.setSessionData(userSession)
+        XCTAssertEqual(context.sessionId, userSession.getId())
+        XCTAssertTrue(context.sessionStart)
+    }
+    
+    func test_setConsentData() {
+        var deniedConsentIds = ["deniedId1", "deniedId2", "deniedId3", "deniedId4"]
+        context.setConsentData(deniedConsentIds)
+        XCTAssertEqual(getConsentData(), ["deniedConsentIds": deniedConsentIds])
+        deniedConsentIds = ["deniedId5", "deniedId6", "deniedId7", "deniedId8"]
+        context.setConsentData(deniedConsentIds)
+        XCTAssertEqual(getConsentData(), ["deniedConsentIds": deniedConsentIds])
+        deniedConsentIds = ["deniedId9", "deniedId10", "deniedId11", "deniedId12"]
+        context.setConsentData(deniedConsentIds)
+        XCTAssertEqual(getConsentData(), ["deniedConsentIds": deniedConsentIds])
+    }
+    
+    func getConsentData() -> [String: [String]]{
+        let dict = context.dict()
+        let consentManagement: [String: [String]] = dict["consentManagement"] as! [String: [String]]
+        return consentManagement
+        
+    }
+}

--- a/Tests/TestUtils.swift
+++ b/Tests/TestUtils.swift
@@ -32,4 +32,27 @@ internal final class TestUtils {
             fatalError("Can not parse or invalid JSON.")
         }
     }
+    
+    func convertToDictionary(text: String) -> [String: String]? {
+        if let data = text.data(using: .utf8) {
+            do {
+                return try JSONSerialization.jsonObject(with: data, options: []) as? [String: String]
+            } catch {
+                print(error.localizedDescription)
+            }
+        }
+        return nil
+    }
+    
+    func convertToJSONString(arrayObject: NSMutableArray) -> String? {
+        do {
+            let jsonData: Data = try JSONSerialization.data(withJSONObject: arrayObject, options: [])
+            if  let jsonString = NSString(data: jsonData, encoding: String.Encoding.utf8.rawValue) {
+                return jsonString as String
+            }
+        } catch {
+            print(error.localizedDescription)
+        }
+        return nil
+    }
 }

--- a/package.json
+++ b/package.json
@@ -1,4 +1,4 @@
 {
-    "version": "1.12.1",
+    "version": "1.13.0",
     "description": "Rudder is a platform for collecting, storing and routing customer event data to dozens of tools"
 }

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -6,7 +6,7 @@ sonar.qualitygate.wait=false
 sonar.projectKey=rudderlabs_rudder-sdk-ios
 sonar.organization=rudderlabs
 sonar.projectName=RudderStack iOS SDK
-sonar.projectVersion=1.12.1
+sonar.projectVersion=1.13.0
 
 # C/C++/Objective-C related details
 # sonar.cfamily.compile-commands=compile_commands.json


### PR DESCRIPTION
:crown: *An automated PR*

   Unreleased (2023-03-27)<br> * feat: made reset and identify api's synchronous to reflect the data immediately ( 284) ([6047fc6](https://github.com/rudderlabs/rudder-sdk-ios/commit/6047fc6)), closes [ 284](https://github.com/rudderlabs/rudder-sdk-ios/issues/284)<br> * ci: added workflows for making a beta release ( 292) ([4838b49](https://github.com/rudderlabs/rudder-sdk-ios/commit/4838b49)), closes [ 292](https://github.com/rudderlabs/rudder-sdk-ios/issues/292)