### PR TITLE
chore(release): pulling release/1.13.2 into master

### DIFF
--- a/.github/workflows/publish-new-release-v2.yml
+++ b/.github/workflows/publish-new-release-v2.yml
@@ -45,6 +45,9 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.PAT }}
           CONVENTIONAL_GITHUB_RELEASER_TOKEN: ${{ secrets.PAT }}
         run: |
+          git for-each-ref refs/tags
+          git tag --delete ${{ steps.extract-version.outputs.release_version }}
+          git push --delete origin ${{ steps.extract-version.outputs.release_version }}
           git tag -a v${{ steps.extract-version.outputs.release_version }} -m "chore: release v${{ steps.extract-version.outputs.release_version }}"
           git push origin refs/tags/v${{ steps.extract-version.outputs.release_version }}
           DEBUG=conventional-github-releaser npx conventional-github-releaser -p angular --config github-release.config.js

--- a/.github/workflows/publish-new-release.yml
+++ b/.github/workflows/publish-new-release.yml
@@ -45,6 +45,9 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.PAT }}
           CONVENTIONAL_GITHUB_RELEASER_TOKEN: ${{ secrets.PAT }}
         run: |
+          git for-each-ref refs/tags
+          git tag --delete ${{ steps.extract-version.outputs.release_version }}
+          git push --delete origin ${{ steps.extract-version.outputs.release_version }}
           git tag -a v${{ steps.extract-version.outputs.release_version }} -m "chore: release v${{ steps.extract-version.outputs.release_version }}"
           git push origin refs/tags/v${{ steps.extract-version.outputs.release_version }}
           DEBUG=conventional-github-releaser npx conventional-github-releaser -p angular --config github-release.config.js

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+### [1.13.2](https://github.com/rudderlabs/rudder-sdk-ios/compare/v1.13.1...v1.13.2) (2023-04-12)
+
+
+### Bug Fixes
+
+* restricted nil assign of dataPlaneUrl and controlPlaneUrl ([#307](https://github.com/rudderlabs/rudder-sdk-ios/issues/307)) ([0e28b6f](https://github.com/rudderlabs/rudder-sdk-ios/commit/0e28b6f6f3539837608840d61fc7bf453097809f))
+
 ### [1.13.1](https://github.com/rudderlabs/rudder-sdk-ios/compare/v1.13.0...v1.13.1) (2023-04-11)
 
 

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -52,7 +52,7 @@ PODS:
   - nanopb/encode (1.30906.0)
   - PromisesObjC (1.2.12)
   - Protobuf (3.21.12)
-  - Rudder (1.13.0)
+  - Rudder (1.13.1)
 
 DEPENDENCIES:
   - FirebaseMessaging
@@ -86,8 +86,8 @@ SPEC CHECKSUMS:
   nanopb: 59317e09cf1f1a0af72f12af412d54edf52603fc
   PromisesObjC: 3113f7f76903778cf4a0586bd1ab89329a0b7b97
   Protobuf: 120350fc38646e2dedc26f49ecba778184ea1de2
-  Rudder: 840bf4dfd9816ce6a82cb8870f1a2d4a44ed2652
+  Rudder: ab259b9a602c90a746af1390673ee50f902fd796
 
 PODFILE CHECKSUM: 70dfafab41ea667506f6d36e1e1a23f2c6e93495
 
-COCOAPODS: 1.11.3
+COCOAPODS: 1.12.0

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 <p align="center">
   <a href="https://cocoapods.org/pods/Rudder">
-    <img src="https://img.shields.io/static/v1?label=pod&message=v1.13.1&color=blue&style=flat">
+    <img src="https://img.shields.io/static/v1?label=pod&message=v1.13.2&color=blue&style=flat">
     </a>
 </p>
 
@@ -39,7 +39,7 @@ The iOS SDK is available through [**CocoaPods**](https://cocoapods.org), [**Cart
 To install the SDK, simply add the following line to your Podfile:
 
 ```xcode
-pod 'Rudder', '1.13.1'
+pod 'Rudder', '1.13.2'
 ```
 
 ### Carthage
@@ -47,7 +47,7 @@ pod 'Rudder', '1.13.1'
 For Carthage support, add the following line to your `Cartfile`:
 
 ```xcode
-github "rudderlabs/rudder-sdk-ios" "v1.13.1"
+github "rudderlabs/rudder-sdk-ios" "v1.13.2"
 ```
 
 > Remember to include the following code in all `.m` and `.h` files where you want to refer to or use the RudderStack SDK classes, as shown:
@@ -71,7 +71,7 @@ You can also add the RudderStack iOS SDK via Swift Package Mangaer, via one of t
 
 * Enter the package repository (`git@github.com:rudderlabs/rudder-sdk-ios.git`) in the search bar.
 
-* In **Dependency Rule**, select **Up to Next Major Version** and enter `1.13.1` as the value, as shown:
+* In **Dependency Rule**, select **Up to Next Major Version** and enter `1.13.2` as the value, as shown:
 
 ![Setting dependency](https://user-images.githubusercontent.com/59817155/145574696-8c849749-13e0-40d5-aacb-3fccb5c8e67d.png)
 
@@ -99,7 +99,7 @@ let package = Package(
     ],
     dependencies: [
         // Dependencies declare other packages that this package depends on.
-        .package(url: "git@github.com:rudderlabs/rudder-sdk-ios.git", from: "1.13.1")
+        .package(url: "git@github.com:rudderlabs/rudder-sdk-ios.git", from: "1.13.2")
     ],
     targets: [
         // Targets are the basic building blocks of a package. A target can define a module or a test suite.

--- a/Sources/Classes/Headers/RSVersion.h
+++ b/Sources/Classes/Headers/RSVersion.h
@@ -8,6 +8,6 @@
 #ifndef RSVersion_h
 #define RSVersion_h
 
-NSString *const SDK_VERSION = @"1.13.1";
+NSString *const SDK_VERSION = @"1.13.2";
 
 #endif /* RSVersion_h */

--- a/Sources/Classes/RSConfigBuilder.m
+++ b/Sources/Classes/RSConfigBuilder.m
@@ -28,6 +28,8 @@
     if (config == nil) {
         config = [[RSConfig alloc] init];
     }
+    if (dataPlaneUrl == nil)
+        return self;
     
     NSURL *url = [[NSURL alloc] initWithString:dataPlaneUrl];
     if([RSUtils isValidURL:url]) {
@@ -167,6 +169,9 @@
     if (config == nil) {
         config = [[RSConfig alloc] init];
     }
+    if (controlPlaneUrl == nil)
+        return self;
+    
     NSURL *url = [[NSURL alloc] initWithString:controlPlaneUrl];
     if([RSUtils isValidURL:url]) {
         config.controlPlaneUrl = [RSUtils appendSlashToUrl: url.absoluteString];

--- a/package.json
+++ b/package.json
@@ -1,4 +1,4 @@
 {
-    "version": "1.13.1",
+    "version": "1.13.2",
     "description": "Rudder is a platform for collecting, storing and routing customer event data to dozens of tools"
 }

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -6,7 +6,7 @@ sonar.qualitygate.wait=false
 sonar.projectKey=rudderlabs_rudder-sdk-ios
 sonar.organization=rudderlabs
 sonar.projectName=RudderStack iOS SDK
-sonar.projectVersion=1.13.1
+sonar.projectVersion=1.13.2
 
 # C/C++/Objective-C related details
 # sonar.cfamily.compile-commands=compile_commands.json


### PR DESCRIPTION
:crown: *An automated PR*

   <small>1.13.1 (2023-04-12)</small><br> * fix: restricted nil assign of dataPlaneUrl and controlPlaneUrl ( 307) ([0e28b6f](https://github.com/rudderlabs/rudder-sdk-ios/commit/0e28b6f)), closes [ 307](https://github.com/rudderlabs/rudder-sdk-ios/issues/307)<br> * chore: fix duplicate tag creation ( 306) ([6c54ed7](https://github.com/rudderlabs/rudder-sdk-ios/commit/6c54ed7)), closes [ 306](https://github.com/rudderlabs/rudder-sdk-ios/issues/306)