### PR TITLE
feat: added support for dual SIM carrier names

### DIFF
--- a/Sources/Classes/Headers/Public/RSNetwork.h
+++ b/Sources/Classes/Headers/Public/RSNetwork.h
@@ -13,13 +13,13 @@
 NS_ASSUME_NONNULL_BEGIN
 
 @interface RSNetwork : NSObject
-- (instancetype) initWithDict:(NSDictionary*) dict;
-- (NSDictionary<NSString* , NSObject *>*) dict;
+- (instancetype)initWithDict:(NSDictionary *)dict;
+- (NSDictionary<NSString *, NSObject *> *)dict;
 
-@property (nonatomic, readwrite) NSString* carrier;
-@property (nonatomic, readwrite) bool wifi;
-@property (nonatomic, readwrite) bool isNetworkReachable;
-@property (nonatomic, readwrite) bool cellular;
+@property(nonatomic, strong) NSMutableArray<NSString *> *carriers;
+@property(nonatomic, readwrite) bool wifi;
+@property(nonatomic, readwrite) bool isNetworkReachable;
+@property(nonatomic, readwrite) bool cellular;
 
 @end
 

--- a/Sources/Classes/Headers/Public/RSNetwork.h
+++ b/Sources/Classes/Headers/Public/RSNetwork.h
@@ -16,7 +16,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (instancetype)initWithDict:(NSDictionary *)dict;
 - (NSDictionary<NSString *, NSObject *> *)dict;
 
-@property(nonatomic, strong) NSMutableArray<NSString *> *carriers;
+@property(nonatomic, strong) NSMutableArray<NSString *> *carrier;
 @property(nonatomic, readwrite) bool wifi;
 @property(nonatomic, readwrite) bool isNetworkReachable;
 @property(nonatomic, readwrite) bool cellular;

--- a/Sources/Classes/RSNetwork.m
+++ b/Sources/Classes/RSNetwork.m
@@ -83,7 +83,9 @@
     NSMutableDictionary *tempDict;
     @synchronized (tempDict) {
         tempDict = [[NSMutableDictionary alloc] init];
-        [tempDict setValue:_carrier forKey:@"carriers"];
+        if(_carrier.count !=0) {
+            [tempDict setValue:_carrier forKey:@"carriers"];
+        }
 #if !TARGET_OS_WATCH
         if(_isNetworkReachable) {
             [tempDict setValue:[NSNumber numberWithBool:_wifi] forKey:@"wifi"];

--- a/Sources/Classes/RSNetwork.m
+++ b/Sources/Classes/RSNetwork.m
@@ -22,19 +22,22 @@
         _carrier = [[NSMutableArray alloc] init];
 #if !TARGET_OS_TV && !TARGET_OS_WATCH
         CTTelephonyNetworkInfo *networkInfo = [[CTTelephonyNetworkInfo alloc] init];
-        NSString *carrierName = nil;
         
         if (@available(iOS 12.0, *)) {
             NSDictionary *serviceProviders = [networkInfo serviceSubscriberCellularProviders];
             for (NSString *rat in serviceProviders) {
                 CTCarrier *carrier = [serviceProviders objectForKey:rat];
-                if (carrier && [carrier carrierName]) {
-                    [_carrier addObject:[carrier carrierName]];
+                if(carrier == nil) {
+                    continue;
+                }
+                NSString *carrierName = [carrier carrierName];
+                if (carrierName) {
+                    [_carrier addObject:carrierName];
                 }
             }
         } else {
             CTCarrier *carrier = [networkInfo subscriberCellularProvider];
-            carrierName = [carrier carrierName];
+            NSString *carrierName = [carrier carrierName];
             if (carrierName) {
                 [_carrier addObject:carrierName];
             }

--- a/Sources/Classes/RSNetwork.m
+++ b/Sources/Classes/RSNetwork.m
@@ -19,6 +19,7 @@
 {
     self = [super init];
     if (self) {
+        _carriers = [[NSMutableArray alloc] init];
 #if !TARGET_OS_TV && !TARGET_OS_WATCH
         CTTelephonyNetworkInfo *networkInfo = [[CTTelephonyNetworkInfo alloc] init];
         NSString *carrierName = nil;
@@ -27,19 +28,19 @@
             NSDictionary *serviceProviders = [networkInfo serviceSubscriberCellularProviders];
             for (NSString *rat in serviceProviders) {
                 CTCarrier *carrier = [serviceProviders objectForKey:rat];
-                if (carrier) {
-                    carrierName = [carrier carrierName];
-                    break;
+                if (carrier && [carrier carrierName]) {
+                    [_carriers addObject:[carrier carrierName]];
                 }
             }
         } else {
             CTCarrier *carrier = [networkInfo subscriberCellularProvider];
             carrierName = [carrier carrierName];
+            if (carrierName) {
+                [_carriers addObject:carrierName];
+            }
         }
         
-        if (carrierName) {
-            _carrier = carrierName;
-        } else {
+        if(_carriers.count == 0) {
             [RSLogger logWarn:@"RSNetwork: init: unable to retrieve carrier name"];
         }
 #endif
@@ -66,7 +67,7 @@
 - (instancetype) initWithDict:(NSDictionary*) dict {
     self = [super init];
     if(self) {
-        _carrier = dict[@"carrier"];
+        _carriers = dict[@"carrier"];
         _wifi = dict[@"wifi"];
         _cellular = dict[@"cellular"];
     }
@@ -77,7 +78,7 @@
     NSMutableDictionary *tempDict;
     @synchronized (tempDict) {
         tempDict = [[NSMutableDictionary alloc] init];
-        [tempDict setValue:_carrier forKey:@"carrier"];
+        [tempDict setValue:_carriers forKey:@"carriers"];
 #if !TARGET_OS_WATCH
         if(_isNetworkReachable) {
             [tempDict setValue:[NSNumber numberWithBool:_wifi] forKey:@"wifi"];

--- a/Sources/Classes/RSNetwork.m
+++ b/Sources/Classes/RSNetwork.m
@@ -19,7 +19,7 @@
 {
     self = [super init];
     if (self) {
-        _carriers = [[NSMutableArray alloc] init];
+        _carrier = [[NSMutableArray alloc] init];
 #if !TARGET_OS_TV && !TARGET_OS_WATCH
         CTTelephonyNetworkInfo *networkInfo = [[CTTelephonyNetworkInfo alloc] init];
         NSString *carrierName = nil;
@@ -29,18 +29,18 @@
             for (NSString *rat in serviceProviders) {
                 CTCarrier *carrier = [serviceProviders objectForKey:rat];
                 if (carrier && [carrier carrierName]) {
-                    [_carriers addObject:[carrier carrierName]];
+                    [_carrier addObject:[carrier carrierName]];
                 }
             }
         } else {
             CTCarrier *carrier = [networkInfo subscriberCellularProvider];
             carrierName = [carrier carrierName];
             if (carrierName) {
-                [_carriers addObject:carrierName];
+                [_carrier addObject:carrierName];
             }
         }
         
-        if(_carriers.count == 0) {
+        if(_carrier.count == 0) {
             [RSLogger logWarn:@"RSNetwork: init: unable to retrieve carrier name"];
         }
 #endif
@@ -67,7 +67,7 @@
 - (instancetype) initWithDict:(NSDictionary*) dict {
     self = [super init];
     if(self) {
-        _carriers = dict[@"carrier"];
+        _carrier = dict[@"carrier"];
         _wifi = dict[@"wifi"];
         _cellular = dict[@"cellular"];
     }
@@ -78,7 +78,7 @@
     NSMutableDictionary *tempDict;
     @synchronized (tempDict) {
         tempDict = [[NSMutableDictionary alloc] init];
-        [tempDict setValue:_carriers forKey:@"carriers"];
+        [tempDict setValue:_carrier forKey:@"carriers"];
 #if !TARGET_OS_WATCH
         if(_isNetworkReachable) {
             [tempDict setValue:[NSNumber numberWithBool:_wifi] forKey:@"wifi"];

--- a/Sources/Classes/RSNetwork.m
+++ b/Sources/Classes/RSNetwork.m
@@ -22,8 +22,10 @@
         _carrier = [[NSMutableArray alloc] init];
 #if !TARGET_OS_TV && !TARGET_OS_WATCH
         CTTelephonyNetworkInfo *networkInfo = [[CTTelephonyNetworkInfo alloc] init];
-        
-        if (@available(iOS 12.0, *)) {
+        if(@available(iOS 16.0, *)) {
+            [RSLogger logWarn:@"RSNetwork: init: cannot retrieve carrier names on iOS 16 and above as CTCarrier is deprecated"];
+        }
+        else if (@available(iOS 12.0, *)) {
             NSDictionary *serviceProviders = [networkInfo serviceSubscriberCellularProviders];
             for (NSString *rat in serviceProviders) {
                 CTCarrier *carrier = [serviceProviders objectForKey:rat];

--- a/Sources/Classes/RSNetwork.m
+++ b/Sources/Classes/RSNetwork.m
@@ -33,7 +33,7 @@
                     continue;
                 }
                 NSString *carrierName = [carrier carrierName];
-                if (carrierName) {
+                if (carrierName && ![carrierName isEqualToString:@"--"]) {
                     [_carrier addObject:carrierName];
                 }
             }


### PR DESCRIPTION
# handled deprecation of subscriberCellularProvider API from iOS 12 in RSNetwork

For retrieving carrier name, we are following the below steps:

* Carrier Name is deprecated in iOS versions >=16 hence we cannot get in iOS versions >= 16
* Using serviceSubscriberCellularProviders API of CTTelephonyNetworkInfo in iOS versions >= 12 and <16
* Using subscriberCellularProvider API of CTTelephonyNetworkInfo in iOS versions < 12
