### PR TITLE
chore(release): pulling release/1.16.0 into master

### DIFF
--- a/.github/workflows/slack-notify.yml
+++ b/.github/workflows/slack-notify.yml
@@ -11,7 +11,7 @@ jobs:
     steps:
       - name: Send message to Slack channel
         id: slack
-        uses: slackapi/slack-github-action@v1.23.0
+        uses: slackapi/slack-github-action@v1.24.0
         env:
           SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
           PROJECT_NAME: 'iOS SDK'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+## [1.16.0](https://github.com/rudderlabs/rudder-sdk-ios/compare/v1.15.1...v1.16.0) (2023-06-08)
+
+
+### Features
+
+* added support for gzip ([#325](https://github.com/rudderlabs/rudder-sdk-ios/issues/325)) ([2e1fba0](https://github.com/rudderlabs/rudder-sdk-ios/commit/2e1fba097b7f288047b5593fe2da4244dbf45ea6))
+
 ### [1.15.1](https://github.com/rudderlabs/rudder-sdk-ios/compare/v1.15.0...v1.15.1) (2023-05-12)
 
 

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -1,18 +1,18 @@
 PODS:
   - Amplitude (7.2.2)
-  - Appboy-iOS-SDK (4.4.2):
-    - Appboy-iOS-SDK/UI (= 4.4.2)
-  - Appboy-iOS-SDK/ContentCards (4.4.2):
+  - Appboy-iOS-SDK (4.5.4):
+    - Appboy-iOS-SDK/UI (= 4.5.4)
+  - Appboy-iOS-SDK/ContentCards (4.5.4):
     - Appboy-iOS-SDK/Core
     - SDWebImage (< 6, >= 5.8.2)
-  - Appboy-iOS-SDK/Core (4.4.2)
-  - Appboy-iOS-SDK/InAppMessage (4.4.2):
+  - Appboy-iOS-SDK/Core (4.5.4)
+  - Appboy-iOS-SDK/InAppMessage (4.5.4):
     - Appboy-iOS-SDK/Core
     - SDWebImage (< 6, >= 5.8.2)
-  - Appboy-iOS-SDK/NewsFeed (4.4.2):
+  - Appboy-iOS-SDK/NewsFeed (4.5.4):
     - Appboy-iOS-SDK/Core
     - SDWebImage (< 6, >= 5.8.2)
-  - Appboy-iOS-SDK/UI (4.4.2):
+  - Appboy-iOS-SDK/UI (4.5.4):
     - Appboy-iOS-SDK/ContentCards
     - Appboy-iOS-SDK/Core
     - Appboy-iOS-SDK/InAppMessage
@@ -43,7 +43,7 @@ PODS:
     - GoogleUtilities/Reachability (~> 7.7)
     - GoogleUtilities/UserDefaults (~> 7.7)
     - nanopb (< 2.30910.0, >= 2.30908.0)
-  - GoogleDataTransport (9.2.2):
+  - GoogleDataTransport (9.2.3):
     - GoogleUtilities/Environment (~> 7.7)
     - nanopb (< 2.30910.0, >= 2.30908.0)
     - PromisesObjC (< 3.0, >= 1.2)
@@ -70,16 +70,16 @@ PODS:
   - nanopb/decode (2.30909.0)
   - nanopb/encode (2.30909.0)
   - PromisesObjC (2.2.0)
-  - Rudder (1.13.2)
+  - Rudder (1.15.1)
   - Rudder-Amplitude (1.0.2):
     - Amplitude (~> 7.2.0)
     - Rudder
-  - Rudder-Braze (1.1.1):
-    - Appboy-iOS-SDK (= 4.4.2)
-    - Rudder (~> 1.0)
-  - SDWebImage (5.15.5):
-    - SDWebImage/Core (= 5.15.5)
-  - SDWebImage/Core (5.15.5)
+  - Rudder-Braze (1.2.0):
+    - Appboy-iOS-SDK (~> 4.5.4)
+    - Rudder (~> 1.12)
+  - SDWebImage (5.15.8):
+    - SDWebImage/Core (= 5.15.8)
+  - SDWebImage/Core (5.15.8)
 
 DEPENDENCIES:
   - Amplitude (~> 7.2.0)
@@ -111,21 +111,21 @@ EXTERNAL SOURCES:
 
 SPEC CHECKSUMS:
   Amplitude: 517cdc7c485bda64b685174426ecbf17746eb16a
-  Appboy-iOS-SDK: 4a7dfe908639da81e5e85849355f6066b58b4cc6
+  Appboy-iOS-SDK: 2fc5b290fe1caa85718b811a19b303d45caea975
   FirebaseCore: 2082fffcd855f95f883c0a1641133eb9bbe76d40
   FirebaseCoreDiagnostics: 99a495094b10a57eeb3ae8efa1665700ad0bdaa6
   FirebaseCoreInternal: bca76517fe1ed381e989f5e7d8abb0da8d85bed3
   FirebaseInstallations: 0a115432c4e223c5ab20b0dbbe4cbefa793a0e8e
   FirebaseMessaging: a4d7910e4af663c9cbfc1071c5bef34651690949
-  GoogleDataTransport: 8378d1fa8ac49753ea6ce70d65a7cb70ce5f66e6
+  GoogleDataTransport: f0308f5905a745f94fb91fea9c6cbaf3831cb1bd
   GoogleUtilities: 9aa0ad5a7bc171f8bae016300bfcfa3fb8425749
   nanopb: b552cce312b6c8484180ef47159bc0f65a1f0431
   PromisesObjC: 09985d6d70fbe7878040aa746d78236e6946d2ef
-  Rudder: 1353907b7323389ad213f3ef0a30969261f67773
+  Rudder: 41040d4537a178e4e32477b68400f98ca0c354eb
   Rudder-Amplitude: f845cc125a1a58d4de6155391a2b0392815ae898
-  Rudder-Braze: e8b8c76b7e7f0348c79f8cc359e43f4c6cd7ac9b
-  SDWebImage: fd7e1a22f00303e058058278639bf6196ee431fe
+  Rudder-Braze: e42eb914a03cb418ed8b7a3cd90b724a91476631
+  SDWebImage: cb032eba469c54e0000e78bcb0a13cdde0a52798
 
 PODFILE CHECKSUM: 42bfa6ba9271b8d9518a669daca1fd9a7bbf9f6e
 
-COCOAPODS: 1.12.0
+COCOAPODS: 1.12.1

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 <p align="center">
   <a href="https://cocoapods.org/pods/Rudder">
-    <img src="https://img.shields.io/static/v1?label=pod&message=v1.15.1&color=blue&style=flat">
+    <img src="https://img.shields.io/static/v1?label=pod&message=v1.16.0&color=blue&style=flat">
     </a>
 </p>
 
@@ -39,7 +39,7 @@ The iOS SDK is available through [**CocoaPods**](https://cocoapods.org), [**Cart
 To install the SDK, simply add the following line to your Podfile:
 
 ```xcode
-pod 'Rudder', '1.15.1'
+pod 'Rudder', '1.16.0'
 ```
 
 ### Carthage
@@ -47,7 +47,7 @@ pod 'Rudder', '1.15.1'
 For Carthage support, add the following line to your `Cartfile`:
 
 ```xcode
-github "rudderlabs/rudder-sdk-ios" "v1.15.1"
+github "rudderlabs/rudder-sdk-ios" "v1.16.0"
 ```
 
 > Remember to include the following code in all `.m` and `.h` files where you want to refer to or use the RudderStack SDK classes, as shown:
@@ -71,7 +71,7 @@ You can also add the RudderStack iOS SDK via Swift Package Mangaer, via one of t
 
 * Enter the package repository (`git@github.com:rudderlabs/rudder-sdk-ios.git`) in the search bar.
 
-* In **Dependency Rule**, select **Up to Next Major Version** and enter `1.15.1` as the value, as shown:
+* In **Dependency Rule**, select **Up to Next Major Version** and enter `1.16.0` as the value, as shown:
 
 ![Setting dependency](https://user-images.githubusercontent.com/59817155/145574696-8c849749-13e0-40d5-aacb-3fccb5c8e67d.png)
 
@@ -99,7 +99,7 @@ let package = Package(
     ],
     dependencies: [
         // Dependencies declare other packages that this package depends on.
-        .package(url: "git@github.com:rudderlabs/rudder-sdk-ios.git", from: "1.15.1")
+        .package(url: "git@github.com:rudderlabs/rudder-sdk-ios.git", from: "1.16.0")
     ],
     targets: [
         // Targets are the basic building blocks of a package. A target can define a module or a test suite.

--- a/Rudder.xcodeproj/project.pbxproj
+++ b/Rudder.xcodeproj/project.pbxproj
@@ -18,6 +18,8 @@
 		ED38D39D29CB04C7003A7544 /* EventRepositoryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED38D36E29CB01A0003A7544 /* EventRepositoryTests.swift */; };
 		ED38D39E29CB04C7003A7544 /* TestUtils.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED38D37D29CB01A0003A7544 /* TestUtils.swift */; };
 		ED38D39F29CB04C7003A7544 /* Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED38D37029CB01A0003A7544 /* Extensions.swift */; };
+		ED3CC19F2A14A78200F34082 /* NSData+GZIP.h in Headers */ = {isa = PBXBuildFile; fileRef = ED3CC19D2A14A78200F34082 /* NSData+GZIP.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		ED3CC1A02A14A78200F34082 /* NSData+GZIP.m in Sources */ = {isa = PBXBuildFile; fileRef = ED3CC19E2A14A78200F34082 /* NSData+GZIP.m */; };
 		ED7DFE38298C091800ED5A8E /* RSServerConfigSource.m in Sources */ = {isa = PBXBuildFile; fileRef = ED7DFD85298C091800ED5A8E /* RSServerConfigSource.m */; };
 		ED7DFE39298C091800ED5A8E /* RSTraits.m in Sources */ = {isa = PBXBuildFile; fileRef = ED7DFD86298C091800ED5A8E /* RSTraits.m */; };
 		ED7DFE3A298C091800ED5A8E /* RSLibraryInfo.m in Sources */ = {isa = PBXBuildFile; fileRef = ED7DFD87298C091800ED5A8E /* RSLibraryInfo.m */; };
@@ -250,6 +252,8 @@
 		ED38D37129CB01A0003A7544 /* RudderUtilsTest.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RudderUtilsTest.swift; sourceTree = "<group>"; };
 		ED38D37C29CB01A0003A7544 /* ServerConfigManagerTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ServerConfigManagerTests.swift; sourceTree = "<group>"; };
 		ED38D37D29CB01A0003A7544 /* TestUtils.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TestUtils.swift; sourceTree = "<group>"; };
+		ED3CC19D2A14A78200F34082 /* NSData+GZIP.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "NSData+GZIP.h"; sourceTree = "<group>"; };
+		ED3CC19E2A14A78200F34082 /* NSData+GZIP.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = "NSData+GZIP.m"; sourceTree = "<group>"; };
 		ED7DFD85298C091800ED5A8E /* RSServerConfigSource.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = RSServerConfigSource.m; sourceTree = "<group>"; };
 		ED7DFD86298C091800ED5A8E /* RSTraits.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = RSTraits.m; sourceTree = "<group>"; };
 		ED7DFD87298C091800ED5A8E /* RSLibraryInfo.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = RSLibraryInfo.m; sourceTree = "<group>"; };
@@ -556,6 +560,7 @@
 			children = (
 				ED7DFDD0298C091800ED5A8E /* Ecomm */,
 				EDA2C5B129C0EB9500B7FF42 /* Headers */,
+				ED3CC19E2A14A78200F34082 /* NSData+GZIP.m */,
 				ED7DFD8B298C091800ED5A8E /* RSApp.m */,
 				F6B4B53729C8237D00344864 /* RSApplicationLifeCycleManager.m */,
 				F6B4B53529C8237D00344864 /* RSBackGroundModeManager.m */,
@@ -610,6 +615,7 @@
 			isa = PBXGroup;
 			children = (
 				EDEC3CD829ADC9CF007DDE07 /* Ecomm */,
+				ED3CC19D2A14A78200F34082 /* NSData+GZIP.h */,
 				ED7DFDB1298C091800ED5A8E /* RSApp.h */,
 				F6B4B52529C8236100344864 /* RSApplicationLifeCycleManager.h */,
 				F6B4B51E29C8236100344864 /* RSBackGroundModeManager.h */,
@@ -946,6 +952,7 @@
 				F6B4B53029C8236100344864 /* RSDeviceModeTransformationManager.h in Headers */,
 				ED7DFED7298C091800ED5A8E /* RSProductRemovedFromWishListEvent.h in Headers */,
 				F6B4B52729C8236100344864 /* RSCloudModeManager.h in Headers */,
+				ED3CC19F2A14A78200F34082 /* NSData+GZIP.h in Headers */,
 				F6B4B52D29C8236100344864 /* RSDataResidencyManager.h in Headers */,
 				ED7DFE90298C091800ED5A8E /* RSECommerceCheckout.h in Headers */,
 				F6B4B52A29C8236100344864 /* RSDeviceModeManager.h in Headers */,
@@ -1158,6 +1165,7 @@
 				ED7DFE4C298C091800ED5A8E /* RSMessageType.m in Sources */,
 				ED7DFEAA298C091800ED5A8E /* RSProductAddedToWishListEvent.m in Sources */,
 				ED7DFED1298C091800ED5A8E /* RSProductViewedEvent.m in Sources */,
+				ED3CC1A02A14A78200F34082 /* NSData+GZIP.m in Sources */,
 				ED7DFE41298C091800ED5A8E /* RSEventFilteringPlugin.m in Sources */,
 				F6B4B54029C8237D00344864 /* RSApplicationLifeCycleManager.m in Sources */,
 				ED7DFEAB298C091800ED5A8E /* RSProductSearchedEvent.m in Sources */,

--- a/Sources/Classes/Headers/Public/NSData+GZIP.h
+++ b/Sources/Classes/Headers/Public/NSData+GZIP.h
@@ -1,0 +1,18 @@
+//
+//  NSData+GZIP.h
+//  Rudder
+//
+//  Created by Pallab Maiti on 17/05/23.
+//
+
+#import <Foundation/Foundation.h>
+
+
+@interface NSData (GZIP)
+
+- (nullable NSData *)gzippedDataWithCompressionLevel:(float)level;
+- (nullable NSData *)gzippedData;
+- (nullable NSData *)gunzippedData;
+- (BOOL)isGzippedData;
+
+@end

--- a/Sources/Classes/Headers/Public/RSConfig.h
+++ b/Sources/Classes/Headers/Public/RSConfig.h
@@ -31,6 +31,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, readwrite) NSMutableArray* factories;
 @property (nonatomic, readwrite) NSMutableArray* customFactories;
 @property (nonatomic, readwrite, nullable) id<RSConsentFilter> consentFilter;
+@property (nonatomic) bool gzip;
 
 @end
 

--- a/Sources/Classes/Headers/Public/RSConfigBuilder.h
+++ b/Sources/Classes/Headers/Public/RSConfigBuilder.h
@@ -41,6 +41,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (instancetype)withFactory:(id <RSIntegrationFactory> _Nonnull)factory;
 - (instancetype)withCustomFactory:(id <RSIntegrationFactory> _Nonnull)customFactory;
 - (instancetype)withConsentFilter:(id <RSConsentFilter> _Nonnull)consentFilter;
+- (instancetype)withGzip:(BOOL)status;
 - (RSConfig*)build;
 
 @end

--- a/Sources/Classes/Headers/Public/RSConstants.h
+++ b/Sources/Classes/Headers/Public/RSConstants.h
@@ -37,6 +37,8 @@ extern bool const RSRecordScreenViews;
 extern bool const RSEnableBackgroundMode;
 // default for automatic session tracking
 extern bool const RSAutomaticSessionTracking;
+// default for gzip request payload
+extern bool const RSGzipStatus;
 // SDK Version
 extern NSString *const RS_VERSION;
 // constant used to check if event filtering is disabled

--- a/Sources/Classes/Headers/RSVersion.h
+++ b/Sources/Classes/Headers/RSVersion.h
@@ -8,6 +8,6 @@
 #ifndef RSVersion_h
 #define RSVersion_h
 
-NSString *const SDK_VERSION = @"1.15.1";
+NSString *const SDK_VERSION = @"1.16.0";
 
 #endif /* RSVersion_h */

--- a/Sources/Classes/NSData+GZIP.m
+++ b/Sources/Classes/NSData+GZIP.m
@@ -1,0 +1,94 @@
+//
+//  NSData+GZIP.m
+//  Rudder
+//
+//  Created by Pallab Maiti on 17/05/23.
+//
+
+#import "NSData+GZIP.h"
+#import <zlib.h>
+
+
+#pragma clang diagnostic ignored "-Wcast-qual"
+
+
+@implementation NSData (GZIP)
+
+- (NSData *)gzippedDataWithCompressionLevel:(float)level {
+    if (self.length == 0 || [self isGzippedData]) {
+        return self;
+    }
+    
+    z_stream stream;
+    stream.zalloc = Z_NULL;
+    stream.zfree = Z_NULL;
+    stream.opaque = Z_NULL;
+    stream.avail_in = (uint)self.length;
+    stream.next_in = (Bytef *)(void *)self.bytes;
+    stream.total_out = 0;
+    stream.avail_out = 0;
+    
+    static const NSUInteger ChunkSize = 16384;
+    
+    NSMutableData *output = nil;
+    int compression = (level < 0.0f)? Z_DEFAULT_COMPRESSION: (int)(roundf(level * 9));
+    if (deflateInit2(&stream, compression, Z_DEFLATED, 31, 8, Z_DEFAULT_STRATEGY) == Z_OK) {
+        output = [NSMutableData dataWithLength:ChunkSize];
+        while (stream.avail_out == 0) {
+            if (stream.total_out >= output.length) {
+                output.length += ChunkSize;
+            }
+            stream.next_out = (uint8_t *)output.mutableBytes + stream.total_out;
+            stream.avail_out = (uInt)(output.length - stream.total_out);
+            deflate(&stream, Z_FINISH);
+        }
+        deflateEnd(&stream);
+        output.length = stream.total_out;
+    }
+    
+    return output;
+}
+
+- (NSData *)gzippedData {
+    return [self gzippedDataWithCompressionLevel:-1.0f];
+}
+
+- (NSData *)gunzippedData {
+    if (self.length == 0 || ![self isGzippedData]) {
+        return self;
+    }
+    
+    z_stream stream;
+    stream.zalloc = Z_NULL;
+    stream.zfree = Z_NULL;
+    stream.avail_in = (uint)self.length;
+    stream.next_in = (Bytef *)self.bytes;
+    stream.total_out = 0;
+    stream.avail_out = 0;
+    
+    NSMutableData *output = nil;
+    if (inflateInit2(&stream, 47) == Z_OK) {
+        int status = Z_OK;
+        output = [NSMutableData dataWithCapacity:self.length * 2];
+        while (status == Z_OK) {
+            if (stream.total_out >= output.length) {
+                output.length += self.length / 2;
+            }
+            stream.next_out = (uint8_t *)output.mutableBytes + stream.total_out;
+            stream.avail_out = (uInt)(output.length - stream.total_out);
+            status = inflate (&stream, Z_SYNC_FLUSH);
+        }
+        if (inflateEnd(&stream) == Z_OK && status == Z_STREAM_END) {
+            output.length = stream.total_out;
+        }
+    }
+    
+    return output;
+}
+
+- (BOOL)isGzippedData {
+    const UInt8 *bytes = (const UInt8 *)self.bytes;
+    return (self.length >= 2 && bytes[0] == 0x1f && bytes[1] == 0x8b);
+}
+
+@end

--- a/Sources/Classes/RSApplicationLifeCycleManager.m
+++ b/Sources/Classes/RSApplicationLifeCycleManager.m
@@ -7,8 +7,8 @@
 //
 
 #import "RSApplicationLifeCycleManager.h"
-#import <Rudder/UIViewController+RSScreen.h>
-#import <Rudder/WKInterfaceController+RSScreen.h>
+#import "UIViewController+RSScreen.h"
+#import "WKInterfaceController+RSScreen.h"
 
 @implementation RSApplicationLifeCycleManager
 

--- a/Sources/Classes/RSConfig.m
+++ b/Sources/Classes/RSConfig.m
@@ -30,6 +30,7 @@
         _controlPlaneUrl = RSControlPlaneUrl;
         _factories = [[NSMutableArray alloc] init];
         _customFactories = [[NSMutableArray alloc] init];
+        _gzip = RSGzipStatus;
     }
     return self;
 }

--- a/Sources/Classes/RSConfigBuilder.m
+++ b/Sources/Classes/RSConfigBuilder.m
@@ -209,6 +209,14 @@
     return self;
 }
 
+- (instancetype)withGzip:(BOOL)status {
+    if (config == nil) {
+        config = [[RSConfig alloc] init];
+    }
+    config.gzip = status;
+    return self;
+}
+
 - (RSConfig*) build {
     if (config == nil) {
         config = [[RSConfig alloc] init];

--- a/Sources/Classes/RSConstants.m
+++ b/Sources/Classes/RSConstants.m
@@ -22,6 +22,7 @@ bool const RSTrackLifeCycleEvents = YES;
 bool const RSRecordScreenViews = NO;
 bool const RSEnableBackgroundMode = NO;
 bool const RSAutomaticSessionTracking = YES;
+bool const RSGzipStatus = YES;
 NSString *const RS_VERSION = SDK_VERSION;
 NSString* const DISABLE = @"disable";
 NSString* const WHITELISTED_EVENTS = @"whitelistedEvents";

--- a/Sources/Classes/RSNetworkManager.m
+++ b/Sources/Classes/RSNetworkManager.m
@@ -7,6 +7,7 @@
 //
 
 #import "RSNetworkManager.h"
+#import "NSData+GZIP.h"
 
 @implementation RSNetworkManager
 
@@ -58,6 +59,10 @@ NSString* const RESPONSE = @"RESPONSE";
         [urlRequest addValue:@"Application/json" forHTTPHeaderField:@"Content-Type"];
         [urlRequest addValue:self->anonymousIdToken forHTTPHeaderField:@"AnonymousId"];
         NSData *httpBody = [payload dataUsingEncoding:NSUTF8StringEncoding];
+        if (self-> config.gzip) {
+            httpBody = [httpBody gzippedData];
+            [urlRequest addValue:@"gzip" forHTTPHeaderField:@"Content-Encoding"];
+        }
         [urlRequest setHTTPBody:httpBody];
     }
     NSURLSession *session = [NSURLSession sharedSession];

--- a/package.json
+++ b/package.json
@@ -1,4 +1,4 @@
 {
-    "version": "1.15.1",
+    "version": "1.16.0",
     "description": "Rudder is a platform for collecting, storing and routing customer event data to dozens of tools"
 }

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -6,7 +6,7 @@ sonar.qualitygate.wait=false
 sonar.projectKey=rudderlabs_rudder-sdk-ios
 sonar.organization=rudderlabs
 sonar.projectName=RudderStack iOS SDK
-sonar.projectVersion=1.15.1
+sonar.projectVersion=1.16.0
 
 # C/C++/Objective-C related details
 # sonar.cfamily.compile-commands=compile_commands.json


### PR DESCRIPTION
:crown: *An automated PR*

   Unreleased (2023-06-08)<br> * chore: fix for SPM build ( 333) ([7867df3](https://github.com/rudderlabs/rudder-sdk-ios/commit/7867df3)), closes [ 333](https://github.com/rudderlabs/rudder-sdk-ios/issues/333)<br> * chore(deps): bump slackapi/slack-github-action from 1.23.0 to 1.24.0 ( 326) ([6cd98b3](https://github.com/rudderlabs/rudder-sdk-ios/commit/6cd98b3)), closes [ 326](https://github.com/rudderlabs/rudder-sdk-ios/issues/326)<br> * chore(release): 1.15.1 ([919fe9c](https://github.com/rudderlabs/rudder-sdk-ios/commit/919fe9c))<br> * feat: added support for gzip ( 325) ([2e1fba0](https://github.com/rudderlabs/rudder-sdk-ios/commit/2e1fba0)), closes [ 325](https://github.com/rudderlabs/rudder-sdk-ios/issues/325)   <small>1.15.1 (2023-05-12)</small><br> * fix: correct the width and height properties ( 302) ([98d5b55](https://github.com/rudderlabs/rudder-sdk-ios/commit/98d5b55)), closes [ 302](https://github.com/rudderlabs/rudder-sdk-ios/issues/302)<br> * fix: fixed insert sql statements to support sqlite versions less than 3.35.0 ( 318) ([4ed5cc2](https://github.com/rudderlabs/rudder-sdk-ios/commit/4ed5cc2)), closes [ 318](https://github.com/rudderlabs/rudder-sdk-ios/issues/318)<br> * fix: restricted nil assign of dataPlaneUrl and controlPlaneUrl ( 307) ([0e28b6f](https://github.com/rudderlabs/rudder-sdk-ios/commit/0e28b6f)), closes [ 307](https://github.com/rudderlabs/rudder-sdk-ios/issues/307)<br> * fix: semantic versioning issue ([c329286](https://github.com/rudderlabs/rudder-sdk-ios/commit/c329286))<br> * fix: swift package manager build issue ([320a600](https://github.com/rudderlabs/rudder-sdk-ios/commit/320a600))<br> * fix: swift package manager umbrella header warning ([041805c](https://github.com/rudderlabs/rudder-sdk-ios/commit/041805c))<br> * chore: fix duplicate tag creation ( 306) ([6c54ed7](https://github.com/rudderlabs/rudder-sdk-ios/commit/6c54ed7)), closes [ 306](https://github.com/rudderlabs/rudder-sdk-ios/issues/306)<br> * chore: fix duplicate tag creation ( 310) ([218d0d2](https://github.com/rudderlabs/rudder-sdk-ios/commit/218d0d2)), closes [ 310](https://github.com/rudderlabs/rudder-sdk-ios/issues/310)<br> * chore: fix publish release(v1 and v2), draft release(v2) and manually deploy(v1 and v2) ([2cb8d60](https://github.com/rudderlabs/rudder-sdk-ios/commit/2cb8d60))<br> * chore: removed xcode selected version, added ci for beta release ( 300) ([ebf62b5](https://github.com/rudderlabs/rudder-sdk-ios/commit/ebf62b5)), closes [ 300](https://github.com/rudderlabs/rudder-sdk-ios/issues/300)<br> * chore(release): 1.12.0 ([9ed17b6](https://github.com/rudderlabs/rudder-sdk-ios/commit/9ed17b6))<br> * chore(release): 1.12.1 ([0368d74](https://github.com/rudderlabs/rudder-sdk-ios/commit/0368d74))<br> * chore(release): 1.13.0 ([e9e0c00](https://github.com/rudderlabs/rudder-sdk-ios/commit/e9e0c00))<br> * chore(release): 1.13.1 ([2e25f4f](https://github.com/rudderlabs/rudder-sdk-ios/commit/2e25f4f))<br> * chore(release): 1.13.2 ([b9fc341](https://github.com/rudderlabs/rudder-sdk-ios/commit/b9fc341))<br> * chore(release): 1.14.0 ([43a9c0a](https://github.com/rudderlabs/rudder-sdk-ios/commit/43a9c0a))<br> * chore(release): 1.15.0 ([dad2014](https://github.com/rudderlabs/rudder-sdk-ios/commit/dad2014))<br> * feat: added support for device mode transformations ( 160) ([9f145eb](https://github.com/rudderlabs/rudder-sdk-ios/commit/9f145eb)), closes [ 160](https://github.com/rudderlabs/rudder-sdk-ios/issues/160)<br> * feat: handled retrieving carrier names as per different iOS versions ([a81e3a2](https://github.com/rudderlabs/rudder-sdk-ios/commit/a81e3a2))<br> * feat: made reset and identify api's synchronous to reflect the data immediately ( 284) ([6047fc6](https://github.com/rudderlabs/rudder-sdk-ios/commit/6047fc6)), closes [ 284](https://github.com/rudderlabs/rudder-sdk-ios/issues/284)<br> * ci: added workflows for making a beta release ( 292) ([4838b49](https://github.com/rudderlabs/rudder-sdk-ios/commit/4838b49)), closes [ 292](https://github.com/rudderlabs/rudder-sdk-ios/issues/292)<br> * onetrust cloud mode ([eaa69c4](https://github.com/rudderlabs/rudder-sdk-ios/commit/eaa69c4))   <small>1.11.1 (2023-02-28)</small><br> * chore: add issue template for bug report ( 264) ([9b4cba4](https://github.com/rudderlabs/rudder-sdk-ios/commit/9b4cba4)), closes [ 264](https://github.com/rudderlabs/rudder-sdk-ios/issues/264)<br> * chore(release): 1.11.0 ([d938f54](https://github.com/rudderlabs/rudder-sdk-ios/commit/d938f54))<br> * chore(release): pulling release/1.11.1 into master ([168df4c](https://github.com/rudderlabs/rudder-sdk-ios/commit/168df4c))<br> * fix: handled corrupt data of database ([fd67568](https://github.com/rudderlabs/rudder-sdk-ios/commit/fd67568))<br> * feat: log error message for empty writeKey & dataPlaneUrl ([f7887d8](https://github.com/rudderlabs/rudder-sdk-ios/commit/f7887d8))   1.10.0 (2023-02-09)<br> * chore(release): 1.10.0 ([54f8521](https://github.com/rudderlabs/rudder-sdk-ios/commit/54f8521))<br> * feat: added consent support ([c39786c](https://github.com/rudderlabs/rudder-sdk-ios/commit/c39786c))   1.9.0 (2023-02-02)<br> * chore(release): 1.9.0 ([e2501b8](https://github.com/rudderlabs/rudder-sdk-ios/commit/e2501b8))<br> * feat: added Data Residency support ( 203) ([3b2b933](https://github.com/rudderlabs/rudder-sdk-ios/commit/3b2b933)), closes [ 203](https://github.com/rudderlabs/rudder-sdk-ios/issues/203)<br> * ci: bump peterjgrainger/action-create-branch from 2.3.0 to 2.4.0 ([3d580e0](https://github.com/rudderlabs/rudder-sdk-ios/commit/3d580e0))<br> * ci: fix manual deploy to Cocoapods ([fa2a8c8](https://github.com/rudderlabs/rudder-sdk-ios/commit/fa2a8c8))<br> * ci: update deploy-cocoapods-manual-v2.yml ([180c1b2](https://github.com/rudderlabs/rudder-sdk-ios/commit/180c1b2))<br> *  ci(v2): added support for deploy to Cocoapods manually  ([9fbc47d](https://github.com/rudderlabs/rudder-sdk-ios/commit/9fbc47d))<br> * Add files via upload ([f8a47a7](https://github.com/rudderlabs/rudder-sdk-ios/commit/f8a47a7))   1.8.0 (2022-12-08)<br> * chore(release): 1.8.0 ([0af048d](https://github.com/rudderlabs/rudder-sdk-ios/commit/0af048d))<br> * feat: remove timestamp from messageId ([a0f89fc](https://github.com/rudderlabs/rudder-sdk-ios/commit/a0f89fc))<br> * docs: added SECURITY.md ([30a657a](https://github.com/rudderlabs/rudder-sdk-ios/commit/30a657a))<br> * ci: bump peterjgrainger/action-create-branch from 2.2.0 to 2.3.0 ([b80345a](https://github.com/rudderlabs/rudder-sdk-ios/commit/b80345a))   <small>1.7.2 (2022-11-17)</small><br> * chore(release): 1.7.2 ([9ad7159](https://github.com/rudderlabs/rudder-sdk-ios/commit/9ad7159))<br> * fix: initialise `eventFiltering` object even when `destinations` is empty ([3a5c1c4](https://github.com/rudderlabs/rudder-sdk-ios/commit/3a5c1c4))<br> * ci: added CI/CD pipeline for v2 ([e3d3acb](https://github.com/rudderlabs/rudder-sdk-ios/commit/e3d3acb))<br> * ci: added Slack Notification ci ([7fa84d7](https://github.com/rudderlabs/rudder-sdk-ios/commit/7fa84d7))<br> * ci: added Test & Coverage CI ([6bbe4b9](https://github.com/rudderlabs/rudder-sdk-ios/commit/6bbe4b9))<br> * ci: fix publish-new-release.yml ([b9b182a](https://github.com/rudderlabs/rudder-sdk-ios/commit/b9b182a))   <small>1.7.1 (2022-11-04)</small><br> * chore(release): 1.7.1 ([7dc15b2](https://github.com/rudderlabs/rudder-sdk-ios/commit/7dc15b2))<br> * fix: session is generating on reset api even when session is disabled ([7585f3a](https://github.com/rudderlabs/rudder-sdk-ios/commit/7585f3a))<br> * ci: added CI/CD pipeline ([c9dd8c0](https://github.com/rudderlabs/rudder-sdk-ios/commit/c9dd8c0))<br> * [Bugfix] Added support for locale in the timestamp ( 125) ([97c8ba5](https://github.com/rudderlabs/rudder-sdk-ios/commit/97c8ba5)), closes [ 125](https://github.com/rudderlabs/rudder-sdk-ios/issues/125)<br> * [Bugfix] Fixed additional `/` issue in the URL for Data Plane and Control Plane ([69615f7](https://github.com/rudderlabs/rudder-sdk-ios/commit/69615f7))<br> * [BugFix] Made ATT Tracking Status Independent on AdvertisingId ([3d7e72c](https://github.com/rudderlabs/rudder-sdk-ios/commit/3d7e72c))<br> * [BugFix] Made ATT Tracking Status Independent on AdvertisingId ([6097b56](https://github.com/rudderlabs/rudder-sdk-ios/commit/6097b56))<br> * [Bugfix] Version & Build for `Application Installed` and `Application Updated` ([b4ee337](https://github.com/rudderlabs/rudder-sdk-ios/commit/b4ee337))<br> * [Enhancement] PR template added ([08f09bb](https://github.com/rudderlabs/rudder-sdk-ios/commit/08f09bb))<br> * [Feature] Added Support for Flush API ([1e50bd8](https://github.com/rudderlabs/rudder-sdk-ios/commit/1e50bd8))<br> * [Feature] Session tracking ([b3fe089](https://github.com/rudderlabs/rudder-sdk-ios/commit/b3fe089))<br> * [Improvement] Changed data type of session timeout from int to long ([dbbdda4](https://github.com/rudderlabs/rudder-sdk-ios/commit/dbbdda4))<br> * [Improvement] Correctly handled bluetooth, cellular, wifi values ([b4be654](https://github.com/rudderlabs/rudder-sdk-ios/commit/b4be654))<br> * Update pull_request_template.md ( 136) ([4399392](https://github.com/rudderlabs/rudder-sdk-ios/commit/4399392)), closes [ 136](https://github.com/rudderlabs/rudder-sdk-ios/issues/136)   <small>1.5.2 (2022-02-16)</small><br> * [Bugfix] All warnings has been removed ([faceb9c](https://github.com/rudderlabs/rudder-sdk-ios/commit/faceb9c))<br> * [Bugfix] Fixed building issue via Carthage for watchOS, tvOS ([ef5212e](https://github.com/rudderlabs/rudder-sdk-ios/commit/ef5212e))<br> * [Enhancement] Removed background mode support for watchOS ([80bd3b5](https://github.com/rudderlabs/rudder-sdk-ios/commit/80bd3b5))<br> * [Enhancement] Weak reference for threads ([6ca52c0](https://github.com/rudderlabs/rudder-sdk-ios/commit/6ca52c0))<br> * [Feature] Added support for sending events from background for watchOS ([e706544](https://github.com/rudderlabs/rudder-sdk-ios/commit/e706544))<br> * [Feature] Added support for sending events from background for watchOS ([b59a6b7](https://github.com/rudderlabs/rudder-sdk-ios/commit/b59a6b7))<br> * [Feature] Added support for sending vents from background mode ([6b75b28](https://github.com/rudderlabs/rudder-sdk-ios/commit/6b75b28))<br> * [Feature] Added support for watchOS ([b129711](https://github.com/rudderlabs/rudder-sdk-ios/commit/b129711))<br> * [Feature] Event filtering ([c2e8e86](https://github.com/rudderlabs/rudder-sdk-ios/commit/c2e8e86))<br> * [Release] Version 1.5.2 ([d875bb1](https://github.com/rudderlabs/rudder-sdk-ios/commit/d875bb1)), closes [ 123](https://github.com/rudderlabs/rudder-sdk-ios/issues/123)<br> * Added CODEOWNERS ([b91e527](https://github.com/rudderlabs/rudder-sdk-ios/commit/b91e527))<br> * Bumped version to 1.0.25 ([de7c91a](https://github.com/rudderlabs/rudder-sdk-ios/commit/de7c91a))<br> * Bumped version to 1.3.1 ([0555475](https://github.com/rudderlabs/rudder-sdk-ios/commit/0555475))<br> * Bumped version to 1.4.2 ([a2c9058](https://github.com/rudderlabs/rudder-sdk-ios/commit/a2c9058))<br> * Fix for crash regrading Allbirds ([41fc16e](https://github.com/rudderlabs/rudder-sdk-ios/commit/41fc16e))<br> * Improved GDPR handling and removed redundant getOptStatus() call from EventRepository ([936e0c1](https://github.com/rudderlabs/rudder-sdk-ios/commit/936e0c1))<br> * Removed optStatus check from saveBuildVersionCode() ([725cc62](https://github.com/rudderlabs/rudder-sdk-ios/commit/725cc62))<br> * Removed unnecessary opt check for Application Foregrounded ([027d974](https://github.com/rudderlabs/rudder-sdk-ios/commit/027d974))<br> * Using Weakself in initiateSDK ([c640c48](https://github.com/rudderlabs/rudder-sdk-ios/commit/c640c48))   <small>1.2.2 (2021-12-13)</small><br> * [Release] Version 1.2.2 ([1a814da](https://github.com/rudderlabs/rudder-sdk-ios/commit/1a814da))   <small>1.2.1 (2021-11-25)</small><br> * [Bugix] Method 'setAnonymousId' marked as deprecated method ([cca3fe4](https://github.com/rudderlabs/rudder-sdk-ios/commit/cca3fe4))   1.2.0 (2021-11-24)<br> * [Feature] Added Support for Setting Device Token before & after SDK Initialisation ([4c545f0](https://github.com/rudderlabs/rudder-sdk-ios/commit/4c545f0))   <small>1.1.5 (2021-11-18)</small><br> * [Bugfix] Timestamp issue ([a7d0e27](https://github.com/rudderlabs/rudder-sdk-ios/commit/a7d0e27))<br> * Create CONTRIBUTING.md ([0b65149](https://github.com/rudderlabs/rudder-sdk-ios/commit/0b65149))<br> * Update CONTRIBUTING.md ([c734133](https://github.com/rudderlabs/rudder-sdk-ios/commit/c734133))<br> * Update README.md ([1645c1b](https://github.com/rudderlabs/rudder-sdk-ios/commit/1645c1b))<br> * Update README.md ([52e7130](https://github.com/rudderlabs/rudder-sdk-ios/commit/52e7130))<br> * Update README.md ([e314ef6](https://github.com/rudderlabs/rudder-sdk-ios/commit/e314ef6))<br> * Update README.md ([9e03e92](https://github.com/rudderlabs/rudder-sdk-ios/commit/9e03e92))<br> * Update README.md ([811ca36](https://github.com/rudderlabs/rudder-sdk-ios/commit/811ca36))   <small>1.1.4 (2021-11-08)</small><br> * [Enhancement] Removed user agent ([598dcfa](https://github.com/rudderlabs/rudder-sdk-ios/commit/598dcfa))<br> * [Releaase] Version 1.1.4 ([3109288](https://github.com/rudderlabs/rudder-sdk-ios/commit/3109288))   <small>1.1.3 (2021-11-05)</small><br> * [Releaase]Bumped version 1.1.3 ([df69bdf](https://github.com/rudderlabs/rudder-sdk-ios/commit/df69bdf))   <small>1.1.2 (2021-11-05)</small><br> * [Enhancement] Mutating trait object of identify call ([656998f](https://github.com/rudderlabs/rudder-sdk-ios/commit/656998f))<br> * [Release] Version 1.1.1 ([25e1f8a](https://github.com/rudderlabs/rudder-sdk-ios/commit/25e1f8a))   <small>1.1.1 (2021-11-02)</small><br> * [Bugfix] Swift Package Manager is not working ([6293e8c](https://github.com/rudderlabs/rudder-sdk-ios/commit/6293e8c))   1.1.0 (2021-10-28)<br> * [Release] Version 1.1.0 ([3cef4e2](https://github.com/rudderlabs/rudder-sdk-ios/commit/3cef4e2))<br> * Added a message support for optOut ([e971975](https://github.com/rudderlabs/rudder-sdk-ios/commit/e971975))<br> * Added Initial changes for GDPR Support ([d0c2702](https://github.com/rudderlabs/rudder-sdk-ios/commit/d0c2702))<br> * Added Missing files into Xcode Rudder Example Project ([9e170d1](https://github.com/rudderlabs/rudder-sdk-ios/commit/9e170d1))<br> * Added Support for Flush in iOS SDK ([3166a21](https://github.com/rudderlabs/rudder-sdk-ios/commit/3166a21))<br> * Bumped version to 1.0.21 ([b32c851](https://github.com/rudderlabs/rudder-sdk-ios/commit/b32c851))<br> * Bumped version to 1.0.23 ([fbae19c](https://github.com/rudderlabs/rudder-sdk-ios/commit/fbae19c))<br> * Bumped version to 1.0.24 ([2afba60](https://github.com/rudderlabs/rudder-sdk-ios/commit/2afba60))<br> * Changed SDK Version to 1.0.22 in Readme ([84bde73](https://github.com/rudderlabs/rudder-sdk-ios/commit/84bde73))<br> * CustomFactory class name improved ([9906c22](https://github.com/rudderlabs/rudder-sdk-ios/commit/9906c22))<br> * Defaulting Loglevel to RSLogLevelInfo ([9f809bb](https://github.com/rudderlabs/rudder-sdk-ios/commit/9f809bb))<br> * Fix for non-null issue ([b16c7ec](https://github.com/rudderlabs/rudder-sdk-ios/commit/b16c7ec))<br> * Fixed 500 errors being reported as WriteKey Errors ([756f0e7](https://github.com/rudderlabs/rudder-sdk-ios/commit/756f0e7))<br> * Fixed Crash for Identify calls from Background Thread ([b1bfc96](https://github.com/rudderlabs/rudder-sdk-ios/commit/b1bfc96))<br> * GDPR implementation ([d244bf4](https://github.com/rudderlabs/rudder-sdk-ios/commit/d244bf4))<br> * GDPR support for trackLifeCycleEvent ([260e046](https://github.com/rudderlabs/rudder-sdk-ios/commit/260e046))<br> * Implemented custom Factories. Changed: Config, ConfigBuilder and EventRepository. Created CustomFact ([b01e260](https://github.com/rudderlabs/rudder-sdk-ios/commit/b01e260))<br> * iOS-sdk version changed to 1.0.22 ([03371ec](https://github.com/rudderlabs/rudder-sdk-ios/commit/03371ec))<br> * Modified version to 1.0.21-beta.1 ([b77b168](https://github.com/rudderlabs/rudder-sdk-ios/commit/b77b168))<br> * Optimised replayMessageQueue() by removing unnecessary variable ([a104753](https://github.com/rudderlabs/rudder-sdk-ios/commit/a104753))<br> * Removed ERROR500 and handling it in NetworkError ([24e4fc0](https://github.com/rudderlabs/rudder-sdk-ios/commit/24e4fc0))<br> * Removed unnecessary if{} checking ([3411727](https://github.com/rudderlabs/rudder-sdk-ios/commit/3411727))<br> * Reverted changes in Example/AppDelegate.m ([4b1baf0](https://github.com/rudderlabs/rudder-sdk-ios/commit/4b1baf0))<br> * Update README.md ([3471a21](https://github.com/rudderlabs/rudder-sdk-ios/commit/3471a21))<br> * Update README.md ([d4edaa1](https://github.com/rudderlabs/rudder-sdk-ios/commit/d4edaa1))   <small>1.0.21 (2021-07-28)</small><br> * Added macos to supported platforms ([393c4e9](https://github.com/rudderlabs/rudder-sdk-ios/commit/393c4e9))<br> * ATTrackingStatus implementation ([3f456da](https://github.com/rudderlabs/rudder-sdk-ios/commit/3f456da))<br> * Bumped version ([13d05af](https://github.com/rudderlabs/rudder-sdk-ios/commit/13d05af))<br> * Bumped version ([ce0302a](https://github.com/rudderlabs/rudder-sdk-ios/commit/ce0302a))<br> * Bumped Version to 1.0.19 ([880e909](https://github.com/rudderlabs/rudder-sdk-ios/commit/880e909))<br> * Bumped Version to 1.0.20 ([a49ea21](https://github.com/rudderlabs/rudder-sdk-ios/commit/a49ea21))<br> * Bumped version to 1.0.21-beta.1 and added tag ([6c107e4](https://github.com/rudderlabs/rudder-sdk-ios/commit/6c107e4))<br> * Cleaned up files ([7921fec](https://github.com/rudderlabs/rudder-sdk-ios/commit/7921fec))<br> * Finalized Event Replay Message Queue Initialization ([4a55553](https://github.com/rudderlabs/rudder-sdk-ios/commit/4a55553))<br> * Fixed Swift package manager paths ([03ac06a](https://github.com/rudderlabs/rudder-sdk-ios/commit/03ac06a))<br> * Moved Initialization of EventReplayMessageQueue to Constructor of EventRepository ([1b90696](https://github.com/rudderlabs/rudder-sdk-ios/commit/1b90696))<br> * Provided Support for supplying Custom Context at Event Level through RSOptions ([b0bcfe3](https://github.com/rudderlabs/rudder-sdk-ios/commit/b0bcfe3))<br> * Reset Traits on Successive Identify calls with Different UserId's ([56951c9](https://github.com/rudderlabs/rudder-sdk-ios/commit/56951c9))<br> * Synchronized Adding Messages to EventReplayMessage Queue ([e6209cf](https://github.com/rudderlabs/rudder-sdk-ios/commit/e6209cf))<br> * Updated README ([f85889e](https://github.com/rudderlabs/rudder-sdk-ios/commit/f85889e))<br> * Updated supported version to 9.0 and platform to iOS ([5fb5c1a](https://github.com/rudderlabs/rudder-sdk-ios/commit/5fb5c1a))   <small>1.0.16 (2021-06-03)</small><br> * Bumped version ([e930922](https://github.com/rudderlabs/rudder-sdk-ios/commit/e930922))<br> * Bumped version to 1.0.15 ([c6bda6c](https://github.com/rudderlabs/rudder-sdk-ios/commit/c6bda6c))<br> * Fixed Control Plane Urls having '/' as path ([022e5b4](https://github.com/rudderlabs/rudder-sdk-ios/commit/022e5b4))<br> * Minor changes ([a95442f](https://github.com/rudderlabs/rudder-sdk-ios/commit/a95442f))<br> * Updated headers as public ([5c174a1](https://github.com/rudderlabs/rudder-sdk-ios/commit/5c174a1))   <small>1.0.14 (2021-05-11)</small><br> * added backoffer logic for 500 error from server ([26f80fd](https://github.com/rudderlabs/rudder-sdk-ios/commit/26f80fd))<br> * Added RudderOption Support for Device Mode Integrations ([709d791](https://github.com/rudderlabs/rudder-sdk-ios/commit/709d791))<br> * Added Support for RudderOption to enable or disable integrations while initializing sdk as well as i ([b6806df](https://github.com/rudderlabs/rudder-sdk-ios/commit/b6806df))<br> * Bumped version ([b39cbc2](https://github.com/rudderlabs/rudder-sdk-ios/commit/b39cbc2))<br> * Changes in RSOption ([2cafc19](https://github.com/rudderlabs/rudder-sdk-ios/commit/2cafc19))<br> * Fixed Control Plane Url issue with Path ([9df3015](https://github.com/rudderlabs/rudder-sdk-ios/commit/9df3015))<br> * Fixes for userAgent being unknown ([28f04f1](https://github.com/rudderlabs/rudder-sdk-ios/commit/28f04f1))<br> * format ([c60e1a1](https://github.com/rudderlabs/rudder-sdk-ios/commit/c60e1a1))<br> * Integrations can be added with Factory objects now ([d5983bd](https://github.com/rudderlabs/rudder-sdk-ios/commit/d5983bd))<br> * Minor fixes ([4190d4a](https://github.com/rudderlabs/rudder-sdk-ios/commit/4190d4a))<br> * Removed redundant code ([1b4c821](https://github.com/rudderlabs/rudder-sdk-ios/commit/1b4c821))<br> * Setting All:YES in integrations object by default ([ac3e35f](https://github.com/rudderlabs/rudder-sdk-ios/commit/ac3e35f))   <small>1.0.12 (2021-04-22)</small><br> * Add modulemap ([4ad42e5](https://github.com/rudderlabs/rudder-sdk-ios/commit/4ad42e5))<br> * Add publicHeadersPath ([e202a30](https://github.com/rudderlabs/rudder-sdk-ios/commit/e202a30))<br> * Added support for setting anoymousId externally ([5227473](https://github.com/rudderlabs/rudder-sdk-ios/commit/5227473))<br> * Bumped version ([b2885ce](https://github.com/rudderlabs/rudder-sdk-ios/commit/b2885ce))<br> * Bumped version to 1.0.12 ([dc8c68f](https://github.com/rudderlabs/rudder-sdk-ios/commit/dc8c68f))<br> * Carthage support initial commit ([ab5eb9f](https://github.com/rudderlabs/rudder-sdk-ios/commit/ab5eb9f))<br> * Create LICENSE ([394efbb](https://github.com/rudderlabs/rudder-sdk-ios/commit/394efbb))<br> * Delete LICENSE ([bed49ad](https://github.com/rudderlabs/rudder-sdk-ios/commit/bed49ad))<br> * fetch config from backend on each app open ([ba9a44a](https://github.com/rudderlabs/rudder-sdk-ios/commit/ba9a44a))<br> * Fixes for pod upload and README updates ([8c16d7a](https://github.com/rudderlabs/rudder-sdk-ios/commit/8c16d7a))<br> * increase initiateSDK retry interval ([e53756a](https://github.com/rudderlabs/rudder-sdk-ios/commit/e53756a))<br> * Match segment package.swift ([af90194](https://github.com/rudderlabs/rudder-sdk-ios/commit/af90194))<br> * Move file ([159c9c2](https://github.com/rudderlabs/rudder-sdk-ios/commit/159c9c2))<br> * Remove module map ([9bf0d92](https://github.com/rudderlabs/rudder-sdk-ios/commit/9bf0d92))<br> * removed bug for reset calls ([b29e3cc](https://github.com/rudderlabs/rudder-sdk-ios/commit/b29e3cc))<br> * Set dynamic type ([60ecace](https://github.com/rudderlabs/rudder-sdk-ios/commit/60ecace))<br> * Support Swift Package Manager ([29eb701](https://github.com/rudderlabs/rudder-sdk-ios/commit/29eb701))<br> * Try different syntax ([3149ed6](https://github.com/rudderlabs/rudder-sdk-ios/commit/3149ed6))<br> * Update README.md ([ab5facf](https://github.com/rudderlabs/rudder-sdk-ios/commit/ab5facf))<br> * Update README.md ([3618548](https://github.com/rudderlabs/rudder-sdk-ios/commit/3618548))<br> * Update README.md ([092bc35](https://github.com/rudderlabs/rudder-sdk-ios/commit/092bc35))<br> * Update README.md ([5134b37](https://github.com/rudderlabs/rudder-sdk-ios/commit/5134b37))<br> * Use shortest path ([4645c43](https://github.com/rudderlabs/rudder-sdk-ios/commit/4645c43))   <small>1.0.9 (2020-10-20)</small><br> * Bumped version ([c95d879](https://github.com/rudderlabs/rudder-sdk-ios/commit/c95d879))<br> * Bumped version ([faf20b9](https://github.com/rudderlabs/rudder-sdk-ios/commit/faf20b9))<br> * Bumped version ([5ff1951](https://github.com/rudderlabs/rudder-sdk-ios/commit/5ff1951))<br> * Bumped version 1.0.5 ([0f65f98](https://github.com/rudderlabs/rudder-sdk-ios/commit/0f65f98))<br> * Extrernal Id implementation in identify call ([cd4be95](https://github.com/rudderlabs/rudder-sdk-ios/commit/cd4be95))<br> * Fixed crash for alias call ([3810d56](https://github.com/rudderlabs/rudder-sdk-ios/commit/3810d56))<br> * Fixes for anomaly in screen call ([2da9c36](https://github.com/rudderlabs/rudder-sdk-ios/commit/2da9c36))<br> * Fixes for device-mode event replay queue ([a04de11](https://github.com/rudderlabs/rudder-sdk-ios/commit/a04de11))<br> * Handled case sensitive device.type ([a1ff030](https://github.com/rudderlabs/rudder-sdk-ios/commit/a1ff030))<br> * Removed redundant code ([3f62857](https://github.com/rudderlabs/rudder-sdk-ios/commit/3f62857))<br> * Updated log from error to debug ([09d5e74](https://github.com/rudderlabs/rudder-sdk-ios/commit/09d5e74))<br> * RN: add support for tracking lifecycle events ([685b1b0](https://github.com/rudderlabs/rudder-sdk-ios/commit/685b1b0))   <small>1.0.4 (2020-08-23)</small><br> * Addded userdata to gitignore ([60dc6ff](https://github.com/rudderlabs/rudder-sdk-ios/commit/60dc6ff))<br> * Added Advertisement ID support for iOS ([7afcefc](https://github.com/rudderlabs/rudder-sdk-ios/commit/7afcefc))<br> * added handling for single quotes in properties ([04f6f7c](https://github.com/rudderlabs/rudder-sdk-ios/commit/04f6f7c))<br> * added logic for backoff when dataplane wrong ([a9e52d5](https://github.com/rudderlabs/rudder-sdk-ios/commit/a9e52d5))<br> * addressed issue related to dataplaneurl in ios ([59763cb](https://github.com/rudderlabs/rudder-sdk-ios/commit/59763cb))<br> * backoff logic for write key ([18f1976](https://github.com/rudderlabs/rudder-sdk-ios/commit/18f1976))<br> * Bumped version to 1.0.4 ([373052f](https://github.com/rudderlabs/rudder-sdk-ios/commit/373052f))<br> * Bumped version to v1.0.3-patch.1 ([e8a482b](https://github.com/rudderlabs/rudder-sdk-ios/commit/e8a482b))<br> * Bumped version to v1.0.3-patch.4 ([b183a9d](https://github.com/rudderlabs/rudder-sdk-ios/commit/b183a9d))<br> * Bumpeed version to 1.0.3-patch.2 ([3a68fc2](https://github.com/rudderlabs/rudder-sdk-ios/commit/3a68fc2))<br> * Bumpeed version to 1.0.3-patch.3 ([08d80ce](https://github.com/rudderlabs/rudder-sdk-ios/commit/08d80ce))<br> * checked for condition if port not present ([55cb09b](https://github.com/rudderlabs/rudder-sdk-ios/commit/55cb09b))<br> * Fixes for app.version and app.build ([a135330](https://github.com/rudderlabs/rudder-sdk-ios/commit/a135330))<br> * Minor formatting fixes ([ccfc9cd](https://github.com/rudderlabs/rudder-sdk-ios/commit/ccfc9cd))<br> * Removed unnecessary files ([e1b3174](https://github.com/rudderlabs/rudder-sdk-ios/commit/e1b3174))<br> * Removed whitespace changes ([9a41c50](https://github.com/rudderlabs/rudder-sdk-ios/commit/9a41c50))<br> * Updated backoff logic for data plane ([7c6e006](https://github.com/rudderlabs/rudder-sdk-ios/commit/7c6e006))<br> * Updated commit hash in podspec ([3f2f3bd](https://github.com/rudderlabs/rudder-sdk-ios/commit/3f2f3bd))<br> * Updated commit hash in podspec ([46f8f96](https://github.com/rudderlabs/rudder-sdk-ios/commit/46f8f96))<br> * Updated commit hash in podspec ([3cb6dfe](https://github.com/rudderlabs/rudder-sdk-ios/commit/3cb6dfe))<br> * Updated commit hash in podspec ([21f17a7](https://github.com/rudderlabs/rudder-sdk-ios/commit/21f17a7))<br> * Updated commit hash in podspec ([cc6252b](https://github.com/rudderlabs/rudder-sdk-ios/commit/cc6252b))   <small>1.0.3 (2020-05-13)</small><br> * added alias ([c2831cd](https://github.com/rudderlabs/rudder-sdk-ios/commit/c2831cd))<br> * Added ExampleSwift and fix for NSDictionary ([bedd4d0](https://github.com/rudderlabs/rudder-sdk-ios/commit/bedd4d0))<br> * added group ([6a59537](https://github.com/rudderlabs/rudder-sdk-ios/commit/6a59537))<br> * Added project file ([083749d](https://github.com/rudderlabs/rudder-sdk-ios/commit/083749d))<br> * Added support for turning off the source from dashboard ([5f5c17d](https://github.com/rudderlabs/rudder-sdk-ios/commit/5f5c17d))<br> * Changed userAgent from local string to unknown ([7d36baf](https://github.com/rudderlabs/rudder-sdk-ios/commit/7d36baf))<br> * changes for alias ([eb44395](https://github.com/rudderlabs/rudder-sdk-ios/commit/eb44395))<br> * event and batch size enforcement ([0edbfac](https://github.com/rudderlabs/rudder-sdk-ios/commit/0edbfac))<br> * Exposed RudderContext from RudderClient to be used in integration ([bd79bc0](https://github.com/rudderlabs/rudder-sdk-ios/commit/bd79bc0))<br> * Fix for urlOptionsLaunch crash ([867956a](https://github.com/rudderlabs/rudder-sdk-ios/commit/867956a))<br> * Fix for userAgent using WKWebView ([8fca7fb](https://github.com/rudderlabs/rudder-sdk-ios/commit/8fca7fb))<br> * Fixed dataPlaneUrl and controlPlaneUrl ([3eb8652](https://github.com/rudderlabs/rudder-sdk-ios/commit/3eb8652))<br> * Fixed logLevel in RudderConfig ([d0eccba](https://github.com/rudderlabs/rudder-sdk-ios/commit/d0eccba))<br> * Fixed properties for automatic screenview events ([f973cf2](https://github.com/rudderlabs/rudder-sdk-ios/commit/f973cf2))<br> * Fixed race in RSServerConfigManager ([bcd1224](https://github.com/rudderlabs/rudder-sdk-ios/commit/bcd1224))<br> * Fixed the blank event type for Application Lifecycle Events ([e1845e9](https://github.com/rudderlabs/rudder-sdk-ios/commit/e1845e9))<br> * Fixed the blank event type for Application Lifecycle Events ([b6132df](https://github.com/rudderlabs/rudder-sdk-ios/commit/b6132df))<br> * Improvement in the logging ([af5867a](https://github.com/rudderlabs/rudder-sdk-ios/commit/af5867a))<br> * minor changes ([87e31fe](https://github.com/rudderlabs/rudder-sdk-ios/commit/87e31fe))<br> * Nil support and idetify traits support ([64792ec](https://github.com/rudderlabs/rudder-sdk-ios/commit/64792ec))<br> * refactored code ([01e2ce6](https://github.com/rudderlabs/rudder-sdk-ios/commit/01e2ce6))<br> * Release V1.0 ( 11) ([656ea86](https://github.com/rudderlabs/rudder-sdk-ios/commit/656ea86)), closes [ 11](https://github.com/rudderlabs/rudder-sdk-ios/issues/11) [ 6](https://github.com/rudderlabs/rudder-sdk-ios/issues/6) [ 7](https://github.com/rudderlabs/rudder-sdk-ios/issues/7) [ 9](https://github.com/rudderlabs/rudder-sdk-ios/issues/9) [ 10](https://github.com/rudderlabs/rudder-sdk-ios/issues/10) [ 12](https://github.com/rudderlabs/rudder-sdk-ios/issues/12)<br> * Removed debug log ([284b0eb](https://github.com/rudderlabs/rudder-sdk-ios/commit/284b0eb))<br> * Reverted changes in _AppDelegate.m ([40d29ba](https://github.com/rudderlabs/rudder-sdk-ios/commit/40d29ba))<br> * Reverted changes in _AppDelegate.m ([9384004](https://github.com/rudderlabs/rudder-sdk-ios/commit/9384004))<br> * Reverted changes in _AppDelegate.m ([8c5c2b3](https://github.com/rudderlabs/rudder-sdk-ios/commit/8c5c2b3))<br> * Standard naming for endPointUrl and configPlaneUrl ( 16) ([9704fc4](https://github.com/rudderlabs/rudder-sdk-ios/commit/9704fc4)), closes [ 16](https://github.com/rudderlabs/rudder-sdk-ios/issues/16)<br> * Update README.md ([387b266](https://github.com/rudderlabs/rudder-sdk-ios/commit/387b266))<br> * Update README.md ([930062e](https://github.com/rudderlabs/rudder-sdk-ios/commit/930062e))<br> * Update README.md ([c517bce](https://github.com/rudderlabs/rudder-sdk-ios/commit/c517bce))<br> * Updated Change Log ([29006e6](https://github.com/rudderlabs/rudder-sdk-ios/commit/29006e6))<br> * Updated commit hash to podspec ([9e877f0](https://github.com/rudderlabs/rudder-sdk-ios/commit/9e877f0))<br> * Updated commit hash to podspec ([fe760dd](https://github.com/rudderlabs/rudder-sdk-ios/commit/fe760dd))<br> * Updated commit hash to podspec ([c037fe2](https://github.com/rudderlabs/rudder-sdk-ios/commit/c037fe2))<br> * Updated commit hash to podspec ([8b21357](https://github.com/rudderlabs/rudder-sdk-ios/commit/8b21357))<br> * Updated commit hash to podspec ([3798d62](https://github.com/rudderlabs/rudder-sdk-ios/commit/3798d62))<br> * Updated commit hash to podspec ([ab33f64](https://github.com/rudderlabs/rudder-sdk-ios/commit/ab33f64))<br> * Updated commit hash to podspec ([71cd373](https://github.com/rudderlabs/rudder-sdk-ios/commit/71cd373))<br> * Updated disabled logic ([596df74](https://github.com/rudderlabs/rudder-sdk-ios/commit/596df74))<br> * Updated file names prefixed with RS ([ead8d1c](https://github.com/rudderlabs/rudder-sdk-ios/commit/ead8d1c))<br> * Updated library version ([fd189ba](https://github.com/rudderlabs/rudder-sdk-ios/commit/fd189ba))<br> * Updated library versions ([b7abfb3](https://github.com/rudderlabs/rudder-sdk-ios/commit/b7abfb3))<br> * Updated library versions ([c1fd663](https://github.com/rudderlabs/rudder-sdk-ios/commit/c1fd663))<br> * Updated library with RS prefixes ([1876f36](https://github.com/rudderlabs/rudder-sdk-ios/commit/1876f36))<br> * Updated Namespace in core library ([9061bad](https://github.com/rudderlabs/rudder-sdk-ios/commit/9061bad))<br> * Updated Podspec commit ([d100a10](https://github.com/rudderlabs/rudder-sdk-ios/commit/d100a10))<br> * Updated Podspec commit ([0cf1223](https://github.com/rudderlabs/rudder-sdk-ios/commit/0cf1223))<br> * Updated Podspec to point to a commit ([b9a9c38](https://github.com/rudderlabs/rudder-sdk-ios/commit/b9a9c38))<br> * Updated podspec with commitid and readme ([5dd4dae](https://github.com/rudderlabs/rudder-sdk-ios/commit/5dd4dae))<br> * Updated podspec with commitid for v1.0-patch.1 ([b894db4](https://github.com/rudderlabs/rudder-sdk-ios/commit/b894db4))<br> * Updated podspec with tag ([2ec2b3b](https://github.com/rudderlabs/rudder-sdk-ios/commit/2ec2b3b))<br> * Updated README ([cd26edb](https://github.com/rudderlabs/rudder-sdk-ios/commit/cd26edb))<br> * Updated README ([9807e62](https://github.com/rudderlabs/rudder-sdk-ios/commit/9807e62))<br> * Updated README ([40224f0](https://github.com/rudderlabs/rudder-sdk-ios/commit/40224f0))<br> * Updated README ([74151e5](https://github.com/rudderlabs/rudder-sdk-ios/commit/74151e5))<br> * Updated README ([2e2945b](https://github.com/rudderlabs/rudder-sdk-ios/commit/2e2945b))<br> * Updated RSConfigmanger for better redability ([4d6e162](https://github.com/rudderlabs/rudder-sdk-ios/commit/4d6e162))<br> * Updated version in RudderLibrary ([bb8ac1c](https://github.com/rudderlabs/rudder-sdk-ios/commit/bb8ac1c))<br> * Updated with putDeviceToken method for deviceToken support ([0693cc4](https://github.com/rudderlabs/rudder-sdk-ios/commit/0693cc4))   <small>0.1.6 (2019-12-12)</small><br> * debug log removed and support for dictionary in identify ([46b6d48](https://github.com/rudderlabs/rudder-sdk-ios/commit/46b6d48))<br> * fixed warning for pod lint ([f230ce2](https://github.com/rudderlabs/rudder-sdk-ios/commit/f230ce2))<br> * release of v0.1.6 ([8993856](https://github.com/rudderlabs/rudder-sdk-ios/commit/8993856))<br> * released v0.1.4 ([ea0d6ef](https://github.com/rudderlabs/rudder-sdk-ios/commit/ea0d6ef))<br> * released v0.1.5 ([e6c0ffe](https://github.com/rudderlabs/rudder-sdk-ios/commit/e6c0ffe))<br> * Traits persistence accross sessions ( 5) ([2834553](https://github.com/rudderlabs/rudder-sdk-ios/commit/2834553)), closes [ 5](https://github.com/rudderlabs/rudder-sdk-ios/issues/5)<br> * Update README.md ([398917a](https://github.com/rudderlabs/rudder-sdk-ios/commit/398917a))<br> * Update README.md ([3ffe7d7](https://github.com/rudderlabs/rudder-sdk-ios/commit/3ffe7d7))   <small>0.1.3 (2019-11-11)</small><br> * minor update ([af548f5](https://github.com/rudderlabs/rudder-sdk-ios/commit/af548f5))<br> * native sdk integration support for ios ([4062bd3](https://github.com/rudderlabs/rudder-sdk-ios/commit/4062bd3))<br> * Objective c src code ( 1) ([52df29d](https://github.com/rudderlabs/rudder-sdk-ios/commit/52df29d)), closes [ 1](https://github.com/rudderlabs/rudder-sdk-ios/issues/1)<br> * server config persing logic modified ([4ceed96](https://github.com/rudderlabs/rudder-sdk-ios/commit/4ceed96))<br> * Update LICENSE ([56dcb16](https://github.com/rudderlabs/rudder-sdk-ios/commit/56dcb16))<br> * Update README.md ([cf57868](https://github.com/rudderlabs/rudder-sdk-ios/commit/cf57868))<br> * Update README.md ([9fc7e4c](https://github.com/rudderlabs/rudder-sdk-ios/commit/9fc7e4c))<br> * updated license ([21eaf1f](https://github.com/rudderlabs/rudder-sdk-ios/commit/21eaf1f))<br> * updated podspec ([dba6e04](https://github.com/rudderlabs/rudder-sdk-ios/commit/dba6e04))<br> * updated podspec and readme files ([3434b41](https://github.com/rudderlabs/rudder-sdk-ios/commit/3434b41))   0.1.0 (2019-10-16)<br> * added .gitignore ([9179487](https://github.com/rudderlabs/rudder-sdk-ios/commit/9179487))<br> * initial commit ([ae9640f](https://github.com/rudderlabs/rudder-sdk-ios/commit/ae9640f))<br> * removed old project ([6a008e6](https://github.com/rudderlabs/rudder-sdk-ios/commit/6a008e6))<br> * updated pod project ([c92dacc](https://github.com/rudderlabs/rudder-sdk-ios/commit/c92dacc))