### PR TITLE
chore: lock conventional-changelog-cli to 2.2.2 in draft-new-release CIs

### DIFF
--- a/.github/workflows/draft-new-release-v2.yml
+++ b/.github/workflows/draft-new-release-v2.yml
@@ -65,7 +65,7 @@ jobs:
         env:
           HUSKY: 0
         run: |
-          npm i -g conventional-changelog-cli
+          npm i -g conventional-changelog-cli@2.2.2
           SUMMARY=$(((npx conventional-changelog -u) 2>&1) | sed "s/*/<br> */g" | sed "s/#/ /g" | tr -d '\n' || true)
           echo $SUMMARY
           echo "Current version: $CURRENT_VERSION_VALUE"

--- a/.github/workflows/draft-new-release.yml
+++ b/.github/workflows/draft-new-release.yml
@@ -65,7 +65,7 @@ jobs:
         env:
           HUSKY: 0
         run: |
-          npm i -g conventional-changelog-cli
+          npm i -g conventional-changelog-cli@2.2.2
           SUMMARY=$(((npx conventional-changelog -u) 2>&1) | sed "s/*/<br> */g" | sed "s/#/ /g" | tr -d '\n' || true)
           echo $SUMMARY
           echo "Current version: $CURRENT_VERSION_VALUE"


### PR DESCRIPTION
# Description

Lock conventional-changelog-cli to 2.2.2 in draft-new-release CIs
