### PR TITLE
fix: event not getting removed from DB and certain processing issue

### DIFF
--- a/Podfile.lock
+++ b/Podfile.lock
@@ -77,9 +77,9 @@ PODS:
   - Rudder-Braze (1.2.0):
     - Appboy-iOS-SDK (~> 4.5.4)
     - Rudder (~> 1.12)
-  - SDWebImage (5.15.8):
-    - SDWebImage/Core (= 5.15.8)
-  - SDWebImage/Core (5.15.8)
+  - SDWebImage (5.16.0):
+    - SDWebImage/Core (= 5.16.0)
+  - SDWebImage/Core (5.16.0)
 
 DEPENDENCIES:
   - Amplitude (~> 7.2.0)
@@ -124,8 +124,8 @@ SPEC CHECKSUMS:
   Rudder: 41040d4537a178e4e32477b68400f98ca0c354eb
   Rudder-Amplitude: f845cc125a1a58d4de6155391a2b0392815ae898
   Rudder-Braze: e42eb914a03cb418ed8b7a3cd90b724a91476631
-  SDWebImage: cb032eba469c54e0000e78bcb0a13cdde0a52798
+  SDWebImage: 2aea163b50bfcb569a2726b6a754c54a4506fcf6
 
 PODFILE CHECKSUM: 42bfa6ba9271b8d9518a669daca1fd9a7bbf9f6e
 
-COCOAPODS: 1.12.1
+COCOAPODS: 1.11.3

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -70,7 +70,7 @@ PODS:
   - nanopb/decode (2.30909.0)
   - nanopb/encode (2.30909.0)
   - PromisesObjC (2.2.0)
-  - Rudder (1.15.1)
+  - Rudder (1.16.0)
   - Rudder-Amplitude (1.0.2):
     - Amplitude (~> 7.2.0)
     - Rudder
@@ -121,7 +121,7 @@ SPEC CHECKSUMS:
   GoogleUtilities: 9aa0ad5a7bc171f8bae016300bfcfa3fb8425749
   nanopb: b552cce312b6c8484180ef47159bc0f65a1f0431
   PromisesObjC: 09985d6d70fbe7878040aa746d78236e6946d2ef
-  Rudder: 41040d4537a178e4e32477b68400f98ca0c354eb
+  Rudder: 718bc5bf0de0e4d83850dedd792f08e5e2065a0a
   Rudder-Amplitude: f845cc125a1a58d4de6155391a2b0392815ae898
   Rudder-Braze: e42eb914a03cb418ed8b7a3cd90b724a91476631
   SDWebImage: 2aea163b50bfcb569a2726b6a754c54a4506fcf6

--- a/Sources/Classes/Headers/Public/RSApplicationLifeCycleManager.h
+++ b/Sources/Classes/Headers/Public/RSApplicationLifeCycleManager.h
@@ -9,6 +9,7 @@
 #import <Foundation/Foundation.h>
 #import "RSPreferenceManager.h"
 #import "RSBackGroundModeManager.h"
+#import "RSUtils.h"
 
 @interface RSApplicationLifeCycleManager : NSObject {
     RSPreferenceManager* preferenceManager;

--- a/Sources/Classes/Headers/Public/RSApplicationLifeCycleManager.h
+++ b/Sources/Classes/Headers/Public/RSApplicationLifeCycleManager.h
@@ -16,11 +16,13 @@
     RSUserSession* userSession;
     RSConfig* config;
     BOOL firstForeGround;
+    BOOL isApplicationUpdated;
 }
 
 - (instancetype)initWithConfig:(RSConfig*) config andPreferenceManager:(RSPreferenceManager*) preferenceManager andBackGroundModeManager:(RSBackGroundModeManager *) backGroundModeManager andUserSession:(RSUserSession *) userSession;
 - (void) applicationDidFinishLaunchingWithOptions:(NSDictionary *)launchOptions;
 - (void) trackApplicationLifeCycle;
 - (void) prepareScreenRecorder;
+- (BOOL) isApplicationUpdated;
 
 @end

--- a/Sources/Classes/Headers/Public/RSApplicationLifeCycleManager.h
+++ b/Sources/Classes/Headers/Public/RSApplicationLifeCycleManager.h
@@ -16,13 +16,11 @@
     RSUserSession* userSession;
     RSConfig* config;
     BOOL firstForeGround;
-    BOOL isApplicationUpdated;
 }
 
 - (instancetype)initWithConfig:(RSConfig*) config andPreferenceManager:(RSPreferenceManager*) preferenceManager andBackGroundModeManager:(RSBackGroundModeManager *) backGroundModeManager andUserSession:(RSUserSession *) userSession;
 - (void) applicationDidFinishLaunchingWithOptions:(NSDictionary *)launchOptions;
 - (void) trackApplicationLifeCycle;
 - (void) prepareScreenRecorder;
-- (BOOL) isApplicationUpdated;
 
 @end

--- a/Sources/Classes/Headers/Public/RSDBPersistentManager.h
+++ b/Sources/Classes/Headers/Public/RSDBPersistentManager.h
@@ -36,6 +36,8 @@ NS_ASSUME_NONNULL_BEGIN
 -(void) clearProcessedEventsFromDB;
 - (int) getDBRecordCountForMode:(MODES) mode;
 -(void) flushEventsFromDB;
+-(RSDBMessage *) fetchUnprocessedDeviceModeEventsFromDb;
+-(void) updateEventsStatusToDeviceModeProcessingDone:(long) timestamp;
 
 @end
 

--- a/Sources/Classes/Headers/Public/RSDBPersistentManager.h
+++ b/Sources/Classes/Headers/Public/RSDBPersistentManager.h
@@ -36,7 +36,7 @@ NS_ASSUME_NONNULL_BEGIN
 -(void) clearProcessedEventsFromDB;
 - (int) getDBRecordCountForMode:(MODES) mode;
 -(void) flushEventsFromDB;
--(void) markUnProcessedDeviceModeEventsStatusesAsDeviceModeProcessingDone;
+-(void) updateDeviceModeEventsStatus;
 
 @end
 

--- a/Sources/Classes/Headers/Public/RSDBPersistentManager.h
+++ b/Sources/Classes/Headers/Public/RSDBPersistentManager.h
@@ -36,8 +36,7 @@ NS_ASSUME_NONNULL_BEGIN
 -(void) clearProcessedEventsFromDB;
 - (int) getDBRecordCountForMode:(MODES) mode;
 -(void) flushEventsFromDB;
--(RSDBMessage *) fetchUnprocessedDeviceModeEventsFromDb;
--(void) updateEventsStatusToDeviceModeProcessingDone:(long) timestamp;
+-(void) markUnProcessedDeviceModeEventsStatusesAsDeviceModeProcessingDone;
 
 @end
 

--- a/Sources/Classes/Headers/Public/RSDeviceModeManager.h
+++ b/Sources/Classes/Headers/Public/RSDeviceModeManager.h
@@ -22,6 +22,7 @@
     NSMutableDictionary<NSString*, id<RSIntegration>>* integrationOperationMap;
     NSDictionary<NSString*, NSString*>* destinationsWithTransformationsEnabled;
     BOOL areFactoriesInitialized;
+    BOOL isDeviceModeFactoriesNotPresent;
 }
 
 - (instancetype) initWithConfig:(RSConfig *) config andDBPersistentManager:(RSDBPersistentManager *)dbPersistentManager andNetworkManager:(RSNetworkManager *)networkManager;
@@ -31,5 +32,6 @@
 - (void) dumpTransformedEvents:(NSArray*) transformedPayloads toDestinationId:(NSString*) destinationId;
 - (void) reset;
 - (void) flush;
+- (void) handleCaseWhenNoDeviceModeFactoryIsPresent;
 
 @end

--- a/Sources/Classes/Headers/Public/RSDeviceModeManager.h
+++ b/Sources/Classes/Headers/Public/RSDeviceModeManager.h
@@ -20,12 +20,14 @@
     RSEventFilteringPlugin *eventFilteringPlugin;
     RSConsentFilterHandler *consentFilterHandler;
     NSMutableDictionary<NSString*, id<RSIntegration>>* integrationOperationMap;
-    NSMutableDictionary<NSNumber*, RSMessage*> *eventReplayMessage;
     NSDictionary<NSString*, NSString*>* destinationsWithTransformationsEnabled;
     BOOL areFactoriesInitialized;
+    long beforeSDKInitEventTimestamp;
 }
 
 - (instancetype) initWithConfig:(RSConfig *) config andDBPersistentManager:(RSDBPersistentManager *)dbPersistentManager andNetworkManager:(RSNetworkManager *)networkManager;
+- (void) sendPreviousUnprocessedDeviceModeEvents;
+- (long) getFirstEventTimestampBeforeSDKInit;
 - (void) startDeviceModeProcessor:(NSArray<RSServerDestination*>*) destinations andDestinationsWithTransformationsEnabled: (NSDictionary<NSString*, NSString*>*) destinationsWithTransformationsEnabled;
 - (void) makeFactoryDump:(RSMessage *)message FromHistory:(BOOL) fromHistory withRowId:(NSNumber *) rowId;
 - (void) dumpOriginalEvents:(NSArray *) originalPayloads;

--- a/Sources/Classes/Headers/Public/RSDeviceModeManager.h
+++ b/Sources/Classes/Headers/Public/RSDeviceModeManager.h
@@ -22,12 +22,10 @@
     NSMutableDictionary<NSString*, id<RSIntegration>>* integrationOperationMap;
     NSDictionary<NSString*, NSString*>* destinationsWithTransformationsEnabled;
     BOOL areFactoriesInitialized;
-    long beforeSDKInitEventTimestamp;
 }
 
 - (instancetype) initWithConfig:(RSConfig *) config andDBPersistentManager:(RSDBPersistentManager *)dbPersistentManager andNetworkManager:(RSNetworkManager *)networkManager;
 - (void) sendPreviousUnprocessedDeviceModeEvents;
-- (long) getFirstEventTimestampBeforeSDKInit;
 - (void) startDeviceModeProcessor:(NSArray<RSServerDestination*>*) destinations andDestinationsWithTransformationsEnabled: (NSDictionary<NSString*, NSString*>*) destinationsWithTransformationsEnabled;
 - (void) makeFactoryDump:(RSMessage *)message FromHistory:(BOOL) fromHistory withRowId:(NSNumber *) rowId;
 - (void) dumpOriginalEvents:(NSArray *) originalPayloads;

--- a/Sources/Classes/Headers/Public/RSDeviceModeManager.h
+++ b/Sources/Classes/Headers/Public/RSDeviceModeManager.h
@@ -25,7 +25,6 @@
 }
 
 - (instancetype) initWithConfig:(RSConfig *) config andDBPersistentManager:(RSDBPersistentManager *)dbPersistentManager andNetworkManager:(RSNetworkManager *)networkManager;
-- (void) sendPreviousUnprocessedDeviceModeEvents;
 - (void) startDeviceModeProcessor:(NSArray<RSServerDestination*>*) destinations andDestinationsWithTransformationsEnabled: (NSDictionary<NSString*, NSString*>*) destinationsWithTransformationsEnabled;
 - (void) makeFactoryDump:(RSMessage *)message FromHistory:(BOOL) fromHistory withRowId:(NSNumber *) rowId;
 - (void) dumpOriginalEvents:(NSArray *) originalPayloads;

--- a/Sources/Classes/Headers/Public/RSEventRepository.h
+++ b/Sources/Classes/Headers/Public/RSEventRepository.h
@@ -56,7 +56,6 @@ NS_ASSUME_NONNULL_BEGIN
     dispatch_source_t source;
     dispatch_queue_t repositoryQueue;
     RSClient *client;
-    BOOL isDeviceModeFactoriesNotPresent;
 }
 
 + (instancetype)initiate:(NSString*)writeKey config:(RSConfig*)config client:(RSClient *)client;

--- a/Sources/Classes/Headers/Public/RSEventRepository.h
+++ b/Sources/Classes/Headers/Public/RSEventRepository.h
@@ -56,6 +56,7 @@ NS_ASSUME_NONNULL_BEGIN
     dispatch_source_t source;
     dispatch_queue_t repositoryQueue;
     RSClient *client;
+    BOOL isDeviceModeFactoriesNotPresent;
 }
 
 + (instancetype)initiate:(NSString*)writeKey config:(RSConfig*)config client:(RSClient *)client;

--- a/Sources/Classes/Headers/Public/RSPreferenceManager.h
+++ b/Sources/Classes/Headers/Public/RSPreferenceManager.h
@@ -79,11 +79,8 @@ extern NSString *const RSSessionAutoTrackStatus;
 - (void) saveAutoTrackingStatus: (BOOL) autoTrackingStatus;
 - (BOOL) getAutoTrackingStatus;
 
-- (void) saveEventDeletionCompletedStatus;
-- (BOOL) getEventDeletionCompletedStatus;
-
-- (void) saveBeforeSDKInitEventTimestamp:(long) beforeSDKInitEventTimestamp;
-- (long) getBeforeSDKInitEventTimestamp;
+- (void) saveEventDeletionStatus;
+- (BOOL) getEventDeletionStatus;
 
 @end
 

--- a/Sources/Classes/Headers/Public/RSPreferenceManager.h
+++ b/Sources/Classes/Headers/Public/RSPreferenceManager.h
@@ -79,6 +79,9 @@ extern NSString *const RSSessionAutoTrackStatus;
 - (void) saveAutoTrackingStatus: (BOOL) autoTrackingStatus;
 - (BOOL) getAutoTrackingStatus;
 
+- (void) saveEventDeletionCompletedStatus;
+- (BOOL) getEventDeletionCompletedStatus;
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/Sources/Classes/Headers/Public/RSPreferenceManager.h
+++ b/Sources/Classes/Headers/Public/RSPreferenceManager.h
@@ -82,6 +82,9 @@ extern NSString *const RSSessionAutoTrackStatus;
 - (void) saveEventDeletionCompletedStatus;
 - (BOOL) getEventDeletionCompletedStatus;
 
+- (void) saveBeforeSDKInitEventTimestamp:(long) beforeSDKInitEventTimestamp;
+- (long) getBeforeSDKInitEventTimestamp;
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/Sources/Classes/Headers/Public/RSUtils.h
+++ b/Sources/Classes/Headers/Public/RSUtils.h
@@ -34,6 +34,7 @@ NS_ASSUME_NONNULL_BEGIN
 + (BOOL) isValidURL:(NSURL*) url;
 + (NSString*) appendSlashToUrl:(NSString*) url;
 + (NSString* _Nullable) getBase64EncodedString:(NSString* __nonnull) inputString;
++ (NSNumber *) convertStringIntoNSNumber:(NSString* __nonnull) stringNumber;
 
 extern unsigned int MAX_EVENT_SIZE;
 extern unsigned int MAX_BATCH_SIZE;

--- a/Sources/Classes/Headers/Public/RSUtils.h
+++ b/Sources/Classes/Headers/Public/RSUtils.h
@@ -34,7 +34,6 @@ NS_ASSUME_NONNULL_BEGIN
 + (BOOL) isValidURL:(NSURL*) url;
 + (NSString*) appendSlashToUrl:(NSString*) url;
 + (NSString* _Nullable) getBase64EncodedString:(NSString* __nonnull) inputString;
-+ (NSNumber * _Nullable) convertStringIntoNSNumber:(NSString* __nonnull) stringNumber;
 + (BOOL) isApplicationUpdated;
 
 extern unsigned int MAX_EVENT_SIZE;

--- a/Sources/Classes/Headers/Public/RSUtils.h
+++ b/Sources/Classes/Headers/Public/RSUtils.h
@@ -35,6 +35,7 @@ NS_ASSUME_NONNULL_BEGIN
 + (NSString*) appendSlashToUrl:(NSString*) url;
 + (NSString* _Nullable) getBase64EncodedString:(NSString* __nonnull) inputString;
 + (NSNumber * _Nullable) convertStringIntoNSNumber:(NSString* __nonnull) stringNumber;
++ (BOOL) isApplicationUpdated;
 
 extern unsigned int MAX_EVENT_SIZE;
 extern unsigned int MAX_BATCH_SIZE;

--- a/Sources/Classes/Headers/Public/RSUtils.h
+++ b/Sources/Classes/Headers/Public/RSUtils.h
@@ -34,7 +34,7 @@ NS_ASSUME_NONNULL_BEGIN
 + (BOOL) isValidURL:(NSURL*) url;
 + (NSString*) appendSlashToUrl:(NSString*) url;
 + (NSString* _Nullable) getBase64EncodedString:(NSString* __nonnull) inputString;
-+ (NSNumber *) convertStringIntoNSNumber:(NSString* __nonnull) stringNumber;
++ (NSNumber * _Nullable) convertStringIntoNSNumber:(NSString* __nonnull) stringNumber;
 
 extern unsigned int MAX_EVENT_SIZE;
 extern unsigned int MAX_BATCH_SIZE;

--- a/Sources/Classes/RSApplicationLifeCycleManager.m
+++ b/Sources/Classes/RSApplicationLifeCycleManager.m
@@ -91,7 +91,7 @@
            }];
            [preferenceManager saveVersionNumber:currentVersion];
            [preferenceManager saveBuildNumber:currentBuildNumber];
-       } else if (![previousVersion isEqualToString:currentVersion]) {
+       } else if ([RSUtils isApplicationUpdated]) {
            [RSLogger logVerbose:@"RSApplicationLifeCycleManager: applicationDidFinishLaunchingWithOptions: Tracking Application Updated"];
            [[RSClient sharedInstance] track:@"Application Updated" properties:@{
                @"previous_version" : previousVersion ?: @"",

--- a/Sources/Classes/RSApplicationLifeCycleManager.m
+++ b/Sources/Classes/RSApplicationLifeCycleManager.m
@@ -21,8 +21,19 @@
         self->userSession = userSession;
         self->firstForeGround = YES;
         self->backGroundModeManager = backGroundModeManager;
+        
+        self->isApplicationUpdated = NO;
+        NSString *previousVersion = [preferenceManager getVersionNumber];
+        NSString *currentVersion = [[NSBundle mainBundle] infoDictionary][@"CFBundleShortVersionString"];
+        if (![previousVersion isEqualToString:currentVersion]) {
+            self->isApplicationUpdated = YES;
+        }
     }
     return self;
+}
+
+- (BOOL) isApplicationUpdated {
+    return self->isApplicationUpdated;
 }
 
 #if !TARGET_OS_WATCH

--- a/Sources/Classes/RSApplicationLifeCycleManager.m
+++ b/Sources/Classes/RSApplicationLifeCycleManager.m
@@ -25,7 +25,7 @@
         self->isApplicationUpdated = NO;
         NSString *previousVersion = [preferenceManager getVersionNumber];
         NSString *currentVersion = [[NSBundle mainBundle] infoDictionary][@"CFBundleShortVersionString"];
-        if (![previousVersion isEqualToString:currentVersion]) {
+        if (previousVersion && ![previousVersion isEqualToString:currentVersion]) {
             self->isApplicationUpdated = YES;
         }
     }

--- a/Sources/Classes/RSApplicationLifeCycleManager.m
+++ b/Sources/Classes/RSApplicationLifeCycleManager.m
@@ -23,7 +23,7 @@
         self->backGroundModeManager = backGroundModeManager;
         
         self->isApplicationUpdated = NO;
-        NSString *previousVersion = [preferenceManager getVersionNumber];
+        NSString *previousVersion = [self->preferenceManager getVersionNumber];
         NSString *currentVersion = [[NSBundle mainBundle] infoDictionary][@"CFBundleShortVersionString"];
         if (previousVersion && ![previousVersion isEqualToString:currentVersion]) {
             self->isApplicationUpdated = YES;

--- a/Sources/Classes/RSApplicationLifeCycleManager.m
+++ b/Sources/Classes/RSApplicationLifeCycleManager.m
@@ -21,19 +21,8 @@
         self->userSession = userSession;
         self->firstForeGround = YES;
         self->backGroundModeManager = backGroundModeManager;
-        
-        self->isApplicationUpdated = NO;
-        NSString *previousVersion = [self->preferenceManager getVersionNumber];
-        NSString *currentVersion = [[NSBundle mainBundle] infoDictionary][@"CFBundleShortVersionString"];
-        if (previousVersion && ![previousVersion isEqualToString:currentVersion]) {
-            self->isApplicationUpdated = YES;
-        }
     }
     return self;
-}
-
-- (BOOL) isApplicationUpdated {
-    return self->isApplicationUpdated;
 }
 
 #if !TARGET_OS_WATCH

--- a/Sources/Classes/RSDBPersistentManager.m
+++ b/Sources/Classes/RSDBPersistentManager.m
@@ -174,20 +174,15 @@ NSString* _Nonnull const COL_STATUS = @"status";
     }
 }
 
--(void) updateEventsStatusToDeviceModeProcessingDone:(long) timestamp {
-    NSString* updateEventStatusSQL = [[NSString alloc] initWithFormat:@"UPDATE %@ SET %@ = (%@ | %d) WHERE %@ IN (%d, %d) AND updated < %ld;", TABLE_EVENTS, COL_STATUS, COL_STATUS, DEVICE_MODE_PROCESSING_DONE, COL_STATUS, NOT_PROCESSED, CLOUD_MODE_PROCESSING_DONE, timestamp];
+-(void) markUnProcessedDeviceModeEventsStatusesAsDeviceModeProcessingDone {
+    NSString* updateEventStatusSQL = [[NSString alloc] initWithFormat:@"UPDATE %@ SET %@ = (%@ | %d) WHERE %@ IN (%d, %d);", TABLE_EVENTS, COL_STATUS, COL_STATUS, DEVICE_MODE_PROCESSING_DONE, COL_STATUS, NOT_PROCESSED, CLOUD_MODE_PROCESSING_DONE];
     @synchronized (self) {
         if([self execSQL:updateEventStatusSQL]) {
-            [RSLogger logDebug:[[NSString alloc] initWithFormat:@"RSDBPersistentManager: updateEventsStatusToDeviceModeProcessingDone: Successfully updated the event status for unprocessed and cloud mode processing done events to device mode processing done."]];
+            [RSLogger logDebug:[[NSString alloc] initWithFormat:@"RSDBPersistentManager: markUnProcessedDeviceModeEventsStatusesAsDeviceModeProcessingDone: Successfully updated the event status for unprocessed and cloud mode processing done events to device mode processing done."]];
             return;
         }
-        [RSLogger logError:[[NSString alloc] initWithFormat:@"RSDBPersistentManager: updateEventsStatusToDeviceModeProcessingDone: Failed to update the status for events."]];
+        [RSLogger logError:[[NSString alloc] initWithFormat:@"RSDBPersistentManager: markUnProcessedDeviceModeEventsStatusesAsDeviceModeProcessingDone: Failed to update the status for events."]];
     }
-}
-
--(RSDBMessage *) fetchUnprocessedDeviceModeEventsFromDb {
-    NSString* querySQLString = [[NSString alloc] initWithFormat:@"SELECT * FROM %@ WHERE %@ = %d OR %@ = %d ORDER BY %@ ASC;", TABLE_EVENTS, COL_STATUS, NOT_PROCESSED, COL_STATUS, CLOUD_MODE_PROCESSING_DONE, COL_UPDATED];
-    return [self getEventsFromDB:querySQLString];
 }
 
 -(RSDBMessage *)fetchEventsFromDB:(int)count ForMode:(MODES) mode {

--- a/Sources/Classes/RSDBPersistentManager.m
+++ b/Sources/Classes/RSDBPersistentManager.m
@@ -174,14 +174,14 @@ NSString* _Nonnull const COL_STATUS = @"status";
     }
 }
 
--(void) markUnProcessedDeviceModeEventsStatusesAsDeviceModeProcessingDone {
+-(void) updateDeviceModeEventsStatus {
     NSString* updateEventStatusSQL = [[NSString alloc] initWithFormat:@"UPDATE %@ SET %@ = (%@ | %d) WHERE %@ IN (%d, %d);", TABLE_EVENTS, COL_STATUS, COL_STATUS, DEVICE_MODE_PROCESSING_DONE, COL_STATUS, NOT_PROCESSED, CLOUD_MODE_PROCESSING_DONE];
     @synchronized (self) {
         if([self execSQL:updateEventStatusSQL]) {
-            [RSLogger logDebug:[[NSString alloc] initWithFormat:@"RSDBPersistentManager: markUnProcessedDeviceModeEventsStatusesAsDeviceModeProcessingDone: Successfully updated the event status for unprocessed and cloud mode processing done events to device mode processing done."]];
+            [RSLogger logDebug:[[NSString alloc] initWithFormat:@"RSDBPersistentManager: updateDeviceModeEventsStatus: Successfully updated the event status for unprocessed and cloud mode processing done events to device mode processing done."]];
             return;
         }
-        [RSLogger logError:[[NSString alloc] initWithFormat:@"RSDBPersistentManager: markUnProcessedDeviceModeEventsStatusesAsDeviceModeProcessingDone: Failed to update the status for events."]];
+        [RSLogger logError:[[NSString alloc] initWithFormat:@"RSDBPersistentManager: updateDeviceModeEventsStatuse: Failed to update the status for events."]];
     }
 }
 

--- a/Sources/Classes/RSDeviceModeManager.m
+++ b/Sources/Classes/RSDeviceModeManager.m
@@ -121,7 +121,7 @@
     NSArray *messages = dbMessage.messages;
     for (int i=0; i<messageIds.count; i++) {
         id object = [RSUtils deSerializeJSONString:messages[i]];
-        NSNumber *rowId = [NSNumber numberWithInt:[messages[i] intValue]];
+        NSNumber *rowId = [NSNumber numberWithInt:[messageIds[i] intValue]];
         if (object && rowId) {
             RSMessage* originalMessage = [[RSMessage alloc] initWithDict:object];
             [self makeFactoryDump:originalMessage FromHistory:YES withRowId:rowId];

--- a/Sources/Classes/RSDeviceModeManager.m
+++ b/Sources/Classes/RSDeviceModeManager.m
@@ -121,7 +121,7 @@
     NSArray *messages = dbMessage.messages;
     for (int i=0; i<messageIds.count; i++) {
         id object = [RSUtils deSerializeJSONString:messages[i]];
-        NSNumber *rowId = [RSUtils convertStringIntoNSNumber:messageIds[i]];
+        NSNumber *rowId = [NSNumber numberWithInt:[messages[i] intValue]];
         if (object && rowId) {
             RSMessage* originalMessage = [[RSMessage alloc] initWithDict:object];
             [self makeFactoryDump:originalMessage FromHistory:YES withRowId:rowId];

--- a/Sources/Classes/RSDeviceModeManager.m
+++ b/Sources/Classes/RSDeviceModeManager.m
@@ -25,11 +25,6 @@
     return self;
 }
 
-- (void) sendPreviousUnprocessedDeviceModeEvents {
-    self->areFactoriesInitialized = YES;
-    [self replayMessageQueue];
-}
-
 - (void) startDeviceModeProcessor:(NSArray<RSServerDestination*>*) destinations andDestinationsWithTransformationsEnabled: (NSDictionary<NSString*, NSString*>*) destinationsWithTransformationsEnabled {
     [RSLogger logDebug:@"RSDeviceModeManager: DeviceModeProcessor: Starting the Device Mode Processor"];
     self->destinationsWithTransformationsEnabled = destinationsWithTransformationsEnabled;

--- a/Sources/Classes/RSDeviceModeManager.m
+++ b/Sources/Classes/RSDeviceModeManager.m
@@ -56,10 +56,12 @@
 - (void) initiateFactories : (NSArray*) destinations {
     if (![self areFactoriesPassedInConfig]) {
         [RSLogger logInfo:@"RSDeviceModeManager: initiateFactories: No native SDK is found in the config"];
+        self->isDeviceModeFactoriesNotPresent = YES;
         return;
     }
     if (destinations.count == 0) {
         [RSLogger logInfo:@"RSDeviceModeManager: initiateFactories: No native SDK factory is found in the server config"];
+        self->isDeviceModeFactoriesNotPresent = YES;
         return;
     }
     RSClient* client = [RSClient sharedInstance];

--- a/Sources/Classes/RSDeviceModeManager.m
+++ b/Sources/Classes/RSDeviceModeManager.m
@@ -124,8 +124,11 @@
     NSArray *messages = dbMessage.messages;
     for (int i=0; i<messageIds.count; i++) {
         id object = [RSUtils deSerializeJSONString:messages[i]];
-        RSMessage* originalMessage = [[RSMessage alloc] initWithDict:object];
-        [self makeFactoryDump:originalMessage FromHistory:YES withRowId:[RSUtils convertStringIntoNSNumber:messageIds[i]]];
+        NSNumber *rowId = [RSUtils convertStringIntoNSNumber:messageIds[i]];
+        if (object && rowId) {
+            RSMessage* originalMessage = [[RSMessage alloc] initWithDict:object];
+            [self makeFactoryDump:originalMessage FromHistory:YES withRowId:rowId];
+        }
     }
 }
 

--- a/Sources/Classes/RSDeviceModeManager.m
+++ b/Sources/Classes/RSDeviceModeManager.m
@@ -48,6 +48,11 @@
     }
 }
 
+- (void) handleCaseWhenNoDeviceModeFactoryIsPresent {
+    self->isDeviceModeFactoriesNotPresent = YES;
+    [self replayMessageQueue];
+}
+
 - (void) initiateFactories : (NSArray*) destinations {
     if (![self areFactoriesPassedInConfig]) {
         [RSLogger logInfo:@"RSDeviceModeManager: initiateFactories: No native SDK is found in the config"];
@@ -123,7 +128,9 @@
 }
 
 - (void) makeFactoryDump:(RSMessage *)message FromHistory:(BOOL) fromHistory withRowId:(NSNumber *) rowId {
-    if (self->areFactoriesInitialized || fromHistory) {
+    if (self->isDeviceModeFactoriesNotPresent) {
+        [self->dbPersistentManager updateEventWithId:rowId withStatus:DEVICE_MODE_PROCESSING_DONE];
+    } else if (self->areFactoriesInitialized || fromHistory) {
         [RSLogger logVerbose:@"RSDeviceModeManager: makeFactoryDump: dumping message to native sdk factories"];
         NSArray<NSString *>* eligibleDestinations = [self getEligibleDestinations:message];
         

--- a/Sources/Classes/RSDeviceModeManager.m
+++ b/Sources/Classes/RSDeviceModeManager.m
@@ -21,7 +21,11 @@
         self->dbPersistentManager = dbPersistentManager;
         self->networkManager = networkManager;
         self->integrationOperationMap = [[NSMutableDictionary alloc] init];
-        self->beforeSDKInitEventTimestamp = 0;
+        self->beforeSDKInitEventTimestamp = [[RSPreferenceManager getInstance] getBeforeSDKInitEventTimestamp];
+        if (self->beforeSDKInitEventTimestamp == 0) {
+            self->beforeSDKInitEventTimestamp = [RSUtils getTimeStampLong];
+            [[RSPreferenceManager getInstance] saveBeforeSDKInitEventTimestamp:self->beforeSDKInitEventTimestamp];
+        }
     }
     return self;
 }
@@ -123,13 +127,9 @@
         RSMessage* originalMessage = [[RSMessage alloc] initWithDict:object];
         [self makeFactoryDump:originalMessage FromHistory:YES withRowId:[RSUtils convertStringIntoNSNumber:messageIds[i]]];
     }
-    NSLog(@"Abhishek: %@", dbMessage);
 }
 
 - (long) getFirstEventTimestampBeforeSDKInit {
-    if (self->beforeSDKInitEventTimestamp == 0) {
-        self->beforeSDKInitEventTimestamp = [RSUtils getTimeStampLong];
-    }
     return self->beforeSDKInitEventTimestamp;
 }
 
@@ -150,8 +150,6 @@
         
         NSArray<NSString *>* destinationsWithoutTransformations = [self getDestinationsWithTransformationStatus:DISABLED fromDestinations:eligibleDestinations];
         [self dumpEvent:message toDestinations:destinationsWithoutTransformations withLogTag:@"makeFactoryDump"];
-    } else if (self->beforeSDKInitEventTimestamp == 0) {
-        self->beforeSDKInitEventTimestamp = [RSUtils getTimeStampLong];
     }
 }
 

--- a/Sources/Classes/RSEventRepository.m
+++ b/Sources/Classes/RSEventRepository.m
@@ -95,6 +95,13 @@ static RSEventRepository* _instance;
         [RSLogger logDebug:@"EventRepository: Initiating RSDeviceModeManager"];
         self->deviceModeManager = [[RSDeviceModeManager alloc] initWithConfig:config andDBPersistentManager:self->dbpersistenceManager andNetworkManager:self->networkManager];
         
+        // Prviously in certain cases (e.g., network unavialability) events are not processed by device mode factories and statuses remains at either 0 or 2. Now we are marking those events as device_mode_processing_done.
+        [RSLogger logDebug:@"EventRepository: Checking if previous unprocessed event deletion is allowed or not. If allowed then mark previous events with status code 0 and 2 as device_mode_processing_done."];
+        if ([self isPreviousEventsDeletionAllowed]) {
+            [self->dbpersistenceManager markUnProcessedDeviceModeEventsStatusesAsDeviceModeProcessingDone];
+            [self->dbpersistenceManager clearProcessedEventsFromDB];
+        }
+        
         [RSLogger logDebug:@"EventRepository: Initiating the SDK"];
         [self __initiateSDK];
         
@@ -133,6 +140,14 @@ static RSEventRepository* _instance;
     return self;
 }
 
+- (BOOL) isPreviousEventsDeletionAllowed {
+    if (![preferenceManager getEventDeletionStatus]) {
+        [preferenceManager saveEventDeletionStatus];
+        return [RSUtils isApplicationUpdated];
+    }
+    return NO;
+}
+
 - (void) setAnonymousIdToken {
     NSData *anonymousIdData = [[[NSString alloc] initWithFormat:@"%@:", [RSElementCache getAnonymousId]] dataUsingEncoding:NSUTF8StringEncoding];
     dispatch_sync(repositoryQueue, ^{
@@ -168,12 +183,6 @@ static RSEventRepository* _instance;
                         strongSelf->consentFilterHandler = [RSConsentFilterHandler initiate:strongSelf->config.consentFilter withServerConfig:serverConfig];
                     }
                     
-                    // Check if SDK got updated from post DMT released version to >= 1.15.2, if it is then remove the previous unprocessed device mode events
-                    if ([self isUserHasUpdatedFromPostDMTReleaseVersion]) {
-                        [strongSelf->dbpersistenceManager updateEventsStatusToDeviceModeProcessingDone:[self->deviceModeManager getFirstEventTimestampBeforeSDKInit]];
-                        [strongSelf->dbpersistenceManager clearProcessedEventsFromDB];
-                    }
-                    
                     // initiate the native SDK factories if destinations are present
                     if (serverConfig.destinations != nil && serverConfig.destinations.count > 0) {
                         NSArray <RSServerDestination *> *consentedDestinations = self->consentFilterHandler != nil ? [self->consentFilterHandler filterDestinationList:serverConfig.destinations] : serverConfig.destinations;
@@ -181,8 +190,7 @@ static RSEventRepository* _instance;
                             [self->deviceModeManager startDeviceModeProcessor:consentedDestinations andDestinationsWithTransformationsEnabled:[strongSelf->configManager getDestinationsWithTransformationsEnabled]];
                         }
                     } else {
-                        [self->deviceModeManager sendPreviousUnprocessedDeviceModeEvents];
-                        [strongSelf->dbpersistenceManager clearProcessedEventsFromDB];
+                        self->isDeviceModeFactoriesNotPresent = YES;
                         [RSLogger logDebug:@"EventRepository: no device mode present"];
                     }
                 } else {
@@ -200,16 +208,6 @@ static RSEventRepository* _instance;
             }
         }
     });
-}
-
-- (BOOL) isUserHasUpdatedFromPostDMTReleaseVersion {
-    if (![preferenceManager getEventDeletionCompletedStatus]) {
-        [preferenceManager saveEventDeletionCompletedStatus];
-        if ([self->applicationLifeCycleManager isApplicationUpdated]) {
-            return YES;
-        }
-    }
-    return NO;
 }
 
 - (void) dump:(RSMessage *)message {
@@ -231,7 +229,11 @@ static RSEventRepository* _instance;
         return;
     }
     NSNumber* rowId = [self->dbpersistenceManager saveEvent:jsonString];
-    [self->deviceModeManager makeFactoryDump: message FromHistory:NO withRowId:rowId];
+    if (self->isDeviceModeFactoriesNotPresent) {
+        [self->dbpersistenceManager updateEventsWithIds:[[NSArray alloc] initWithObjects:rowId, nil] withStatus:DEVICE_MODE_PROCESSING_DONE];
+    } else {
+        [self->deviceModeManager makeFactoryDump: message FromHistory:NO withRowId:rowId];
+    }
 }
 
 - (void)applyIntegrations:(RSMessage *)message withDefaultOption:(RSOption *)defaultOption {

--- a/Sources/Classes/RSEventRepository.m
+++ b/Sources/Classes/RSEventRepository.m
@@ -190,7 +190,7 @@ static RSEventRepository* _instance;
                             [self->deviceModeManager startDeviceModeProcessor:consentedDestinations andDestinationsWithTransformationsEnabled:[strongSelf->configManager getDestinationsWithTransformationsEnabled]];
                         }
                     } else {
-                        self->isDeviceModeFactoriesNotPresent = YES;
+                        [self->deviceModeManager handleCaseWhenNoDeviceModeFactoryIsPresent];
                         [RSLogger logDebug:@"EventRepository: no device mode present"];
                     }
                 } else {
@@ -229,11 +229,7 @@ static RSEventRepository* _instance;
         return;
     }
     NSNumber* rowId = [self->dbpersistenceManager saveEvent:jsonString];
-    if (self->isDeviceModeFactoriesNotPresent) {
-        [self->dbpersistenceManager updateEventsWithIds:[[NSArray alloc] initWithObjects:rowId, nil] withStatus:DEVICE_MODE_PROCESSING_DONE];
-    } else {
-        [self->deviceModeManager makeFactoryDump: message FromHistory:NO withRowId:rowId];
-    }
+    [self->deviceModeManager makeFactoryDump: message FromHistory:NO withRowId:rowId];
 }
 
 - (void)applyIntegrations:(RSMessage *)message withDefaultOption:(RSOption *)defaultOption {

--- a/Sources/Classes/RSEventRepository.m
+++ b/Sources/Classes/RSEventRepository.m
@@ -98,7 +98,7 @@ static RSEventRepository* _instance;
         // Prviously in certain cases (e.g., network unavialability) events are not processed by device mode factories and statuses remains at either 0 or 2. Now we are marking those events as device_mode_processing_done.
         [RSLogger logDebug:@"EventRepository: Checking if previous unprocessed event deletion is allowed or not. If allowed then mark previous events with status code 0 and 2 as device_mode_processing_done."];
         if ([self isPreviousEventsDeletionAllowed]) {
-            [self->dbpersistenceManager markUnProcessedDeviceModeEventsStatusesAsDeviceModeProcessingDone];
+            [self->dbpersistenceManager updateDeviceModeEventsStatus];
             [self->dbpersistenceManager clearProcessedEventsFromDB];
         }
         

--- a/Sources/Classes/RSPreferenceManager.m
+++ b/Sources/Classes/RSPreferenceManager.m
@@ -31,6 +31,7 @@ NSString *const RSOptOutTimeKey = @"rl_opt_out_time";
 NSString *const RSSessionIdKey = @"rl_session_id";
 NSString *const RSLastEventTimeStamp = @"rl_last_event_time_stamp";
 NSString *const RSSessionAutoTrackStatus = @"rl_session_auto_track_status";
+NSString *const RSEventDeletionCompletedStatus = @"rl_event_deletion_completed_status";
 
 
 + (instancetype)getInstance {
@@ -253,6 +254,15 @@ NSString *const RSSessionAutoTrackStatus = @"rl_session_auto_track_status";
 
 - (BOOL) getAutoTrackingStatus {
     return [[NSUserDefaults standardUserDefaults] boolForKey:RSSessionAutoTrackStatus];
+}
+
+- (void) saveEventDeletionCompletedStatus {
+    [[NSUserDefaults standardUserDefaults] setBool:true forKey:RSEventDeletionCompletedStatus];
+    [[NSUserDefaults standardUserDefaults] synchronize];
+}
+
+- (BOOL) getEventDeletionCompletedStatus {
+    return [[NSUserDefaults standardUserDefaults] boolForKey:RSEventDeletionCompletedStatus];
 }
 
 @end

--- a/Sources/Classes/RSPreferenceManager.m
+++ b/Sources/Classes/RSPreferenceManager.m
@@ -256,27 +256,13 @@ NSString *const RSBeforeSDKInitEventTimestamp = @"rl_before_sdk_init_event_time_
     return [[NSUserDefaults standardUserDefaults] boolForKey:RSSessionAutoTrackStatus];
 }
 
-- (void) saveEventDeletionCompletedStatus {
+- (void) saveEventDeletionStatus {
     [[NSUserDefaults standardUserDefaults] setBool:true forKey:RSEventDeletionCompletedStatus];
     [[NSUserDefaults standardUserDefaults] synchronize];
 }
 
-- (BOOL) getEventDeletionCompletedStatus {
+- (BOOL) getEventDeletionStatus {
     return [[NSUserDefaults standardUserDefaults] boolForKey:RSEventDeletionCompletedStatus];
-}
-
-- (void) saveBeforeSDKInitEventTimestamp:(long) beforeSDKInitEventTimestamp {
-    [[NSUserDefaults standardUserDefaults] setValue:[[NSNumber alloc] initWithLong:beforeSDKInitEventTimestamp] forKey:RSBeforeSDKInitEventTimestamp];
-    [[NSUserDefaults standardUserDefaults] synchronize];
-}
-
-- (long) getBeforeSDKInitEventTimestamp {
-    NSNumber *beforeSDKInitEventTimestamp = [[NSUserDefaults standardUserDefaults] valueForKey:RSBeforeSDKInitEventTimestamp];
-    if(beforeSDKInitEventTimestamp == nil) {
-        return 0;
-    } else {
-        return [beforeSDKInitEventTimestamp longValue];
-    }
 }
 
 @end

--- a/Sources/Classes/RSPreferenceManager.m
+++ b/Sources/Classes/RSPreferenceManager.m
@@ -31,8 +31,7 @@ NSString *const RSOptOutTimeKey = @"rl_opt_out_time";
 NSString *const RSSessionIdKey = @"rl_session_id";
 NSString *const RSLastEventTimeStamp = @"rl_last_event_time_stamp";
 NSString *const RSSessionAutoTrackStatus = @"rl_session_auto_track_status";
-NSString *const RSEventDeletionCompletedStatus = @"rl_event_deletion_completed_status";
-NSString *const RSBeforeSDKInitEventTimestamp = @"rl_before_sdk_init_event_time_stamp";
+NSString *const RSEventDeletionStatus = @"rl_event_deletion_status";
 
 + (instancetype)getInstance {
     if (instance == nil) {
@@ -257,12 +256,12 @@ NSString *const RSBeforeSDKInitEventTimestamp = @"rl_before_sdk_init_event_time_
 }
 
 - (void) saveEventDeletionStatus {
-    [[NSUserDefaults standardUserDefaults] setBool:true forKey:RSEventDeletionCompletedStatus];
+    [[NSUserDefaults standardUserDefaults] setBool:true forKey:RSEventDeletionStatus];
     [[NSUserDefaults standardUserDefaults] synchronize];
 }
 
 - (BOOL) getEventDeletionStatus {
-    return [[NSUserDefaults standardUserDefaults] boolForKey:RSEventDeletionCompletedStatus];
+    return [[NSUserDefaults standardUserDefaults] boolForKey:RSEventDeletionStatus];
 }
 
 @end

--- a/Sources/Classes/RSPreferenceManager.m
+++ b/Sources/Classes/RSPreferenceManager.m
@@ -32,7 +32,7 @@ NSString *const RSSessionIdKey = @"rl_session_id";
 NSString *const RSLastEventTimeStamp = @"rl_last_event_time_stamp";
 NSString *const RSSessionAutoTrackStatus = @"rl_session_auto_track_status";
 NSString *const RSEventDeletionCompletedStatus = @"rl_event_deletion_completed_status";
-
+NSString *const RSBeforeSDKInitEventTimestamp = @"rl_before_sdk_init_event_time_stamp";
 
 + (instancetype)getInstance {
     if (instance == nil) {
@@ -263,6 +263,20 @@ NSString *const RSEventDeletionCompletedStatus = @"rl_event_deletion_completed_s
 
 - (BOOL) getEventDeletionCompletedStatus {
     return [[NSUserDefaults standardUserDefaults] boolForKey:RSEventDeletionCompletedStatus];
+}
+
+- (void) saveBeforeSDKInitEventTimestamp:(long) beforeSDKInitEventTimestamp {
+    [[NSUserDefaults standardUserDefaults] setValue:[[NSNumber alloc] initWithLong:beforeSDKInitEventTimestamp] forKey:RSBeforeSDKInitEventTimestamp];
+    [[NSUserDefaults standardUserDefaults] synchronize];
+}
+
+- (long) getBeforeSDKInitEventTimestamp {
+    NSNumber *beforeSDKInitEventTimestamp = [[NSUserDefaults standardUserDefaults] valueForKey:RSBeforeSDKInitEventTimestamp];
+    if(beforeSDKInitEventTimestamp == nil) {
+        return 0;
+    } else {
+        return [beforeSDKInitEventTimestamp longValue];
+    }
 }
 
 @end

--- a/Sources/Classes/RSUtils.m
+++ b/Sources/Classes/RSUtils.m
@@ -192,6 +192,12 @@
     return base64EncodedString;
 }
 
++ (NSNumber *) convertStringIntoNSNumber:(NSString* __nonnull) stringNumber {
+    NSNumberFormatter *numberFormatter = [[NSNumberFormatter alloc] init];
+    NSNumber *number = [numberFormatter numberFromString:stringNumber];
+    return number;
+}
+
 unsigned int MAX_EVENT_SIZE = 32 * 1024; // 32 KB
 unsigned int MAX_BATCH_SIZE = 500 * 1024; // 500 KB
 

--- a/Sources/Classes/RSUtils.m
+++ b/Sources/Classes/RSUtils.m
@@ -198,6 +198,12 @@
     return number;
 }
 
++ (BOOL) isApplicationUpdated {
+    NSString *previousVersion = [[RSPreferenceManager getInstance] getVersionNumber];
+    NSString *currentVersion = [[NSBundle mainBundle] infoDictionary][@"CFBundleShortVersionString"];
+    return (previousVersion && ![previousVersion isEqualToString:currentVersion]);
+}
+
 unsigned int MAX_EVENT_SIZE = 32 * 1024; // 32 KB
 unsigned int MAX_BATCH_SIZE = 500 * 1024; // 500 KB
 

--- a/Sources/Classes/RSUtils.m
+++ b/Sources/Classes/RSUtils.m
@@ -192,12 +192,6 @@
     return base64EncodedString;
 }
 
-+ (NSNumber * _Nullable) convertStringIntoNSNumber:(NSString* __nonnull) stringNumber {
-    NSNumberFormatter *numberFormatter = [[NSNumberFormatter alloc] init];
-    NSNumber *number = [numberFormatter numberFromString:stringNumber];
-    return number;
-}
-
 + (BOOL) isApplicationUpdated {
     NSString *previousVersion = [[RSPreferenceManager getInstance] getVersionNumber];
     NSString *currentVersion = [[NSBundle mainBundle] infoDictionary][@"CFBundleShortVersionString"];

--- a/Sources/Classes/RSUtils.m
+++ b/Sources/Classes/RSUtils.m
@@ -192,7 +192,7 @@
     return base64EncodedString;
 }
 
-+ (NSNumber *) convertStringIntoNSNumber:(NSString* __nonnull) stringNumber {
++ (NSNumber * _Nullable) convertStringIntoNSNumber:(NSString* __nonnull) stringNumber {
     NSNumberFormatter *numberFormatter = [[NSNumberFormatter alloc] init];
     NSNumber *number = [numberFormatter numberFromString:stringNumber];
     return number;


### PR DESCRIPTION
# Description

## Fix:

- While SDK updated for the first time from the version containing the issue to the latest version containing the fix:
    - Mark all the previous events whose statuses are 0 and 2 to device_mode_processing_done and remove events whose status code is updated to 3.
    - Any event made after the SDK update will be sent to makeFactoryDump.
    - Also, if the user updates again to any newer version containing this fix, then the SDK will send an event with status codes 0 and 2 to makeFactoryDump instead of directly marking it as device_mode_processing_done.
- Handle network issues where events are not sent to the device mode integrations and remained stored in the DB. Now, if such a case happens then the event will be sent to device mode factories and when cloud mode processing is done, it’ll be removed from the DB.
- Handle event not removed from the DB in case of wrong write key while SDK init. Now, if such a case happens then the event will be sent to device mode factories and when cloud mode processing is done, it’ll be removed from the DB.


## It is also ensured that there is no issue while:
- Updating the app from the pre-DMT release to the latest version
- Updating the app from the post-DMT release to the latest version
- Reverting back from the latest version to the post-DMT version
