### PR TITLE
fix: auto-session  un-cleared on dynamically disabling trackLifeCycleEvents & autoSessionTracking

### DIFF
--- a/Sources/Classes/RSEventRepository.m
+++ b/Sources/Classes/RSEventRepository.m
@@ -112,16 +112,18 @@ static RSEventRepository* _instance;
         self->userSession = [RSUserSession initiate:self->config.sessionInActivityTimeOut with: self->preferenceManager];
         
         // clear session if automatic session tracking was enabled previously but disabled presently or vice versa.
+        BOOL currentAutoTrackingStatus = self->config.automaticSessionTracking && self->config.trackLifecycleEvents;
         BOOL previousAutoTrackingStatus = [self->preferenceManager getAutoTrackingStatus];
-        if(previousAutoTrackingStatus && previousAutoTrackingStatus != config.automaticSessionTracking) {
+        if(previousAutoTrackingStatus && previousAutoTrackingStatus != currentAutoTrackingStatus) {
             [RSLogger logDebug:@"EventRepository: Automatic Session Tracking status has been updated since last launch, hence clearing the session"];
             [self->userSession clearSession];
         }
-        [self->preferenceManager saveAutoTrackingStatus:config.automaticSessionTracking];
-        
-        if(self->config.trackLifecycleEvents && self->config.automaticSessionTracking) {
+        if(currentAutoTrackingStatus) {
+            [self->preferenceManager saveAutoTrackingStatus:YES];
             [RSLogger logDebug:@"EventRepository: Starting Automatic Sessions"];
             [self->userSession startSessionIfExpired];
+        } else {
+            [self->preferenceManager saveAutoTrackingStatus:NO];
         }
         
         [RSLogger logDebug:@"EventRepository: Initiating RSApplicationLifeCycleManager"];


### PR DESCRIPTION
# fix: fixed automatic session not getting cleared on dynamically disabling track life cycle events / automatic session tracking

The previous automatic session would still be active, if we disable the track life cycle events on next launch, hence we need to save the automatic tracking status as enabled in the preferences only when both track life cycle events and automatic session tracking is enabled. 
