### PR TITLE
fix: fixed application installed, updated triggered in-correctly

### DIFF
--- a/Sources/Classes/RSApplicationLifeCycleManager.m
+++ b/Sources/Classes/RSApplicationLifeCycleManager.m
@@ -73,35 +73,40 @@
 }
 #endif
 
+- (void)saveCurrentBuildNumberAndVersion:(NSString *)currentBuildNumber currentVersion:(NSString *)currentVersion {
+    [preferenceManager saveVersionNumber:currentVersion];
+    [preferenceManager saveBuildNumber:currentBuildNumber];
+}
+
 - (void) applicationDidFinishLaunchingWithOptions:(NSDictionary *)launchOptions {
+    
+    NSString *previousVersion = [preferenceManager getVersionNumber];
+    NSString* previousBuildNumber = [preferenceManager getBuildNumber];
+    
+    NSString *currentVersion = [[NSBundle mainBundle] infoDictionary][@"CFBundleShortVersionString"];
+    NSString *currentBuildNumber = [[NSBundle mainBundle] infoDictionary][@"CFBundleVersion"];
+    
     if (!self->config.trackLifecycleEvents) {
+        [self saveCurrentBuildNumberAndVersion:currentBuildNumber currentVersion:currentVersion];
         return;
     }
-    NSString *previousVersion = [preferenceManager getVersionNumber];
-       NSString *currentVersion = [[NSBundle mainBundle] infoDictionary][@"CFBundleShortVersionString"];
-       
-       NSString* previousBuildNumber = [preferenceManager getBuildNumber];
-       NSString *currentBuildNumber = [[NSBundle mainBundle] infoDictionary][@"CFBundleVersion"];
-       
-       if (!previousVersion) {
-           [RSLogger logVerbose:@"RSApplicationLifeCycleManager: applicationDidFinishLaunchingWithOptions: Tracking Application Installed"];
-           [[RSClient sharedInstance] track:@"Application Installed" properties:@{
-               @"version": currentVersion,
-               @"build": currentBuildNumber
-           }];
-           [preferenceManager saveVersionNumber:currentVersion];
-           [preferenceManager saveBuildNumber:currentBuildNumber];
-       } else if ([RSUtils isApplicationUpdated]) {
-           [RSLogger logVerbose:@"RSApplicationLifeCycleManager: applicationDidFinishLaunchingWithOptions: Tracking Application Updated"];
-           [[RSClient sharedInstance] track:@"Application Updated" properties:@{
-               @"previous_version" : previousVersion ?: @"",
-               @"version": currentVersion,
-               @"previous_build": previousBuildNumber ?: @"",
-               @"build": currentBuildNumber
-           }];
-           [preferenceManager saveVersionNumber:currentVersion];
-           [preferenceManager saveBuildNumber:currentBuildNumber];
-       }
+    
+    if (!previousVersion) {
+        [RSLogger logVerbose:@"RSApplicationLifeCycleManager: applicationDidFinishLaunchingWithOptions: Tracking Application Installed"];
+        [[RSClient sharedInstance] track:@"Application Installed" properties:@{
+            @"version": currentVersion,
+            @"build": currentBuildNumber
+        }];
+    } else if ([RSUtils isApplicationUpdated]) {
+        [RSLogger logVerbose:@"RSApplicationLifeCycleManager: applicationDidFinishLaunchingWithOptions: Tracking Application Updated"];
+        [[RSClient sharedInstance] track:@"Application Updated" properties:@{
+            @"previous_version" : previousVersion ?: @"",
+            @"version": currentVersion,
+            @"previous_build": previousBuildNumber ?: @"",
+            @"build": currentBuildNumber
+        }];
+    }
+    [self saveCurrentBuildNumberAndVersion:currentBuildNumber currentVersion:currentVersion];
     [self sendApplicationOpenedOnLaunch:launchOptions withVersion:currentVersion];
 }
 

--- a/Sources/Classes/RSEventRepository.m
+++ b/Sources/Classes/RSEventRepository.m
@@ -127,10 +127,8 @@ static RSEventRepository* _instance;
         [RSLogger logDebug:@"EventRepository: Initiating RSApplicationLifeCycleManager"];
         self->applicationLifeCycleManager = [[RSApplicationLifeCycleManager alloc] initWithConfig:config andPreferenceManager:self->preferenceManager andBackGroundModeManager:self->backGroundModeManager andUserSession:self->userSession];
         
-        if (config.trackLifecycleEvents) {
-            [RSLogger logDebug:@"EventRepository: Enabling tracking of application lifecycle events"];
-            [self->applicationLifeCycleManager trackApplicationLifeCycle];
-        }
+        [RSLogger logDebug:@"EventRepository: Enabling tracking of application lifecycle events"];
+        [self->applicationLifeCycleManager trackApplicationLifeCycle];
         
         if (config.recordScreenViews) {
             [RSLogger logDebug:@"EventRepository: Enabling automatic recording of screen views"];


### PR DESCRIPTION

# fixed application installed, updated triggered in-correctly

When tracking the life cycle events is disabled, we are not saving the build number and version number to preferences as a result when this flag is enabled in future then Application Installed/Updated is getting triggered, which is kind of in-correct, hence we fixed this by saving build number and version number irrespective of whether life cycle events are enabled or not.
