### PR TITLE
fix: no events recorded for dm destinations on the first launch

### DIFF
--- a/Sources/Classes/Client/RSClient+Plugins.swift
+++ b/Sources/Classes/Client/RSClient+Plugins.swift
@@ -150,8 +150,8 @@ extension RSClient {
             
             switch result {
             case .success(let serverConfig):
-                self.update(serverConfig: serverConfig, type: .refresh)
                 self.serverConfig = serverConfig
+                self.update(serverConfig: serverConfig, type: .refresh)
                 RSUserDefaults.saveServerConfig(serverConfig)
                 RSUserDefaults.updateLastUpdatedTime(RSUtils.getTimeStamp())
                 self.log(message: "server config download successful", logLevel: .debug)

--- a/Sources/Classes/Client/RSController.swift
+++ b/Sources/Classes/Client/RSController.swift
@@ -206,7 +206,7 @@ extension RSDestinationPlugin {
             }
         }
         
-        return !customerDisabled || (hasSettings && !customerDisabled)
+        return (hasSettings == true && customerDisabled == false)
     }
     
     // swiftlint:disable inclusive_language

--- a/Sources/Classes/Client/RSController.swift
+++ b/Sources/Classes/Client/RSController.swift
@@ -206,7 +206,7 @@ extension RSDestinationPlugin {
             }
         }
         
-        return (hasSettings == true && customerDisabled == false)
+        return customerDisabled == false || (hasSettings == true && customerDisabled == false)
     }
     
     // swiftlint:disable inclusive_language

--- a/Sources/Classes/Client/RSController.swift
+++ b/Sources/Classes/Client/RSController.swift
@@ -206,7 +206,7 @@ extension RSDestinationPlugin {
             }
         }
         
-        return customerDisabled == false || (hasSettings == true && customerDisabled == false)
+        return !customerDisabled || (hasSettings && !customerDisabled)
     }
     
     // swiftlint:disable inclusive_language


### PR DESCRIPTION
# Description

On the first app launch, events were not recorded for the device modes on the first launch. It works ok on the second launch.
