### PR TITLE
fix: header not found issue on cross platforms

### DIFF
--- a/Sources/Classes/Headers/Public/Rudder.h
+++ b/Sources/Classes/Headers/Public/Rudder.h
@@ -105,6 +105,7 @@
 #import "WKInterfaceController+RSScreen.h"
 #import "NSData+GZIP.h"
 #import "sqlite3.h"
+#import "RSDBEncryption.h"
 
 //! Project version number for RS.
 FOUNDATION_EXPORT double RSVersionNumber;


### PR DESCRIPTION
# Description

Header not found issue on Flutter.
