### PR TITLE
fix: SPM build error due to use of unsafe flags

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -27,7 +27,10 @@ let package = Package(
             publicHeadersPath: "Classes/Headers/Public/",
             cSettings: [
                 .headerSearchPath("Classes/Headers/"),
-                .unsafeFlags(["-DSQLITE_HAS_CODEC", "-DSQLITE_TEMP_STORE=3", "-DSQLCIPHER_CRYPTO_CC", "-DNDEBUG"])
+                .define("SQLITE_HAS_CODEC"),
+                .define("SQLITE_TEMP_STORE", to: "3"),
+                .define("SQLCIPHER_CRYPTO_CC"),
+                .define("NDEBUG")
             ]
         ),
         .testTarget(


### PR DESCRIPTION
# Description

SPM build was failing when a specific version was given due to the use of unsafe flags.
