### PR TITLE
chore(release): pulling hotfix-release/1.22.0 into master

### DIFF
--- a/.github/workflows/deploy-cocoapods.yml
+++ b/.github/workflows/deploy-cocoapods.yml
@@ -1,9 +1,8 @@
 name: Deploy to Cocoapods
 
 on:
-  workflow_run:
-    workflows: ['Publish new github release']
-    types: ['completed']
+  release:
+    types: [created]
     
 jobs:
   build:

--- a/.github/workflows/deploy-private-pod.yml
+++ b/.github/workflows/deploy-private-pod.yml
@@ -11,7 +11,7 @@ jobs:
   deploy_private_pod:
     name: Deploy to Private Pod
     runs-on: macOS-latest
-    if: (startsWith(github.event.client_payload.branch_name, 'release/') || startsWith(github.event.client_payload.branch_name, 'hotfix-release/'))
+    if: (startsWith(github.event.pull_request.head.ref, 'release/') || startsWith(github.event.pull_request.head.ref, 'hotfix-release/'))
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/slack-notify.yml
+++ b/.github/workflows/slack-notify.yml
@@ -1,9 +1,8 @@
 name: Notify Slack Channel
 
 on:
-  workflow_run:
-    workflows: ['Deploy to Cocoapods']
-    types: ['completed']
+  release:
+    types: [created]
 
 jobs:
   deploy-tag:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+## [1.22.0](https://github.com/rudderlabs/rudder-sdk-ios/compare/v1.20.0...v1.22.0) (2023-09-28)
+
+
+### Features
+
+* improvements of SQLite RETURNING clause ([00e5032](https://github.com/rudderlabs/rudder-sdk-ios/commit/00e5032f68bde1fe171278c979a080a21a8efa12))
+
+
+### Bug Fixes
+
+* crash on RSDBPersistentManager ([b645316](https://github.com/rudderlabs/rudder-sdk-ios/commit/b645316201caceec943dcbab8b220875e370d6f3))
+
 ## [1.21.0](https://github.com/rudderlabs/rudder-sdk-ios/compare/v1.20.0...v1.21.0) (2023-09-28)
 
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 <p align="center">
   <a href="https://cocoapods.org/pods/Rudder">
-    <img src="https://img.shields.io/static/v1?label=pod&message=v1.21.0&color=blue&style=flat">
+    <img src="https://img.shields.io/static/v1?label=pod&message=v1.22.0&color=blue&style=flat">
     </a>
 </p>
 
@@ -39,7 +39,7 @@ The iOS SDK is available through [**CocoaPods**](https://cocoapods.org), [**Cart
 To install the SDK, simply add the following line to your Podfile:
 
 ```xcode
-pod 'Rudder', '1.21.0'
+pod 'Rudder', '1.22.0'
 ```
 
 ### Carthage
@@ -47,7 +47,7 @@ pod 'Rudder', '1.21.0'
 For Carthage support, add the following line to your `Cartfile`:
 
 ```xcode
-github "rudderlabs/rudder-sdk-ios" "v1.21.0"
+github "rudderlabs/rudder-sdk-ios" "v1.22.0"
 ```
 
 > Remember to include the following code in all `.m` and `.h` files where you want to refer to or use the RudderStack SDK classes, as shown:
@@ -71,7 +71,7 @@ You can also add the RudderStack iOS SDK via Swift Package Mangaer, via one of t
 
 * Enter the package repository (`git@github.com:rudderlabs/rudder-sdk-ios.git`) in the search bar.
 
-* In **Dependency Rule**, select **Up to Next Major Version** and enter `1.21.0` as the value, as shown:
+* In **Dependency Rule**, select **Up to Next Major Version** and enter `1.22.0` as the value, as shown:
 
 ![Setting dependency](https://user-images.githubusercontent.com/59817155/145574696-8c849749-13e0-40d5-aacb-3fccb5c8e67d.png)
 
@@ -99,7 +99,7 @@ let package = Package(
     ],
     dependencies: [
         // Dependencies declare other packages that this package depends on.
-        .package(url: "git@github.com:rudderlabs/rudder-sdk-ios.git", from: "1.21.0")
+        .package(url: "git@github.com:rudderlabs/rudder-sdk-ios.git", from: "1.22.0")
     ],
     targets: [
         // Targets are the basic building blocks of a package. A target can define a module or a test suite.

--- a/Sources/Classes/Headers/RSVersion.h
+++ b/Sources/Classes/Headers/RSVersion.h
@@ -8,6 +8,6 @@
 #ifndef RSVersion_h
 #define RSVersion_h
 
-NSString *const SDK_VERSION = @"1.21.0";
+NSString *const SDK_VERSION = @"1.22.0";
 
 #endif /* RSVersion_h */

--- a/Sources/Classes/RSDBPersistentManager.m
+++ b/Sources/Classes/RSDBPersistentManager.m
@@ -337,7 +337,7 @@ NSString* _Nonnull const UNENCRYPTED_DB_NAME = @"rl_persistence.sqlite";
             if ([database step:insertStmt] == SQLITE_ROW) {
                 // table created
                 [RSLogger logDebug:@"RSDBPersistentManager: saveEvent: Successfully inserted event to table"];
-                rowId = sqlite3_column_int(insertStmt, 0);
+                rowId = [database column_int:insertStmt i:0];
             } else {
                 [RSLogger logError:@"RSDBPersistentManager: saveEvent: Failed to insert the event"];
             }

--- a/package.json
+++ b/package.json
@@ -1,4 +1,4 @@
 {
-    "version": "1.21.0",
+    "version": "1.22.0",
     "description": "Rudder is a platform for collecting, storing and routing customer event data to dozens of tools"
 }

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -6,7 +6,7 @@ sonar.qualitygate.wait=false
 sonar.projectKey=rudderlabs_rudder-sdk-ios
 sonar.organization=rudderlabs
 sonar.projectName=RudderStack iOS SDK
-sonar.projectVersion=1.21.0
+sonar.projectVersion=1.22.0
 
 # C/C++/Objective-C related details
 # sonar.cfamily.compile-commands=compile_commands.json


### PR DESCRIPTION
:crown: *An automated PR*

   1.21.0 (2023-09-28)<br> * fix: crash on RSDBPersistentManager ([b645316](https://github.com/rudderlabs/rudder-sdk-ios/commit/b645316))<br> * chore(ci): private pod release workflow added and other improvements ( 394) ([2960118](https://github.com/rudderlabs/rudder-sdk-ios/commit/2960118)), closes [ 394](https://github.com/rudderlabs/rudder-sdk-ios/issues/394)<br> * chore(release): 1.21.0 ([f8ce0f7](https://github.com/rudderlabs/rudder-sdk-ios/commit/f8ce0f7))<br> * feat: improvements of SQLite RETURNING clause ([00e5032](https://github.com/rudderlabs/rudder-sdk-ios/commit/00e5032))