### PR TITLE
feat: provide onIntegrationReady API support

### DIFF
--- a/Examples/RudderSampleAppObjC/RudderSampleAppObjC/_AppDelegate.m
+++ b/Examples/RudderSampleAppObjC/RudderSampleAppObjC/_AppDelegate.m
@@ -39,6 +39,10 @@ static int screenCount = 1;
             [builder withDBEncryption:[[RSDBEncryption alloc] initWithKey:@"test1234" enable:NO databaseProvider:[EncryptedDatabaseProvider new]]];
             [RSClient getInstance:rudderConfig.WRITE_KEY config:[builder build]];
         }
+        
+        [[RSClient getInstance] onIntegrationReady:@"Braze" withCallback:^(NSObject *integrationInstance) {
+            // Handle integrationInstance
+        }];
     }
     return YES;
 }

--- a/Examples/RudderSampleAppObjC/RudderSampleAppObjC/_AppDelegate.m
+++ b/Examples/RudderSampleAppObjC/RudderSampleAppObjC/_AppDelegate.m
@@ -39,10 +39,6 @@ static int screenCount = 1;
             [builder withDBEncryption:[[RSDBEncryption alloc] initWithKey:@"test1234" enable:NO databaseProvider:[EncryptedDatabaseProvider new]]];
             [RSClient getInstance:rudderConfig.WRITE_KEY config:[builder build]];
         }
-        
-        [[RSClient getInstance] onIntegrationReady:@"Braze" withCallback:^(NSObject *integrationInstance) {
-            // Handle integrationInstance
-        }];
     }
     return YES;
 }

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -3,7 +3,7 @@ PODS:
     - RSCrashReporter (= 1.0.0)
     - RudderKit (= 1.4.0)
   - RSCrashReporter (1.0.0)
-  - Rudder (1.23.0):
+  - Rudder (1.23.1):
     - MetricsReporter (= 1.1.1)
   - RudderKit (1.4.0)
   - SQLCipher (4.5.4):
@@ -33,10 +33,10 @@ EXTERNAL SOURCES:
 SPEC CHECKSUMS:
   MetricsReporter: d4265e0ac833e2c0078bbe044b3f9dbe29f53a48
   RSCrashReporter: 7e26b51ac816e967acb58fa458040946a93a9e65
-  Rudder: 125d9dc03e178b35b0f74487aa694afe1a8e6f4f
+  Rudder: 18897c785af9cfe84c2be2a1d15a645edbeda6d0
   RudderKit: d9d6997696e1642b753d8bdf94e57af643a68f03
   SQLCipher: 905b145f65f349f26da9e60a19901ad24adcd381
 
 PODFILE CHECKSUM: b6937cee06e0633464427ff0d975d40e17419e9f
 
-COCOAPODS: 1.14.2
+COCOAPODS: 1.11.3

--- a/Sources/Classes/Headers/Public/RSClient.h
+++ b/Sources/Classes/Headers/Public/RSClient.h
@@ -22,7 +22,7 @@ NS_ASSUME_NONNULL_BEGIN
 @class RSMessage;
 @class RSContext;
 @class RSMessageBuilder;
-typedef void (^Callback)(NSObject *);
+typedef void (^Callback)(NSObject *_Nullable);
 
 @interface RSClient : NSObject {
     RSOption *_options;

--- a/Sources/Classes/Headers/Public/RSClient.h
+++ b/Sources/Classes/Headers/Public/RSClient.h
@@ -22,6 +22,7 @@ NS_ASSUME_NONNULL_BEGIN
 @class RSMessage;
 @class RSContext;
 @class RSMessageBuilder;
+typedef void (^Callback)(NSObject *);
 
 @interface RSClient : NSObject {
     RSOption *_options;
@@ -87,6 +88,8 @@ NS_ASSUME_NONNULL_BEGIN
 - (RSConfig* _Nullable)configuration __attribute((deprecated("This method will be deprecated soon. Use instance property(config) instead.")));
 + (RSOption*) getDefaultOptions __attribute((deprecated("This method will be deprecated soon. Use instance property(defaultOptions) instead.")));
 - (RSContext *) getContext __attribute((deprecated("This method will be deprecated soon. Use instance property(context) instead.")));
+
+- (void) onIntegrationReady:(NSString *)key withCallback:(Callback)callback;
 
 @property (strong, nonatomic, readonly) NSNumber* _Nullable sessionId;
 @property (strong, nonatomic, readonly) NSString* _Nullable anonymousId;

--- a/Sources/Classes/Headers/Public/RSClient.h
+++ b/Sources/Classes/Headers/Public/RSClient.h
@@ -89,7 +89,8 @@ typedef void (^Callback)(NSObject *_Nullable);
 + (RSOption*) getDefaultOptions __attribute((deprecated("This method will be deprecated soon. Use instance property(defaultOptions) instead.")));
 - (RSContext *) getContext __attribute((deprecated("This method will be deprecated soon. Use instance property(context) instead.")));
 
-- (void) onIntegrationReady:(NSString *)integrationName withCallback:(Callback)callback;
+- (void) onIntegrationReadyWithString:(NSString *)integrationName withCallback:(Callback)callback;
+- (void) onIntegrationReadyWithFactory:(id<RSIntegrationFactory>)factory withCallback:(Callback)callback;
 
 @property (strong, nonatomic, readonly) NSNumber* _Nullable sessionId;
 @property (strong, nonatomic, readonly) NSString* _Nullable anonymousId;

--- a/Sources/Classes/Headers/Public/RSClient.h
+++ b/Sources/Classes/Headers/Public/RSClient.h
@@ -89,7 +89,7 @@ typedef void (^Callback)(NSObject *);
 + (RSOption*) getDefaultOptions __attribute((deprecated("This method will be deprecated soon. Use instance property(defaultOptions) instead.")));
 - (RSContext *) getContext __attribute((deprecated("This method will be deprecated soon. Use instance property(context) instead.")));
 
-- (void) onIntegrationReady:(NSString *)key withCallback:(Callback)callback;
+- (void) onIntegrationReady:(NSString *)integrationName withCallback:(Callback)callback;
 
 @property (strong, nonatomic, readonly) NSNumber* _Nullable sessionId;
 @property (strong, nonatomic, readonly) NSString* _Nullable anonymousId;

--- a/Sources/Classes/Headers/Public/RSClient.h
+++ b/Sources/Classes/Headers/Public/RSClient.h
@@ -89,7 +89,6 @@ typedef void (^Callback)(NSObject *_Nullable);
 + (RSOption*) getDefaultOptions __attribute((deprecated("This method will be deprecated soon. Use instance property(defaultOptions) instead.")));
 - (RSContext *) getContext __attribute((deprecated("This method will be deprecated soon. Use instance property(context) instead.")));
 
-- (void) onIntegrationReady:(NSString *)integrationName withCallback:(Callback)callback;
 - (void) onIntegrationReadyWithFactory:(id<RSIntegrationFactory>)factory withCallback:(Callback)callback;
 
 @property (strong, nonatomic, readonly) NSNumber* _Nullable sessionId;

--- a/Sources/Classes/Headers/Public/RSClient.h
+++ b/Sources/Classes/Headers/Public/RSClient.h
@@ -89,7 +89,7 @@ typedef void (^Callback)(NSObject *_Nullable);
 + (RSOption*) getDefaultOptions __attribute((deprecated("This method will be deprecated soon. Use instance property(defaultOptions) instead.")));
 - (RSContext *) getContext __attribute((deprecated("This method will be deprecated soon. Use instance property(context) instead.")));
 
-- (void) onIntegrationReadyWithString:(NSString *)integrationName withCallback:(Callback)callback;
+- (void) onIntegrationReady:(NSString *)integrationName withCallback:(Callback)callback;
 - (void) onIntegrationReadyWithFactory:(id<RSIntegrationFactory>)factory withCallback:(Callback)callback;
 
 @property (strong, nonatomic, readonly) NSNumber* _Nullable sessionId;

--- a/Sources/Classes/Headers/Public/RSClient.h
+++ b/Sources/Classes/Headers/Public/RSClient.h
@@ -89,7 +89,7 @@ typedef void (^Callback)(NSObject *_Nullable);
 + (RSOption*) getDefaultOptions __attribute((deprecated("This method will be deprecated soon. Use instance property(defaultOptions) instead.")));
 - (RSContext *) getContext __attribute((deprecated("This method will be deprecated soon. Use instance property(context) instead.")));
 
-- (void) onIntegrationReadyWithFactory:(id<RSIntegrationFactory>)factory withCallback:(Callback)callback;
+- (void) onIntegrationReady:(id<RSIntegrationFactory>)factory withCallback:(Callback)callback;
 
 @property (strong, nonatomic, readonly) NSNumber* _Nullable sessionId;
 @property (strong, nonatomic, readonly) NSString* _Nullable anonymousId;

--- a/Sources/Classes/Headers/Public/RSDeviceModeManager.h
+++ b/Sources/Classes/Headers/Public/RSDeviceModeManager.h
@@ -27,6 +27,7 @@
     NSMutableArray<NSString*>* destinationsAcceptingEventsOnTransformationError;
     BOOL areFactoriesInitialized;
     BOOL isDeviceModeFactoriesNotPresent;
+    NSMutableDictionary<NSString*, Callback>* integrationCallbacks;
 }
 
 - (instancetype) initWithConfig:(RSConfig *) config andDBPersistentManager:(RSDBPersistentManager *)dbPersistentManager andNetworkManager:(RSNetworkManager *)networkManager;
@@ -39,5 +40,5 @@
 - (void) reset;
 - (void) flush;
 - (void) handleCaseWhenNoDeviceModeFactoryIsPresent;
-
+- (void) onIntegrationReady:(NSString*)key withCallback:(Callback)callback;
 @end

--- a/Sources/Classes/Headers/Public/RSDeviceModeManager.h
+++ b/Sources/Classes/Headers/Public/RSDeviceModeManager.h
@@ -40,5 +40,5 @@
 - (void) reset;
 - (void) flush;
 - (void) handleCaseWhenNoDeviceModeFactoryIsPresent;
-- (void) onIntegrationReady:(NSString*)key withCallback:(Callback)callback;
+- (void) addCallBackForIntegration:(NSString*)integrationName withCallback:(Callback)callback;
 @end

--- a/Sources/Classes/Headers/Public/RSEventRepository.h
+++ b/Sources/Classes/Headers/Public/RSEventRepository.h
@@ -77,6 +77,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)applyIntegrations:(RSMessage *)message withDefaultOption:(RSOption *)defaultOption; // Added this method in header for testing purpose
 - (RSMessage *)applyConsents:(RSMessage *)message; // Added this method in header for testing purpose
 - (void)applySession:(RSMessage *)message withUserSession:(RSUserSession *)userSession andRudderConfig:(RSConfig *)rudderConfig; // Added this method in header for testing purpose
+- (void)onIntegrationReady:(NSString *)key withCallback:(Callback)callback;
 @end
 
 NS_ASSUME_NONNULL_END

--- a/Sources/Classes/Headers/Public/RSEventRepository.h
+++ b/Sources/Classes/Headers/Public/RSEventRepository.h
@@ -77,7 +77,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)applyIntegrations:(RSMessage *)message withDefaultOption:(RSOption *)defaultOption; // Added this method in header for testing purpose
 - (RSMessage *)applyConsents:(RSMessage *)message; // Added this method in header for testing purpose
 - (void)applySession:(RSMessage *)message withUserSession:(RSUserSession *)userSession andRudderConfig:(RSConfig *)rudderConfig; // Added this method in header for testing purpose
-- (void)onIntegrationReady:(NSString *)key withCallback:(Callback)callback;
+- (void)onIntegrationReady:(NSString *)integrationName withCallback:(Callback)callback;
 @end
 
 NS_ASSUME_NONNULL_END

--- a/Sources/Classes/Headers/Public/RSIntegration.h
+++ b/Sources/Classes/Headers/Public/RSIntegration.h
@@ -16,6 +16,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (void) dump: (RSMessage*) message;
 - (void) reset;
 - (void) flush;
+@optional
 - (id) getUnderlyingInstance;
 
 @end

--- a/Sources/Classes/Headers/Public/RSIntegration.h
+++ b/Sources/Classes/Headers/Public/RSIntegration.h
@@ -16,6 +16,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (void) dump: (RSMessage*) message;
 - (void) reset;
 - (void) flush;
+- (id) getUnderlyingInstance;
 
 @end
 

--- a/Sources/Classes/RSClient.m
+++ b/Sources/Classes/RSClient.m
@@ -506,4 +506,13 @@ static NSString* _deviceToken = nil;
     return (_repository != nil) ? [_repository getSessionId] : nil;
 }
 
+- (void) onIntegrationReady:(NSString*)key withCallback:(Callback)callback {
+    if ([RSClient getOptStatus]) {
+        return;
+    }
+    if (_repository != nil) {
+        [_repository onIntegrationReady:key withCallback:callback];
+    }
+}
+
 @end

--- a/Sources/Classes/RSClient.m
+++ b/Sources/Classes/RSClient.m
@@ -506,7 +506,7 @@ static NSString* _deviceToken = nil;
     return (_repository != nil) ? [_repository getSessionId] : nil;
 }
 
-- (void) onIntegrationReadyWithFactory:(id<RSIntegrationFactory>)factory withCallback:(Callback)callback {
+- (void) onIntegrationReady:(id<RSIntegrationFactory>)factory withCallback:(Callback)callback {
     if ([RSClient getOptStatus]) {
         return;
     }

--- a/Sources/Classes/RSClient.m
+++ b/Sources/Classes/RSClient.m
@@ -506,7 +506,7 @@ static NSString* _deviceToken = nil;
     return (_repository != nil) ? [_repository getSessionId] : nil;
 }
 
-- (void) onIntegrationReadyWithString:(NSString*)integrationName withCallback:(Callback)callback {
+- (void) onIntegrationReady:(NSString*)integrationName withCallback:(Callback)callback {
     if ([RSClient getOptStatus]) {
         return;
     }
@@ -516,7 +516,7 @@ static NSString* _deviceToken = nil;
 }
 
 - (void) onIntegrationReadyWithFactory:(id<RSIntegrationFactory>)factory withCallback:(Callback)callback {
-    [self onIntegrationReadyWithString:factory.key withCallback:callback];
+    [self onIntegrationReady:factory.key withCallback:callback];
 }
 
 @end

--- a/Sources/Classes/RSClient.m
+++ b/Sources/Classes/RSClient.m
@@ -506,17 +506,14 @@ static NSString* _deviceToken = nil;
     return (_repository != nil) ? [_repository getSessionId] : nil;
 }
 
-- (void) onIntegrationReady:(NSString*)integrationName withCallback:(Callback)callback {
+- (void) onIntegrationReadyWithFactory:(id<RSIntegrationFactory>)factory withCallback:(Callback)callback {
     if ([RSClient getOptStatus]) {
         return;
     }
     if (_repository != nil) {
+        NSString *integrationName = factory.key;
         [_repository onIntegrationReady:integrationName withCallback:callback];
     }
-}
-
-- (void) onIntegrationReadyWithFactory:(id<RSIntegrationFactory>)factory withCallback:(Callback)callback {
-    [self onIntegrationReady:factory.key withCallback:callback];
 }
 
 @end

--- a/Sources/Classes/RSClient.m
+++ b/Sources/Classes/RSClient.m
@@ -506,13 +506,17 @@ static NSString* _deviceToken = nil;
     return (_repository != nil) ? [_repository getSessionId] : nil;
 }
 
-- (void) onIntegrationReady:(NSString*)integrationName withCallback:(Callback)callback {
+- (void) onIntegrationReadyWithString:(NSString*)integrationName withCallback:(Callback)callback {
     if ([RSClient getOptStatus]) {
         return;
     }
     if (_repository != nil) {
         [_repository onIntegrationReady:integrationName withCallback:callback];
     }
+}
+
+- (void) onIntegrationReadyWithFactory:(id<RSIntegrationFactory>)factory withCallback:(Callback)callback {
+    [self onIntegrationReadyWithString:factory.key withCallback:callback];
 }
 
 @end

--- a/Sources/Classes/RSClient.m
+++ b/Sources/Classes/RSClient.m
@@ -506,12 +506,12 @@ static NSString* _deviceToken = nil;
     return (_repository != nil) ? [_repository getSessionId] : nil;
 }
 
-- (void) onIntegrationReady:(NSString*)key withCallback:(Callback)callback {
+- (void) onIntegrationReady:(NSString*)integrationName withCallback:(Callback)callback {
     if ([RSClient getOptStatus]) {
         return;
     }
     if (_repository != nil) {
-        [_repository onIntegrationReady:key withCallback:callback];
+        [_repository onIntegrationReady:integrationName withCallback:callback];
     }
 }
 

--- a/Sources/Classes/RSDeviceModeManager.m
+++ b/Sources/Classes/RSDeviceModeManager.m
@@ -152,16 +152,15 @@
 }
 
 - (void) handleCallbacks:(NSString*)key withIntegration:(id<RSIntegration>)nativeOp {
-    if ([self->integrationCallbacks objectForKey:key]) {
-        if ([nativeOp respondsToSelector:@selector(getUnderlyingInstance)]) {
-            NSObject *nativeInstance = [nativeOp getUnderlyingInstance];
-            Callback callback = [self->integrationCallbacks objectForKey:key];
-            if (nativeInstance != nil && callback != nil) {
-                [RSLogger logInfo:[[NSString alloc] initWithFormat:@"RSDeviceModeManager: handleCallbacks: Callback for %@ factory is being invoked", key]];
-                callback(nativeInstance);
-            } else {
-                [RSLogger logDebug:[[NSString alloc] initWithFormat:@"RSDeviceModeManager: handleCallbacks: Either underlying instance or callback for %@ factory is null", key]];
-            }
+    if ([self->integrationCallbacks objectForKey:key] &&
+        [nativeOp respondsToSelector:@selector(getUnderlyingInstance)]) {
+        NSObject *nativeInstance = [nativeOp getUnderlyingInstance];
+        Callback callback = [self->integrationCallbacks objectForKey:key];
+        if (nativeInstance != nil && callback != nil) {
+            [RSLogger logInfo:[[NSString alloc] initWithFormat:@"RSDeviceModeManager: handleCallbacks: Callback for %@ factory is being invoked", key]];
+            callback(nativeInstance);
+        } else {
+            [RSLogger logDebug:[[NSString alloc] initWithFormat:@"RSDeviceModeManager: handleCallbacks: Either underlying instance or callback for %@ factory is null", key]];
         }
     }
 }

--- a/Sources/Classes/RSDeviceModeManager.m
+++ b/Sources/Classes/RSDeviceModeManager.m
@@ -114,7 +114,7 @@
                     id<RSIntegration> nativeOp = [factory initiate:destinationConfig client:client rudderConfig:self->config];
                     [integrationOperationMap setValue:nativeOp forKey:factory.key];
                     [RSLogger logDebug:[[NSString alloc] initWithFormat:@"RSDeviceModeManager: initiateFactories: Initiated native SDK factory %@", factory.key]];
-                    [self handleCallback:factory.key withIntegration:nativeOp];
+                    [self handleCallbacks:factory.key withIntegration:nativeOp];
                 }
                 @catch(NSException* e){
                     [RSLogger logError:[[NSString alloc] initWithFormat:@"RSDeviceModeManager: initiateFactories: Exception while initiating native SDK Factory %@ due to %@", factory.key,e.reason]];
@@ -143,7 +143,7 @@
             id<RSIntegration> nativeOp = [factory initiate:@{} client:client rudderConfig:self->config];
             [self->integrationOperationMap setValue:nativeOp forKey:factory.key];
             [RSLogger logDebug:[[NSString alloc] initWithFormat:@"RSDeviceModeManager: initiateCustomFactories: Initiated custom SDK factory %@", factory.key]];
-            [self handleCallback:factory.key withIntegration:nativeOp];
+            [self handleCallbacks:factory.key withIntegration:nativeOp];
         }
         @catch(NSException* e){
             [RSLogger logError:[[NSString alloc] initWithFormat:@"RSDeviceModeManager: initiateCustomFactories: Exception while initiating custom Factory %@ due to %@", factory.key,e.reason]];
@@ -151,14 +151,17 @@
     }
 }
 
-- (void) handleCallback:(NSString*)key withIntegration:(id<RSIntegration>)nativeOp {
+- (void) handleCallbacks:(NSString*)key withIntegration:(id<RSIntegration>)nativeOp {
     if ([self->integrationCallbacks objectForKey:key]) {
-        NSObject *nativeInstance = [nativeOp getUnderlyingInstance];
-        Callback callback = [self->integrationCallbacks objectForKey:key];
-        if (nativeInstance != nil && callback != nil) {
-            callback(nativeInstance);
-        } else {
-                // TODO: Print failure log
+        if ([nativeOp respondsToSelector:@selector(getUnderlyingInstance)]) {
+            NSObject *nativeInstance = [nativeOp getUnderlyingInstance];
+            Callback callback = [self->integrationCallbacks objectForKey:key];
+            if (nativeInstance != nil && callback != nil) {
+                [RSLogger logInfo:[[NSString alloc] initWithFormat:@"RSDeviceModeManager: handleCallbacks: Callback for %@ factory is being invoked", key]];
+                callback(nativeInstance);
+            } else {
+                [RSLogger logDebug:[[NSString alloc] initWithFormat:@"RSDeviceModeManager: handleCallbacks: Either underlying instance or callback for %@ factory is null", key]];
+            }
         }
     }
 }
@@ -421,8 +424,9 @@
     return YES;
 }
 
-- (void) onIntegrationReady:(NSString*)key withCallback:(Callback)callback {
-    [integrationCallbacks setValue:callback forKey:key];
+- (void) addCallBackForIntegration:(NSString*)integrationName withCallback:(Callback)callback {
+    [integrationCallbacks setValue:callback forKey:integrationName];
+    [RSLogger logDebug:[[NSString alloc] initWithFormat:@"RSDeviceModeManager: addCallBackForIntegration: callback registered for %@", integrationName]];
 }
 
 @end

--- a/Sources/Classes/RSDeviceModeManager.m
+++ b/Sources/Classes/RSDeviceModeManager.m
@@ -152,15 +152,20 @@
 }
 
 - (void) handleCallbacks:(NSString*)key withIntegration:(id<RSIntegration>)nativeOp {
-    if ([self->integrationCallbacks objectForKey:key] &&
-        [nativeOp respondsToSelector:@selector(getUnderlyingInstance)]) {
-        NSObject *nativeInstance = [nativeOp getUnderlyingInstance];
+    if ([self->integrationCallbacks objectForKey:key]) {
         Callback callback = [self->integrationCallbacks objectForKey:key];
-        if (nativeInstance != nil && callback != nil) {
-            [RSLogger logInfo:[[NSString alloc] initWithFormat:@"RSDeviceModeManager: handleCallbacks: Callback for %@ factory is being invoked", key]];
-            callback(nativeInstance);
+        if ([nativeOp respondsToSelector:@selector(getUnderlyingInstance)]) {
+            NSObject *nativeInstance = [nativeOp getUnderlyingInstance];
+            if (nativeInstance != nil && callback != nil) {
+                [RSLogger logInfo:[[NSString alloc] initWithFormat:@"RSDeviceModeManager: handleCallbacks: Callback for %@ factory is being invoked", key]];
+                callback(nativeInstance);
+            } else {
+                [RSLogger logDebug:[[NSString alloc] initWithFormat:@"RSDeviceModeManager: handleCallbacks: Either underlying instance or callback for %@ factory is nil", key]];
+                callback(nil);
+            }
         } else {
-            [RSLogger logDebug:[[NSString alloc] initWithFormat:@"RSDeviceModeManager: handleCallbacks: Either underlying instance or callback for %@ factory is null", key]];
+            [RSLogger logError:[[NSString alloc] initWithFormat:@"RSDeviceModeManager: handleCallbacks: getUnderlyingInstance for %@ factory is not found", key]];
+            callback(nil);
         }
     }
 }

--- a/Sources/Classes/RSDeviceModeManager.m
+++ b/Sources/Classes/RSDeviceModeManager.m
@@ -161,7 +161,6 @@
                 callback(nativeInstance);
             } else {
                 [RSLogger logDebug:[[NSString alloc] initWithFormat:@"RSDeviceModeManager: handleCallbacks: Either underlying instance or callback for %@ factory is nil", key]];
-                callback(nil);
             }
         } else {
             [RSLogger logError:[[NSString alloc] initWithFormat:@"RSDeviceModeManager: handleCallbacks: getUnderlyingInstance for %@ factory is not found", key]];

--- a/Sources/Classes/RSEventRepository.m
+++ b/Sources/Classes/RSEventRepository.m
@@ -357,4 +357,8 @@ static RSEventRepository* _instance;
     return [self->userSession getSessionId];
 }
 
+- (void) onIntegrationReady:(NSString *)key withCallback:(Callback)callback {
+    [self->deviceModeManager onIntegrationReady:key withCallback:callback];
+}
+
 @end

--- a/Sources/Classes/RSEventRepository.m
+++ b/Sources/Classes/RSEventRepository.m
@@ -357,8 +357,9 @@ static RSEventRepository* _instance;
     return [self->userSession getSessionId];
 }
 
-- (void) onIntegrationReady:(NSString *)key withCallback:(Callback)callback {
-    [self->deviceModeManager onIntegrationReady:key withCallback:callback];
+- (void) onIntegrationReady:(NSString *)integrationName withCallback:(Callback)callback {
+    [self->deviceModeManager addCallBackForIntegration:integrationName withCallback:callback];
+    [RSLogger logDebug:[[NSString alloc] initWithFormat:@"EventRepository: onIntegrationReady: callback registered for %@", integrationName]];
 }
 
 @end


### PR DESCRIPTION
# Description

- Added `onIntegrationReady` API to get the native instance of the integration SDKs.
- This API needs to be gradually implemented in all the integration SDKs.
