### PR TITLE
chore(ci): add steps to generate xcframework files while releasing the sdk

### DIFF
--- a/.github/workflows/publish-new-release.yml
+++ b/.github/workflows/publish-new-release.yml
@@ -30,7 +30,7 @@ jobs:
         uses: actions/setup-node@v3
         with:
           node-version: 16
-      
+
       # In order to make a commit, we need to initialize a user.
       # You may choose to write something less generic here if you want, it doesn't matter functionality wise.
       - name: Initialize mandatory git config
@@ -47,21 +47,43 @@ jobs:
         run: |
           DEBUG=conventional-github-releaser npx conventional-github-releaser -p angular --config github-release.config.js
 
+      - name: Install xcpretty
+        run: gem install xcpretty
+
+      - name: Install Cocoapods
+        run: gem install cocoapods
+
+      - name: Pod install
+        run: pod install --repo-update
+
+      - name: Generate XCFramework
+        run: |
+          sh ./scripts/generate-xcframework.sh
+
+      - name: Upload Release Artifact
+        run: |
+          zip -r Rudder-xcframeworks.zip xcframeworks
+          shasum -a 256 Rudder-xcframeworks.zip >Rudder-xcframeworks.sha256
+          gh release upload v${{ steps.extract-version.outputs.release_version }} Rudder-xcframeworks.zip
+          gh release upload v${{ steps.extract-version.outputs.release_version }} Rudder-xcframeworks.sha256
+        env:
+          GH_TOKEN: ${{ github.token }}
+
       - name: Create pull request into develop
         uses: repo-sync/pull-request@v2
         with:
-          source_branch: 'master'
-          destination_branch: 'develop'
+          source_branch: "master"
+          destination_branch: "develop"
           github_token: ${{ secrets.PAT }}
           pr_title: "chore(release): pulling master into develop post release v${{ steps.extract-version.outputs.release_version }}"
-          pr_body: ':crown: *An automated PR*'
-          pr_reviewer: 'pallabmaiti'
+          pr_body: ":crown: *An automated PR*"
+          pr_reviewer: "pallabmaiti"
 
       - name: Delete hotfix release branch
         uses: koj-co/delete-merged-action@master
         if: startsWith(github.event.pull_request.head.ref, 'hotfix-release/')
         with:
-          branches: 'hotfix-release/*'
+          branches: "hotfix-release/*"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
@@ -69,6 +91,6 @@ jobs:
         uses: koj-co/delete-merged-action@master
         if: startsWith(github.event.pull_request.head.ref, 'release/')
         with:
-          branches: 'release/*'
+          branches: "release/*"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/publish-new-release.yml
+++ b/.github/workflows/publish-new-release.yml
@@ -67,7 +67,7 @@ jobs:
           gh release upload v${{ steps.extract-version.outputs.release_version }} Rudder-xcframeworks.zip
           gh release upload v${{ steps.extract-version.outputs.release_version }} Rudder-xcframeworks.sha256
         env:
-          GH_TOKEN: ${{ github.token }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Create pull request into develop
         uses: repo-sync/pull-request@v2

--- a/Scripts/generate-xcframework.sh
+++ b/Scripts/generate-xcframework.sh
@@ -1,0 +1,97 @@
+# !/bin/bash -e
+rm -rf archives/
+rm -rf xcframeworks
+
+xcodebuild archive \
+    -workspace Rudder.xcworkspace \
+    -scheme Rudder_iOS \
+    -destination "generic/platform=iOS" \
+    -archivePath "archives/Rudder-iOS" \
+    BUILD_LIBRARY_FOR_DISTRIBUTION=YES \
+    SKIP_INSTALL=NO |
+    xcpretty
+
+xcodebuild archive \
+    -workspace Rudder.xcworkspace \
+    -scheme Rudder_iOS \
+    -destination "generic/platform=iOS Simulator" \
+    -archivePath "archives/Rudder-iOS-simulator" \
+    BUILD_LIBRARY_FOR_DISTRIBUTION=YES \
+    SKIP_INSTALL=NO |
+    xcpretty
+
+xcodebuild archive \
+    -workspace Rudder.xcworkspace \
+    -scheme Rudder_watchOS \
+    -destination "generic/platform=watchOS" \
+    -archivePath "archives/Rudder-watchOS" \
+    BUILD_LIBRARY_FOR_DISTRIBUTION=YES \
+    SKIP_INSTALL=NO |
+    xcpretty
+
+xcodebuild archive \
+    -workspace Rudder.xcworkspace \
+    -scheme Rudder_watchOS \
+    -destination "generic/platform=watchOS Simulator" \
+    -archivePath "archives/Rudder-watchOS-simulator" \
+    BUILD_LIBRARY_FOR_DISTRIBUTION=YES \
+    SKIP_INSTALL=NO |
+    xcpretty
+
+xcodebuild archive \
+    -workspace Rudder.xcworkspace \
+    -scheme Rudder_tvOS \
+    -destination "generic/platform=tvOS" \
+    -archivePath "archives/Rudder-tvOS" \
+    BUILD_LIBRARY_FOR_DISTRIBUTION=YES \
+    SKIP_INSTALL=NO |
+    xcpretty
+
+xcodebuild archive \
+    -workspace Rudder.xcworkspace \
+    -scheme Rudder_tvOS \
+    -destination "generic/platform=tvOS Simulator" \
+    -archivePath "archives/Rudder-tvOS-simulator" \
+    BUILD_LIBRARY_FOR_DISTRIBUTION=YES \
+    SKIP_INSTALL=NO |
+    xcpretty
+
+xcodebuild -create-xcframework \
+    -archive archives/Rudder-iOS.xcarchive -framework Rudder.framework \
+    -archive archives/Rudder-iOS-simulator.xcarchive -framework Rudder.framework \
+    -archive archives/Rudder-watchOS.xcarchive -framework Rudder.framework \
+    -archive archives/Rudder-watchOS-simulator.xcarchive -framework Rudder.framework \
+    -archive archives/Rudder-tvOS.xcarchive -framework Rudder.framework \
+    -archive archives/Rudder-tvOS-simulator.xcarchive -framework Rudder.framework \
+    -output xcframeworks/Rudder.xcframework |
+    xcpretty
+
+xcodebuild -create-xcframework \
+    -archive archives/Rudder-iOS.xcarchive -framework RudderKit.framework \
+    -archive archives/Rudder-iOS-simulator.xcarchive -framework RudderKit.framework \
+    -archive archives/Rudder-watchOS.xcarchive -framework RudderKit.framework \
+    -archive archives/Rudder-watchOS-simulator.xcarchive -framework RudderKit.framework \
+    -archive archives/Rudder-tvOS.xcarchive -framework RudderKit.framework \
+    -archive archives/Rudder-tvOS-simulator.xcarchive -framework RudderKit.framework \
+    -output xcframeworks/RudderKit.xcframework |
+    xcpretty
+
+xcodebuild -create-xcframework \
+    -archive archives/Rudder-iOS.xcarchive -framework RSCrashReporter.framework \
+    -archive archives/Rudder-iOS-simulator.xcarchive -framework RSCrashReporter.framework \
+    -archive archives/Rudder-watchOS.xcarchive -framework RSCrashReporter.framework \
+    -archive archives/Rudder-watchOS-simulator.xcarchive -framework RSCrashReporter.framework \
+    -archive archives/Rudder-tvOS.xcarchive -framework RSCrashReporter.framework \
+    -archive archives/Rudder-tvOS-simulator.xcarchive -framework RSCrashReporter.framework \
+    -output xcframeworks/RSCrashReporter.xcframework |
+    xcpretty
+
+xcodebuild -create-xcframework \
+    -archive archives/Rudder-iOS.xcarchive -framework MetricsReporter.framework \
+    -archive archives/Rudder-iOS-simulator.xcarchive -framework MetricsReporter.framework \
+    -archive archives/Rudder-watchOS.xcarchive -framework MetricsReporter.framework \
+    -archive archives/Rudder-watchOS-simulator.xcarchive -framework MetricsReporter.framework \
+    -archive archives/Rudder-tvOS.xcarchive -framework MetricsReporter.framework \
+    -archive archives/Rudder-tvOS-simulator.xcarchive -framework MetricsReporter.framework \
+    -output xcframeworks/MetricsReporter.xcframework |
+    xcpretty


### PR DESCRIPTION
# Description

> This action will generate XCFrameworks file for iOS-v1 SDK. 

Reference: https://github.com/rudderlabs/rudder-sdk-ios/issues/410.
**NOTE**: iOS-v2 SDK is still in beta. Once we release a stable version, we will implement a similar action.