### PR TITLE
chore(release): pulling release/1.24.2 into master

### DIFF
--- a/.github/workflows/publish-new-release.yml
+++ b/.github/workflows/publish-new-release.yml
@@ -30,7 +30,7 @@ jobs:
         uses: actions/setup-node@v3
         with:
           node-version: 16
-      
+
       # In order to make a commit, we need to initialize a user.
       # You may choose to write something less generic here if you want, it doesn't matter functionality wise.
       - name: Initialize mandatory git config
@@ -47,21 +47,43 @@ jobs:
         run: |
           DEBUG=conventional-github-releaser npx conventional-github-releaser -p angular --config github-release.config.js
 
+      - name: Install xcpretty
+        run: gem install xcpretty
+
+      - name: Install Cocoapods
+        run: gem install cocoapods
+
+      - name: Pod install
+        run: pod install --repo-update
+
+      - name: Generate XCFramework
+        run: |
+          sh ./scripts/generate-xcframework.sh
+
+      - name: Upload Release Artifact
+        run: |
+          zip -r Rudder-xcframeworks.zip xcframeworks
+          shasum -a 256 Rudder-xcframeworks.zip >Rudder-xcframeworks.sha256
+          gh release upload v${{ steps.extract-version.outputs.release_version }} Rudder-xcframeworks.zip
+          gh release upload v${{ steps.extract-version.outputs.release_version }} Rudder-xcframeworks.sha256
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Create pull request into develop
         uses: repo-sync/pull-request@v2
         with:
-          source_branch: 'master'
-          destination_branch: 'develop'
+          source_branch: "master"
+          destination_branch: "develop"
           github_token: ${{ secrets.PAT }}
           pr_title: "chore(release): pulling master into develop post release v${{ steps.extract-version.outputs.release_version }}"
-          pr_body: ':crown: *An automated PR*'
-          pr_reviewer: 'pallabmaiti'
+          pr_body: ":crown: *An automated PR*"
+          pr_reviewer: "pallabmaiti"
 
       - name: Delete hotfix release branch
         uses: koj-co/delete-merged-action@master
         if: startsWith(github.event.pull_request.head.ref, 'hotfix-release/')
         with:
-          branches: 'hotfix-release/*'
+          branches: "hotfix-release/*"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
@@ -69,6 +91,6 @@ jobs:
         uses: koj-co/delete-merged-action@master
         if: startsWith(github.event.pull_request.head.ref, 'release/')
         with:
-          branches: 'release/*'
+          branches: "release/*"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+### [1.24.2](https://github.com/rudderlabs/rudder-sdk-ios/compare/v1.24.1...v1.24.2) (2024-01-03)
+
+
+### Bug Fixes
+
+* updated version of MetricsReporter in package.swift ([#433](https://github.com/rudderlabs/rudder-sdk-ios/issues/433)) ([8870ccd](https://github.com/rudderlabs/rudder-sdk-ios/commit/8870ccd41e3341e75edd8882fa2c12b33283ba9f))
+
 ### [1.24.1](https://github.com/rudderlabs/rudder-sdk-ios/compare/v1.24.0...v1.24.1) (2023-12-20)
 
 ## [1.24.0](https://github.com/rudderlabs/rudder-sdk-ios/compare/v1.23.1...v1.24.0) (2023-12-18)

--- a/Package.swift
+++ b/Package.swift
@@ -14,7 +14,7 @@ let package = Package(
         )
     ],
     dependencies: [
-        .package(name: "MetricsReporter", url: "https://github.com/rudderlabs/metrics-reporter-ios", from: "1.1.0"),
+        .package(name: "MetricsReporter", url: "https://github.com/rudderlabs/metrics-reporter-ios", from: "1.2.1"),
     ],
     targets: [
         .target(

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -1,10 +1,10 @@
 PODS:
-  - MetricsReporter (1.2.0):
+  - MetricsReporter (1.2.1):
     - RSCrashReporter (= 1.0.1)
     - RudderKit (= 1.4.0)
   - RSCrashReporter (1.0.1)
-  - Rudder (1.24.0):
-    - MetricsReporter (= 1.2.0)
+  - Rudder (1.24.1):
+    - MetricsReporter (= 1.2.1)
   - RudderKit (1.4.0)
   - SQLCipher (4.5.4):
     - SQLCipher/standard (= 4.5.4)
@@ -31,9 +31,9 @@ EXTERNAL SOURCES:
     :path: "."
 
 SPEC CHECKSUMS:
-  MetricsReporter: 1b381205a8bcc7ea5413c663cbb438e62078ee11
+  MetricsReporter: 99596ee5003c69949ed2f50acc34aee83c42f843
   RSCrashReporter: 6b8376ac729b0289ebe0908553e5f56d8171f313
-  Rudder: 3e97f9c924c938dd36587a4496a56c3beec286bc
+  Rudder: 8091e861028a12add1107b03d224d4abf08c597f
   RudderKit: d9d6997696e1642b753d8bdf94e57af643a68f03
   SQLCipher: 905b145f65f349f26da9e60a19901ad24adcd381
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 <p align="center">
   <a href="https://cocoapods.org/pods/Rudder">
-    <img src="https://img.shields.io/static/v1?label=pod&message=v1.24.1&color=blue&style=flat">
+    <img src="https://img.shields.io/static/v1?label=pod&message=v1.24.2&color=blue&style=flat">
     </a>
 </p>
 
@@ -39,7 +39,7 @@ The iOS SDK is available through [**CocoaPods**](https://cocoapods.org), [**Cart
 To install the SDK, simply add the following line to your Podfile:
 
 ```xcode
-pod 'Rudder', '1.24.1'
+pod 'Rudder', '1.24.2'
 ```
 
 ### Carthage
@@ -47,7 +47,7 @@ pod 'Rudder', '1.24.1'
 For Carthage support, add the following line to your `Cartfile`:
 
 ```xcode
-github "rudderlabs/rudder-sdk-ios" "v1.24.1"
+github "rudderlabs/rudder-sdk-ios" "v1.24.2"
 ```
 
 > Remember to include the following code in all `.m` and `.h` files where you want to refer to or use the RudderStack SDK classes, as shown:
@@ -71,7 +71,7 @@ You can also add the RudderStack iOS SDK via Swift Package Mangaer, via one of t
 
 * Enter the package repository (`git@github.com:rudderlabs/rudder-sdk-ios.git`) in the search bar.
 
-* In **Dependency Rule**, select **Up to Next Major Version** and enter `1.24.1` as the value, as shown:
+* In **Dependency Rule**, select **Up to Next Major Version** and enter `1.24.2` as the value, as shown:
 
 ![Setting dependency](https://user-images.githubusercontent.com/59817155/145574696-8c849749-13e0-40d5-aacb-3fccb5c8e67d.png)
 
@@ -99,7 +99,7 @@ let package = Package(
     ],
     dependencies: [
         // Dependencies declare other packages that this package depends on.
-        .package(url: "git@github.com:rudderlabs/rudder-sdk-ios.git", from: "1.24.1")
+        .package(url: "git@github.com:rudderlabs/rudder-sdk-ios.git", from: "1.24.2")
     ],
     targets: [
         // Targets are the basic building blocks of a package. A target can define a module or a test suite.

--- a/Rudder.podspec
+++ b/Rudder.podspec
@@ -25,5 +25,5 @@ Pod::Spec.new do |s|
   
   s.source_files = 'Sources/**/*.{h,m}'
   
-  s.dependency 'MetricsReporter', '1.2.0'
+  s.dependency 'MetricsReporter', '1.2.1'
 end

--- a/Rudder.xcodeproj/project.pbxproj
+++ b/Rudder.xcodeproj/project.pbxproj
@@ -9,12 +9,11 @@
 /* Begin PBXBuildFile section */
 		06CABC332630C6B00097BEFF /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 06CABC322630C6B00097BEFF /* Foundation.framework */; };
 		06CABC352630C6D30097BEFF /* UIKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 06CABC2E2630C6660097BEFF /* UIKit.framework */; };
-		1F50A488B9B92CC3704F4C40 /* Pods_RudderTests_iOS.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = EB9D70F3AC003ABFE2052DF7 /* Pods_RudderTests_iOS.framework */; };
-		3B5FAE1B902A41D59C046079 /* Pods_Rudder_watchOS.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 50E828ED6F79396B6A0A25CE /* Pods_Rudder_watchOS.framework */; };
-		3C365299A0F64CFA4803E693 /* Pods_RudderTests_tvOS.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 245002D6A7EAAC3F90D1ADB2 /* Pods_RudderTests_tvOS.framework */; };
-		4840948549942522676F882D /* Pods_Rudder_iOS.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 84978807F97D0C792B0F0ACD /* Pods_Rudder_iOS.framework */; };
-		7738827C8930CAE892D2B6EF /* Pods_Rudder_tvOS.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 9417AFF20BEB561083EA8B71 /* Pods_Rudder_tvOS.framework */; };
-		CF497817BA9306D93A15506D /* Pods_RudderTests_watchOS.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = DDD0A398D686AF248E1979D3 /* Pods_RudderTests_watchOS.framework */; };
+		238487371079D14D0B098555 /* Pods_RudderTests_tvOS.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = A8ACE1A679CAD30B58E39A88 /* Pods_RudderTests_tvOS.framework */; };
+		431F0AE2E4A192AE78D34326 /* Pods_RudderTests_iOS.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = E491712EDB73E1E33A1C1129 /* Pods_RudderTests_iOS.framework */; };
+		9C58FA70616A3762BE1FBE9B /* Pods_Rudder_iOS.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = ED1B2AD2F9D4E0F26745091B /* Pods_Rudder_iOS.framework */; };
+		9FEE83571C0E25C88369FE41 /* Pods_RudderTests_watchOS.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 9FFA1BAA6275D5530AC912B3 /* Pods_RudderTests_watchOS.framework */; };
+		BF320707E73393A5EC3DB72B /* Pods_Rudder_watchOS.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 0AB3A24BE91BE2AEE0CA3FF1 /* Pods_Rudder_watchOS.framework */; };
 		ED0CA6EA2A7D08B900899C1C /* RSTransformationEvent.h in Headers */ = {isa = PBXBuildFile; fileRef = F6F2FA752A53D8310025D510 /* RSTransformationEvent.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		ED0CA6EB2A7D08B900899C1C /* RSTransformationEvent.h in Headers */ = {isa = PBXBuildFile; fileRef = F6F2FA752A53D8310025D510 /* RSTransformationEvent.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		ED0CA6EC2A7D08D800899C1C /* RSTransformationRequest.h in Headers */ = {isa = PBXBuildFile; fileRef = F6F2FA732A53CD9F0025D510 /* RSTransformationRequest.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -716,6 +715,7 @@
 		F6F2FA782A53D8520025D510 /* RSTransformationEvent.m in Sources */ = {isa = PBXBuildFile; fileRef = F6F2FA772A53D8520025D510 /* RSTransformationEvent.m */; };
 		F6F2FA7A2A53D8BF0025D510 /* RSTransformationMetadata.h in Headers */ = {isa = PBXBuildFile; fileRef = F6F2FA792A53D8BF0025D510 /* RSTransformationMetadata.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		F6F2FA7C2A53D8E50025D510 /* RSTransformationMetadata.m in Sources */ = {isa = PBXBuildFile; fileRef = F6F2FA7B2A53D8E50025D510 /* RSTransformationMetadata.m */; };
+		F7A8C3320A3B92B920A6B7EF /* Pods_Rudder_tvOS.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 93E378BE7E662EC3466AD22C /* Pods_Rudder_tvOS.framework */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -743,27 +743,28 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		047016191610999BB5D6639D /* Pods-RudderTests-iOS.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-RudderTests-iOS.debug.xcconfig"; path = "Target Support Files/Pods-RudderTests-iOS/Pods-RudderTests-iOS.debug.xcconfig"; sourceTree = "<group>"; };
 		06CABB842630C3CA0097BEFF /* Rudder.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Rudder.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		06CABC2E2630C6660097BEFF /* UIKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = UIKit.framework; path = Platforms/MacOSX.platform/Developer/SDKs/MacOSX11.1.sdk/System/iOSSupport/System/Library/Frameworks/UIKit.framework; sourceTree = DEVELOPER_DIR; };
 		06CABC322630C6B00097BEFF /* Foundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Foundation.framework; path = Platforms/MacOSX.platform/Developer/SDKs/MacOSX11.1.sdk/System/Library/Frameworks/Foundation.framework; sourceTree = DEVELOPER_DIR; };
-		202611FE2AF7BF1EDBA7E08A /* Pods-RudderTests-iOS.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-RudderTests-iOS.release.xcconfig"; path = "Target Support Files/Pods-RudderTests-iOS/Pods-RudderTests-iOS.release.xcconfig"; sourceTree = "<group>"; };
-		245002D6A7EAAC3F90D1ADB2 /* Pods_RudderTests_tvOS.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_RudderTests_tvOS.framework; sourceTree = BUILT_PRODUCTS_DIR; };
-		2CFB58F208FAEF82CA95FACA /* Pods-RudderTests-tvOS.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-RudderTests-tvOS.debug.xcconfig"; path = "Target Support Files/Pods-RudderTests-tvOS/Pods-RudderTests-tvOS.debug.xcconfig"; sourceTree = "<group>"; };
-		325600378F6A3EC65FF9DDF3 /* Pods-Rudder-tvOS.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Rudder-tvOS.debug.xcconfig"; path = "Target Support Files/Pods-Rudder-tvOS/Pods-Rudder-tvOS.debug.xcconfig"; sourceTree = "<group>"; };
-		47B85BDA1B3670107E452D42 /* Pods-Rudder-tvOS.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Rudder-tvOS.release.xcconfig"; path = "Target Support Files/Pods-Rudder-tvOS/Pods-Rudder-tvOS.release.xcconfig"; sourceTree = "<group>"; };
-		50E828ED6F79396B6A0A25CE /* Pods_Rudder_watchOS.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_Rudder_watchOS.framework; sourceTree = BUILT_PRODUCTS_DIR; };
-		7CC13D65B53713329A2D6C91 /* Pods-Rudder-iOS.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Rudder-iOS.debug.xcconfig"; path = "Target Support Files/Pods-Rudder-iOS/Pods-Rudder-iOS.debug.xcconfig"; sourceTree = "<group>"; };
-		84978807F97D0C792B0F0ACD /* Pods_Rudder_iOS.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_Rudder_iOS.framework; sourceTree = BUILT_PRODUCTS_DIR; };
-		9417AFF20BEB561083EA8B71 /* Pods_Rudder_tvOS.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_Rudder_tvOS.framework; sourceTree = BUILT_PRODUCTS_DIR; };
-		AF620050253AC84EEA724B3F /* Pods-RudderTests-watchOS.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-RudderTests-watchOS.release.xcconfig"; path = "Target Support Files/Pods-RudderTests-watchOS/Pods-RudderTests-watchOS.release.xcconfig"; sourceTree = "<group>"; };
-		B8E2E66494A95FD566A1095C /* Pods-RudderTests-watchOS.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-RudderTests-watchOS.debug.xcconfig"; path = "Target Support Files/Pods-RudderTests-watchOS/Pods-RudderTests-watchOS.debug.xcconfig"; sourceTree = "<group>"; };
-		CE2EA5CE6F129587E332A397 /* Pods-Rudder-iOS.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Rudder-iOS.release.xcconfig"; path = "Target Support Files/Pods-Rudder-iOS/Pods-Rudder-iOS.release.xcconfig"; sourceTree = "<group>"; };
-		CF210219D8B4C73F6A238C2D /* Pods-RudderTests-tvOS.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-RudderTests-tvOS.release.xcconfig"; path = "Target Support Files/Pods-RudderTests-tvOS/Pods-RudderTests-tvOS.release.xcconfig"; sourceTree = "<group>"; };
-		DDD0A398D686AF248E1979D3 /* Pods_RudderTests_watchOS.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_RudderTests_watchOS.framework; sourceTree = BUILT_PRODUCTS_DIR; };
-		E0B734BD9F7523CBA4625D36 /* Pods-Rudder-watchOS.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Rudder-watchOS.release.xcconfig"; path = "Target Support Files/Pods-Rudder-watchOS/Pods-Rudder-watchOS.release.xcconfig"; sourceTree = "<group>"; };
-		EB9D70F3AC003ABFE2052DF7 /* Pods_RudderTests_iOS.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_RudderTests_iOS.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		0AB3A24BE91BE2AEE0CA3FF1 /* Pods_Rudder_watchOS.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_Rudder_watchOS.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		0C12A2068DA24653A547FFC5 /* Pods-RudderTests-watchOS.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-RudderTests-watchOS.release.xcconfig"; path = "Target Support Files/Pods-RudderTests-watchOS/Pods-RudderTests-watchOS.release.xcconfig"; sourceTree = "<group>"; };
+		46E7849777925491E280B136 /* Pods-RudderTests-tvOS.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-RudderTests-tvOS.release.xcconfig"; path = "Target Support Files/Pods-RudderTests-tvOS/Pods-RudderTests-tvOS.release.xcconfig"; sourceTree = "<group>"; };
+		594C68EBA69B23ED13FCDF7D /* Pods-RudderTests-watchOS.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-RudderTests-watchOS.debug.xcconfig"; path = "Target Support Files/Pods-RudderTests-watchOS/Pods-RudderTests-watchOS.debug.xcconfig"; sourceTree = "<group>"; };
+		62E2A1E694983F13BA03EB9D /* Pods-Rudder-iOS.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Rudder-iOS.release.xcconfig"; path = "Target Support Files/Pods-Rudder-iOS/Pods-Rudder-iOS.release.xcconfig"; sourceTree = "<group>"; };
+		6725E430849222D61D5E0234 /* Pods-Rudder-tvOS.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Rudder-tvOS.debug.xcconfig"; path = "Target Support Files/Pods-Rudder-tvOS/Pods-Rudder-tvOS.debug.xcconfig"; sourceTree = "<group>"; };
+		67B6FB354D9492FE1F10F098 /* Pods-RudderTests-tvOS.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-RudderTests-tvOS.debug.xcconfig"; path = "Target Support Files/Pods-RudderTests-tvOS/Pods-RudderTests-tvOS.debug.xcconfig"; sourceTree = "<group>"; };
+		696BB56E6F38B30EA9E87E59 /* Pods-RudderTests-iOS.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-RudderTests-iOS.release.xcconfig"; path = "Target Support Files/Pods-RudderTests-iOS/Pods-RudderTests-iOS.release.xcconfig"; sourceTree = "<group>"; };
+		6B7B1FD50E9D829FF642DF10 /* Pods-Rudder-tvOS.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Rudder-tvOS.release.xcconfig"; path = "Target Support Files/Pods-Rudder-tvOS/Pods-Rudder-tvOS.release.xcconfig"; sourceTree = "<group>"; };
+		93E378BE7E662EC3466AD22C /* Pods_Rudder_tvOS.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_Rudder_tvOS.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		9FFA1BAA6275D5530AC912B3 /* Pods_RudderTests_watchOS.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_RudderTests_watchOS.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		A1322AEF7B87457F0BB3A90F /* Pods-Rudder-watchOS.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Rudder-watchOS.debug.xcconfig"; path = "Target Support Files/Pods-Rudder-watchOS/Pods-Rudder-watchOS.debug.xcconfig"; sourceTree = "<group>"; };
+		A8923DB47023C19C14199A71 /* Pods-Rudder-iOS.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Rudder-iOS.debug.xcconfig"; path = "Target Support Files/Pods-Rudder-iOS/Pods-Rudder-iOS.debug.xcconfig"; sourceTree = "<group>"; };
+		A8ACE1A679CAD30B58E39A88 /* Pods_RudderTests_tvOS.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_RudderTests_tvOS.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		E491712EDB73E1E33A1C1129 /* Pods_RudderTests_iOS.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_RudderTests_iOS.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		ED04A2482986C1750080A88D /* xccov-to-generic.sh */ = {isa = PBXFileReference; lastKnownFileType = text.script.sh; path = "xccov-to-generic.sh"; sourceTree = "<group>"; };
 		ED056314291AABFD00BAEE65 /* sonar-project.properties */ = {isa = PBXFileReference; lastKnownFileType = text; path = "sonar-project.properties"; sourceTree = "<group>"; };
+		ED1B2AD2F9D4E0F26745091B /* Pods_Rudder_iOS.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_Rudder_iOS.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		ED1C4C8829E6CCC7007007C9 /* find-tag.sh */ = {isa = PBXFileReference; lastKnownFileType = text.script.sh; path = "find-tag.sh"; sourceTree = "<group>"; };
 		ED252CF52AA8780600B17ACF /* UserSessionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserSessionTests.swift; sourceTree = "<group>"; };
 		ED38D36C29CB01A0003A7544 /* DataResidencyTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DataResidencyTests.swift; sourceTree = "<group>"; };
@@ -1019,8 +1020,7 @@
 		F6F2FA772A53D8520025D510 /* RSTransformationEvent.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = RSTransformationEvent.m; sourceTree = "<group>"; };
 		F6F2FA792A53D8BF0025D510 /* RSTransformationMetadata.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = RSTransformationMetadata.h; sourceTree = "<group>"; };
 		F6F2FA7B2A53D8E50025D510 /* RSTransformationMetadata.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = RSTransformationMetadata.m; sourceTree = "<group>"; };
-		F7206A8B7B5CF4E4FC9CA683 /* Pods-Rudder-watchOS.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Rudder-watchOS.debug.xcconfig"; path = "Target Support Files/Pods-Rudder-watchOS/Pods-Rudder-watchOS.debug.xcconfig"; sourceTree = "<group>"; };
-		F785CBDD3425ADC4AD1D5121 /* Pods-RudderTests-iOS.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-RudderTests-iOS.debug.xcconfig"; path = "Target Support Files/Pods-RudderTests-iOS/Pods-RudderTests-iOS.debug.xcconfig"; sourceTree = "<group>"; };
+		F8F5D21AB948C5691AD2ADA9 /* Pods-Rudder-watchOS.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Rudder-watchOS.release.xcconfig"; path = "Target Support Files/Pods-Rudder-watchOS/Pods-Rudder-watchOS.release.xcconfig"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -1031,7 +1031,7 @@
 				06CABC332630C6B00097BEFF /* Foundation.framework in Frameworks */,
 				06CABC352630C6D30097BEFF /* UIKit.framework in Frameworks */,
 				EDEF1B312A835A90002B3E57 /* Security.framework in Frameworks */,
-				4840948549942522676F882D /* Pods_Rudder_iOS.framework in Frameworks */,
+				9C58FA70616A3762BE1FBE9B /* Pods_Rudder_iOS.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1041,7 +1041,7 @@
 			files = (
 				ED998F0F2A69003600031B06 /* Foundation.framework in Frameworks */,
 				ED998F102A69003600031B06 /* UIKit.framework in Frameworks */,
-				7738827C8930CAE892D2B6EF /* Pods_Rudder_tvOS.framework in Frameworks */,
+				F7A8C3320A3B92B920A6B7EF /* Pods_Rudder_tvOS.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1051,7 +1051,7 @@
 			files = (
 				ED998FDF2A69024E00031B06 /* Foundation.framework in Frameworks */,
 				ED998FE02A69024E00031B06 /* UIKit.framework in Frameworks */,
-				3B5FAE1B902A41D59C046079 /* Pods_Rudder_watchOS.framework in Frameworks */,
+				BF320707E73393A5EC3DB72B /* Pods_Rudder_watchOS.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1060,7 +1060,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				ED9990312A69102400031B06 /* Rudder.framework in Frameworks */,
-				3C365299A0F64CFA4803E693 /* Pods_RudderTests_tvOS.framework in Frameworks */,
+				238487371079D14D0B098555 /* Pods_RudderTests_tvOS.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1069,7 +1069,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				ED99903F2A69103B00031B06 /* Rudder.framework in Frameworks */,
-				1F50A488B9B92CC3704F4C40 /* Pods_RudderTests_iOS.framework in Frameworks */,
+				431F0AE2E4A192AE78D34326 /* Pods_RudderTests_iOS.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1078,7 +1078,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				ED99904D2A69104B00031B06 /* Rudder.framework in Frameworks */,
-				CF497817BA9306D93A15506D /* Pods_RudderTests_watchOS.framework in Frameworks */,
+				9FEE83571C0E25C88369FE41 /* Pods_RudderTests_watchOS.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1116,12 +1116,12 @@
 				EDEF1B302A835A90002B3E57 /* Security.framework */,
 				06CABC322630C6B00097BEFF /* Foundation.framework */,
 				06CABC2E2630C6660097BEFF /* UIKit.framework */,
-				84978807F97D0C792B0F0ACD /* Pods_Rudder_iOS.framework */,
-				9417AFF20BEB561083EA8B71 /* Pods_Rudder_tvOS.framework */,
-				50E828ED6F79396B6A0A25CE /* Pods_Rudder_watchOS.framework */,
-				EB9D70F3AC003ABFE2052DF7 /* Pods_RudderTests_iOS.framework */,
-				245002D6A7EAAC3F90D1ADB2 /* Pods_RudderTests_tvOS.framework */,
-				DDD0A398D686AF248E1979D3 /* Pods_RudderTests_watchOS.framework */,
+				ED1B2AD2F9D4E0F26745091B /* Pods_Rudder_iOS.framework */,
+				93E378BE7E662EC3466AD22C /* Pods_Rudder_tvOS.framework */,
+				0AB3A24BE91BE2AEE0CA3FF1 /* Pods_Rudder_watchOS.framework */,
+				E491712EDB73E1E33A1C1129 /* Pods_RudderTests_iOS.framework */,
+				A8ACE1A679CAD30B58E39A88 /* Pods_RudderTests_tvOS.framework */,
+				9FFA1BAA6275D5530AC912B3 /* Pods_RudderTests_watchOS.framework */,
 			);
 			name = Frameworks;
 			sourceTree = "<group>";
@@ -1129,18 +1129,18 @@
 		DFB2363B6EC8D146934DE8DD /* Pods */ = {
 			isa = PBXGroup;
 			children = (
-				7CC13D65B53713329A2D6C91 /* Pods-Rudder-iOS.debug.xcconfig */,
-				CE2EA5CE6F129587E332A397 /* Pods-Rudder-iOS.release.xcconfig */,
-				325600378F6A3EC65FF9DDF3 /* Pods-Rudder-tvOS.debug.xcconfig */,
-				47B85BDA1B3670107E452D42 /* Pods-Rudder-tvOS.release.xcconfig */,
-				F7206A8B7B5CF4E4FC9CA683 /* Pods-Rudder-watchOS.debug.xcconfig */,
-				E0B734BD9F7523CBA4625D36 /* Pods-Rudder-watchOS.release.xcconfig */,
-				F785CBDD3425ADC4AD1D5121 /* Pods-RudderTests-iOS.debug.xcconfig */,
-				202611FE2AF7BF1EDBA7E08A /* Pods-RudderTests-iOS.release.xcconfig */,
-				2CFB58F208FAEF82CA95FACA /* Pods-RudderTests-tvOS.debug.xcconfig */,
-				CF210219D8B4C73F6A238C2D /* Pods-RudderTests-tvOS.release.xcconfig */,
-				B8E2E66494A95FD566A1095C /* Pods-RudderTests-watchOS.debug.xcconfig */,
-				AF620050253AC84EEA724B3F /* Pods-RudderTests-watchOS.release.xcconfig */,
+				A8923DB47023C19C14199A71 /* Pods-Rudder-iOS.debug.xcconfig */,
+				62E2A1E694983F13BA03EB9D /* Pods-Rudder-iOS.release.xcconfig */,
+				6725E430849222D61D5E0234 /* Pods-Rudder-tvOS.debug.xcconfig */,
+				6B7B1FD50E9D829FF642DF10 /* Pods-Rudder-tvOS.release.xcconfig */,
+				A1322AEF7B87457F0BB3A90F /* Pods-Rudder-watchOS.debug.xcconfig */,
+				F8F5D21AB948C5691AD2ADA9 /* Pods-Rudder-watchOS.release.xcconfig */,
+				047016191610999BB5D6639D /* Pods-RudderTests-iOS.debug.xcconfig */,
+				696BB56E6F38B30EA9E87E59 /* Pods-RudderTests-iOS.release.xcconfig */,
+				67B6FB354D9492FE1F10F098 /* Pods-RudderTests-tvOS.debug.xcconfig */,
+				46E7849777925491E280B136 /* Pods-RudderTests-tvOS.release.xcconfig */,
+				594C68EBA69B23ED13FCDF7D /* Pods-RudderTests-watchOS.debug.xcconfig */,
+				0C12A2068DA24653A547FFC5 /* Pods-RudderTests-watchOS.release.xcconfig */,
 			);
 			path = Pods;
 			sourceTree = "<group>";
@@ -1858,7 +1858,7 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = 06CABB982630C3CA0097BEFF /* Build configuration list for PBXNativeTarget "Rudder-iOS" */;
 			buildPhases = (
-				913FC60B77A1BE3829790B91 /* [CP] Check Pods Manifest.lock */,
+				AFEA49832884FFAB57FDF230 /* [CP] Check Pods Manifest.lock */,
 				06CABB7F2630C3CA0097BEFF /* Headers */,
 				06CABB802630C3CA0097BEFF /* Sources */,
 				06CABB812630C3CA0097BEFF /* Frameworks */,
@@ -1877,7 +1877,7 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = ED998F122A69003600031B06 /* Build configuration list for PBXNativeTarget "Rudder-tvOS" */;
 			buildPhases = (
-				EAB85CE241B127993EDEC199 /* [CP] Check Pods Manifest.lock */,
+				3D29E465A99831E1830BA50E /* [CP] Check Pods Manifest.lock */,
 				ED998E482A69003600031B06 /* Headers */,
 				ED998EAE2A69003600031B06 /* Sources */,
 				ED998F0E2A69003600031B06 /* Frameworks */,
@@ -1896,7 +1896,7 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = ED998FE22A69024E00031B06 /* Build configuration list for PBXNativeTarget "Rudder-watchOS" */;
 			buildPhases = (
-				C50A689DFD4D0DB9D840BB99 /* [CP] Check Pods Manifest.lock */,
+				FA646B8CEFE5AE97B9FF54B7 /* [CP] Check Pods Manifest.lock */,
 				ED998F182A69024E00031B06 /* Headers */,
 				ED998F7E2A69024E00031B06 /* Sources */,
 				ED998FDE2A69024E00031B06 /* Frameworks */,
@@ -1915,11 +1915,11 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = ED9990342A69102400031B06 /* Build configuration list for PBXNativeTarget "RudderTests-tvOS" */;
 			buildPhases = (
-				AD932E732BF96E5D01C195DD /* [CP] Check Pods Manifest.lock */,
+				7BD8C108C1E023AEC53DA6B9 /* [CP] Check Pods Manifest.lock */,
 				ED9990292A69102400031B06 /* Sources */,
 				ED99902A2A69102400031B06 /* Frameworks */,
 				ED99902B2A69102400031B06 /* Resources */,
-				1B744A963D5F5AB560FFD0B7 /* [CP] Embed Pods Frameworks */,
+				D500A6672225011FA2D992BA /* [CP] Embed Pods Frameworks */,
 			);
 			buildRules = (
 			);
@@ -1935,11 +1935,11 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = ED9990422A69103B00031B06 /* Build configuration list for PBXNativeTarget "RudderTests-iOS" */;
 			buildPhases = (
-				061EEF4A8CACAB7DA9F03931 /* [CP] Check Pods Manifest.lock */,
+				ECDDBE7C2C4DEAE0E3739C04 /* [CP] Check Pods Manifest.lock */,
 				ED9990372A69103A00031B06 /* Sources */,
 				ED9990382A69103A00031B06 /* Frameworks */,
 				ED9990392A69103A00031B06 /* Resources */,
-				A1E35BB522C15750C05A87DB /* [CP] Embed Pods Frameworks */,
+				2DD0BFC71FCF57B2030F35F0 /* [CP] Embed Pods Frameworks */,
 			);
 			buildRules = (
 			);
@@ -1955,11 +1955,11 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = ED9990502A69104B00031B06 /* Build configuration list for PBXNativeTarget "RudderTests-watchOS" */;
 			buildPhases = (
-				BE749B8B2FA526428984F830 /* [CP] Check Pods Manifest.lock */,
+				410B5B108347EF9C66CDB8CA /* [CP] Check Pods Manifest.lock */,
 				ED9990452A69104B00031B06 /* Sources */,
 				ED9990462A69104B00031B06 /* Frameworks */,
 				ED9990472A69104B00031B06 /* Resources */,
-				1B649AF4E7584B4AA843F811 /* [CP] Embed Pods Frameworks */,
+				4C1BBEB758DC89CDF90C677E /* [CP] Embed Pods Frameworks */,
 			);
 			buildRules = (
 			);
@@ -2097,85 +2097,7 @@
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXShellScriptBuildPhase section */
-		061EEF4A8CACAB7DA9F03931 /* [CP] Check Pods Manifest.lock */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputFileListPaths = (
-			);
-			inputPaths = (
-				"${PODS_PODFILE_DIR_PATH}/Podfile.lock",
-				"${PODS_ROOT}/Manifest.lock",
-			);
-			name = "[CP] Check Pods Manifest.lock";
-			outputFileListPaths = (
-			);
-			outputPaths = (
-				"$(DERIVED_FILE_DIR)/Pods-RudderTests-iOS-checkManifestLockResult.txt",
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
-			showEnvVarsInLog = 0;
-		};
-		1B649AF4E7584B4AA843F811 /* [CP] Embed Pods Frameworks */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputFileListPaths = (
-				"${PODS_ROOT}/Target Support Files/Pods-RudderTests-watchOS/Pods-RudderTests-watchOS-frameworks-${CONFIGURATION}-input-files.xcfilelist",
-			);
-			name = "[CP] Embed Pods Frameworks";
-			outputFileListPaths = (
-				"${PODS_ROOT}/Target Support Files/Pods-RudderTests-watchOS/Pods-RudderTests-watchOS-frameworks-${CONFIGURATION}-output-files.xcfilelist",
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-RudderTests-watchOS/Pods-RudderTests-watchOS-frameworks.sh\"\n";
-			showEnvVarsInLog = 0;
-		};
-		1B744A963D5F5AB560FFD0B7 /* [CP] Embed Pods Frameworks */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputFileListPaths = (
-				"${PODS_ROOT}/Target Support Files/Pods-RudderTests-tvOS/Pods-RudderTests-tvOS-frameworks-${CONFIGURATION}-input-files.xcfilelist",
-			);
-			name = "[CP] Embed Pods Frameworks";
-			outputFileListPaths = (
-				"${PODS_ROOT}/Target Support Files/Pods-RudderTests-tvOS/Pods-RudderTests-tvOS-frameworks-${CONFIGURATION}-output-files.xcfilelist",
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-RudderTests-tvOS/Pods-RudderTests-tvOS-frameworks.sh\"\n";
-			showEnvVarsInLog = 0;
-		};
-		913FC60B77A1BE3829790B91 /* [CP] Check Pods Manifest.lock */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputFileListPaths = (
-			);
-			inputPaths = (
-				"${PODS_PODFILE_DIR_PATH}/Podfile.lock",
-				"${PODS_ROOT}/Manifest.lock",
-			);
-			name = "[CP] Check Pods Manifest.lock";
-			outputFileListPaths = (
-			);
-			outputPaths = (
-				"$(DERIVED_FILE_DIR)/Pods-Rudder-iOS-checkManifestLockResult.txt",
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
-			showEnvVarsInLog = 0;
-		};
-		A1E35BB522C15750C05A87DB /* [CP] Embed Pods Frameworks */ = {
+		2DD0BFC71FCF57B2030F35F0 /* [CP] Embed Pods Frameworks */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -2192,7 +2114,7 @@
 			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-RudderTests-iOS/Pods-RudderTests-iOS-frameworks.sh\"\n";
 			showEnvVarsInLog = 0;
 		};
-		AD932E732BF96E5D01C195DD /* [CP] Check Pods Manifest.lock */ = {
+		3D29E465A99831E1830BA50E /* [CP] Check Pods Manifest.lock */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -2207,14 +2129,14 @@
 			outputFileListPaths = (
 			);
 			outputPaths = (
-				"$(DERIVED_FILE_DIR)/Pods-RudderTests-tvOS-checkManifestLockResult.txt",
+				"$(DERIVED_FILE_DIR)/Pods-Rudder-tvOS-checkManifestLockResult.txt",
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
 			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
 			showEnvVarsInLog = 0;
 		};
-		BE749B8B2FA526428984F830 /* [CP] Check Pods Manifest.lock */ = {
+		410B5B108347EF9C66CDB8CA /* [CP] Check Pods Manifest.lock */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -2236,7 +2158,107 @@
 			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
 			showEnvVarsInLog = 0;
 		};
-		C50A689DFD4D0DB9D840BB99 /* [CP] Check Pods Manifest.lock */ = {
+		4C1BBEB758DC89CDF90C677E /* [CP] Embed Pods Frameworks */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-RudderTests-watchOS/Pods-RudderTests-watchOS-frameworks-${CONFIGURATION}-input-files.xcfilelist",
+			);
+			name = "[CP] Embed Pods Frameworks";
+			outputFileListPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-RudderTests-watchOS/Pods-RudderTests-watchOS-frameworks-${CONFIGURATION}-output-files.xcfilelist",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-RudderTests-watchOS/Pods-RudderTests-watchOS-frameworks.sh\"\n";
+			showEnvVarsInLog = 0;
+		};
+		7BD8C108C1E023AEC53DA6B9 /* [CP] Check Pods Manifest.lock */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+				"${PODS_PODFILE_DIR_PATH}/Podfile.lock",
+				"${PODS_ROOT}/Manifest.lock",
+			);
+			name = "[CP] Check Pods Manifest.lock";
+			outputFileListPaths = (
+			);
+			outputPaths = (
+				"$(DERIVED_FILE_DIR)/Pods-RudderTests-tvOS-checkManifestLockResult.txt",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
+			showEnvVarsInLog = 0;
+		};
+		AFEA49832884FFAB57FDF230 /* [CP] Check Pods Manifest.lock */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+				"${PODS_PODFILE_DIR_PATH}/Podfile.lock",
+				"${PODS_ROOT}/Manifest.lock",
+			);
+			name = "[CP] Check Pods Manifest.lock";
+			outputFileListPaths = (
+			);
+			outputPaths = (
+				"$(DERIVED_FILE_DIR)/Pods-Rudder-iOS-checkManifestLockResult.txt",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
+			showEnvVarsInLog = 0;
+		};
+		D500A6672225011FA2D992BA /* [CP] Embed Pods Frameworks */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-RudderTests-tvOS/Pods-RudderTests-tvOS-frameworks-${CONFIGURATION}-input-files.xcfilelist",
+			);
+			name = "[CP] Embed Pods Frameworks";
+			outputFileListPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-RudderTests-tvOS/Pods-RudderTests-tvOS-frameworks-${CONFIGURATION}-output-files.xcfilelist",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-RudderTests-tvOS/Pods-RudderTests-tvOS-frameworks.sh\"\n";
+			showEnvVarsInLog = 0;
+		};
+		ECDDBE7C2C4DEAE0E3739C04 /* [CP] Check Pods Manifest.lock */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+				"${PODS_PODFILE_DIR_PATH}/Podfile.lock",
+				"${PODS_ROOT}/Manifest.lock",
+			);
+			name = "[CP] Check Pods Manifest.lock";
+			outputFileListPaths = (
+			);
+			outputPaths = (
+				"$(DERIVED_FILE_DIR)/Pods-RudderTests-iOS-checkManifestLockResult.txt",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
+			showEnvVarsInLog = 0;
+		};
+		FA646B8CEFE5AE97B9FF54B7 /* [CP] Check Pods Manifest.lock */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -2252,28 +2274,6 @@
 			);
 			outputPaths = (
 				"$(DERIVED_FILE_DIR)/Pods-Rudder-watchOS-checkManifestLockResult.txt",
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
-			showEnvVarsInLog = 0;
-		};
-		EAB85CE241B127993EDEC199 /* [CP] Check Pods Manifest.lock */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputFileListPaths = (
-			);
-			inputPaths = (
-				"${PODS_PODFILE_DIR_PATH}/Podfile.lock",
-				"${PODS_ROOT}/Manifest.lock",
-			);
-			name = "[CP] Check Pods Manifest.lock";
-			outputFileListPaths = (
-			);
-			outputPaths = (
-				"$(DERIVED_FILE_DIR)/Pods-Rudder-tvOS-checkManifestLockResult.txt",
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
@@ -2809,7 +2809,7 @@
 		};
 		06CABB992630C3CA0097BEFF /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 7CC13D65B53713329A2D6C91 /* Pods-Rudder-iOS.debug.xcconfig */;
+			baseConfigurationReference = A8923DB47023C19C14199A71 /* Pods-Rudder-iOS.debug.xcconfig */;
 			buildSettings = {
 				ALLOW_TARGET_PLATFORM_SPECIALIZATION = YES;
 				APPLICATION_EXTENSION_API_ONLY = NO;
@@ -2854,7 +2854,7 @@
 		};
 		06CABB9A2630C3CA0097BEFF /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = CE2EA5CE6F129587E332A397 /* Pods-Rudder-iOS.release.xcconfig */;
+			baseConfigurationReference = 62E2A1E694983F13BA03EB9D /* Pods-Rudder-iOS.release.xcconfig */;
 			buildSettings = {
 				ALLOW_TARGET_PLATFORM_SPECIALIZATION = YES;
 				APPLICATION_EXTENSION_API_ONLY = NO;
@@ -2898,7 +2898,7 @@
 		};
 		ED998F132A69003600031B06 /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 325600378F6A3EC65FF9DDF3 /* Pods-Rudder-tvOS.debug.xcconfig */;
+			baseConfigurationReference = 6725E430849222D61D5E0234 /* Pods-Rudder-tvOS.debug.xcconfig */;
 			buildSettings = {
 				ALLOW_TARGET_PLATFORM_SPECIALIZATION = YES;
 				APPLICATION_EXTENSION_API_ONLY = NO;
@@ -2943,7 +2943,7 @@
 		};
 		ED998F142A69003600031B06 /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 47B85BDA1B3670107E452D42 /* Pods-Rudder-tvOS.release.xcconfig */;
+			baseConfigurationReference = 6B7B1FD50E9D829FF642DF10 /* Pods-Rudder-tvOS.release.xcconfig */;
 			buildSettings = {
 				ALLOW_TARGET_PLATFORM_SPECIALIZATION = YES;
 				APPLICATION_EXTENSION_API_ONLY = NO;
@@ -2987,7 +2987,7 @@
 		};
 		ED998FE32A69024E00031B06 /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = F7206A8B7B5CF4E4FC9CA683 /* Pods-Rudder-watchOS.debug.xcconfig */;
+			baseConfigurationReference = A1322AEF7B87457F0BB3A90F /* Pods-Rudder-watchOS.debug.xcconfig */;
 			buildSettings = {
 				ALLOW_TARGET_PLATFORM_SPECIALIZATION = YES;
 				APPLICATION_EXTENSION_API_ONLY = NO;
@@ -3032,7 +3032,7 @@
 		};
 		ED998FE42A69024E00031B06 /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = E0B734BD9F7523CBA4625D36 /* Pods-Rudder-watchOS.release.xcconfig */;
+			baseConfigurationReference = F8F5D21AB948C5691AD2ADA9 /* Pods-Rudder-watchOS.release.xcconfig */;
 			buildSettings = {
 				ALLOW_TARGET_PLATFORM_SPECIALIZATION = YES;
 				APPLICATION_EXTENSION_API_ONLY = NO;
@@ -3076,7 +3076,7 @@
 		};
 		ED9990352A69102400031B06 /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 2CFB58F208FAEF82CA95FACA /* Pods-RudderTests-tvOS.debug.xcconfig */;
+			baseConfigurationReference = 67B6FB354D9492FE1F10F098 /* Pods-RudderTests-tvOS.debug.xcconfig */;
 			buildSettings = {
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
 				CODE_SIGN_STYLE = Automatic;
@@ -3098,7 +3098,7 @@
 		};
 		ED9990362A69102400031B06 /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = CF210219D8B4C73F6A238C2D /* Pods-RudderTests-tvOS.release.xcconfig */;
+			baseConfigurationReference = 46E7849777925491E280B136 /* Pods-RudderTests-tvOS.release.xcconfig */;
 			buildSettings = {
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
 				CODE_SIGN_STYLE = Automatic;
@@ -3120,7 +3120,7 @@
 		};
 		ED9990432A69103B00031B06 /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = F785CBDD3425ADC4AD1D5121 /* Pods-RudderTests-iOS.debug.xcconfig */;
+			baseConfigurationReference = 047016191610999BB5D6639D /* Pods-RudderTests-iOS.debug.xcconfig */;
 			buildSettings = {
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
 				CODE_SIGN_STYLE = Automatic;
@@ -3152,7 +3152,7 @@
 		};
 		ED9990442A69103B00031B06 /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 202611FE2AF7BF1EDBA7E08A /* Pods-RudderTests-iOS.release.xcconfig */;
+			baseConfigurationReference = 696BB56E6F38B30EA9E87E59 /* Pods-RudderTests-iOS.release.xcconfig */;
 			buildSettings = {
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
 				CODE_SIGN_STYLE = Automatic;
@@ -3184,7 +3184,7 @@
 		};
 		ED9990512A69104B00031B06 /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = B8E2E66494A95FD566A1095C /* Pods-RudderTests-watchOS.debug.xcconfig */;
+			baseConfigurationReference = 594C68EBA69B23ED13FCDF7D /* Pods-RudderTests-watchOS.debug.xcconfig */;
 			buildSettings = {
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
 				CODE_SIGN_STYLE = Automatic;
@@ -3206,7 +3206,7 @@
 		};
 		ED9990522A69104B00031B06 /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = AF620050253AC84EEA724B3F /* Pods-RudderTests-watchOS.release.xcconfig */;
+			baseConfigurationReference = 0C12A2068DA24653A547FFC5 /* Pods-RudderTests-watchOS.release.xcconfig */;
 			buildSettings = {
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
 				CODE_SIGN_STYLE = Automatic;

--- a/Scripts/generate-xcframework.sh
+++ b/Scripts/generate-xcframework.sh
@@ -1,0 +1,97 @@
+# !/bin/bash -e
+rm -rf archives/
+rm -rf xcframeworks
+
+xcodebuild archive \
+    -workspace Rudder.xcworkspace \
+    -scheme Rudder_iOS \
+    -destination "generic/platform=iOS" \
+    -archivePath "archives/Rudder-iOS" \
+    BUILD_LIBRARY_FOR_DISTRIBUTION=YES \
+    SKIP_INSTALL=NO |
+    xcpretty
+
+xcodebuild archive \
+    -workspace Rudder.xcworkspace \
+    -scheme Rudder_iOS \
+    -destination "generic/platform=iOS Simulator" \
+    -archivePath "archives/Rudder-iOS-simulator" \
+    BUILD_LIBRARY_FOR_DISTRIBUTION=YES \
+    SKIP_INSTALL=NO |
+    xcpretty
+
+xcodebuild archive \
+    -workspace Rudder.xcworkspace \
+    -scheme Rudder_watchOS \
+    -destination "generic/platform=watchOS" \
+    -archivePath "archives/Rudder-watchOS" \
+    BUILD_LIBRARY_FOR_DISTRIBUTION=YES \
+    SKIP_INSTALL=NO |
+    xcpretty
+
+xcodebuild archive \
+    -workspace Rudder.xcworkspace \
+    -scheme Rudder_watchOS \
+    -destination "generic/platform=watchOS Simulator" \
+    -archivePath "archives/Rudder-watchOS-simulator" \
+    BUILD_LIBRARY_FOR_DISTRIBUTION=YES \
+    SKIP_INSTALL=NO |
+    xcpretty
+
+xcodebuild archive \
+    -workspace Rudder.xcworkspace \
+    -scheme Rudder_tvOS \
+    -destination "generic/platform=tvOS" \
+    -archivePath "archives/Rudder-tvOS" \
+    BUILD_LIBRARY_FOR_DISTRIBUTION=YES \
+    SKIP_INSTALL=NO |
+    xcpretty
+
+xcodebuild archive \
+    -workspace Rudder.xcworkspace \
+    -scheme Rudder_tvOS \
+    -destination "generic/platform=tvOS Simulator" \
+    -archivePath "archives/Rudder-tvOS-simulator" \
+    BUILD_LIBRARY_FOR_DISTRIBUTION=YES \
+    SKIP_INSTALL=NO |
+    xcpretty
+
+xcodebuild -create-xcframework \
+    -archive archives/Rudder-iOS.xcarchive -framework Rudder.framework \
+    -archive archives/Rudder-iOS-simulator.xcarchive -framework Rudder.framework \
+    -archive archives/Rudder-watchOS.xcarchive -framework Rudder.framework \
+    -archive archives/Rudder-watchOS-simulator.xcarchive -framework Rudder.framework \
+    -archive archives/Rudder-tvOS.xcarchive -framework Rudder.framework \
+    -archive archives/Rudder-tvOS-simulator.xcarchive -framework Rudder.framework \
+    -output xcframeworks/Rudder.xcframework |
+    xcpretty
+
+xcodebuild -create-xcframework \
+    -archive archives/Rudder-iOS.xcarchive -framework RudderKit.framework \
+    -archive archives/Rudder-iOS-simulator.xcarchive -framework RudderKit.framework \
+    -archive archives/Rudder-watchOS.xcarchive -framework RudderKit.framework \
+    -archive archives/Rudder-watchOS-simulator.xcarchive -framework RudderKit.framework \
+    -archive archives/Rudder-tvOS.xcarchive -framework RudderKit.framework \
+    -archive archives/Rudder-tvOS-simulator.xcarchive -framework RudderKit.framework \
+    -output xcframeworks/RudderKit.xcframework |
+    xcpretty
+
+xcodebuild -create-xcframework \
+    -archive archives/Rudder-iOS.xcarchive -framework RSCrashReporter.framework \
+    -archive archives/Rudder-iOS-simulator.xcarchive -framework RSCrashReporter.framework \
+    -archive archives/Rudder-watchOS.xcarchive -framework RSCrashReporter.framework \
+    -archive archives/Rudder-watchOS-simulator.xcarchive -framework RSCrashReporter.framework \
+    -archive archives/Rudder-tvOS.xcarchive -framework RSCrashReporter.framework \
+    -archive archives/Rudder-tvOS-simulator.xcarchive -framework RSCrashReporter.framework \
+    -output xcframeworks/RSCrashReporter.xcframework |
+    xcpretty
+
+xcodebuild -create-xcframework \
+    -archive archives/Rudder-iOS.xcarchive -framework MetricsReporter.framework \
+    -archive archives/Rudder-iOS-simulator.xcarchive -framework MetricsReporter.framework \
+    -archive archives/Rudder-watchOS.xcarchive -framework MetricsReporter.framework \
+    -archive archives/Rudder-watchOS-simulator.xcarchive -framework MetricsReporter.framework \
+    -archive archives/Rudder-tvOS.xcarchive -framework MetricsReporter.framework \
+    -archive archives/Rudder-tvOS-simulator.xcarchive -framework MetricsReporter.framework \
+    -output xcframeworks/MetricsReporter.xcframework |
+    xcpretty

--- a/Sources/Classes/Headers/RSVersion.h
+++ b/Sources/Classes/Headers/RSVersion.h
@@ -8,6 +8,6 @@
 #ifndef RSVersion_h
 #define RSVersion_h
 
-NSString *const SDK_VERSION = @"1.24.1";
+NSString *const SDK_VERSION = @"1.24.2";
 
 #endif /* RSVersion_h */

--- a/package.json
+++ b/package.json
@@ -1,4 +1,4 @@
 {
-    "version": "1.24.1",
+    "version": "1.24.2",
     "description": "Rudder is a platform for collecting, storing and routing customer event data to dozens of tools"
 }

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -6,7 +6,7 @@ sonar.qualitygate.wait=false
 sonar.projectKey=rudderlabs_rudder-sdk-ios
 sonar.organization=rudderlabs
 sonar.projectName=RudderStack iOS SDK
-sonar.projectVersion=1.24.1
+sonar.projectVersion=1.24.2
 
 # C/C++/Objective-C related details
 # sonar.cfamily.compile-commands=compile_commands.json


### PR DESCRIPTION
:crown: *An automated PR*

   Unreleased (2024-01-03)<br> * fix: updated version of MetricsReporter in package.swift ( 433) ([8870ccd](https://github.com/rudderlabs/rudder-sdk-ios/commit/8870ccd)), closes [ 433](https://github.com/rudderlabs/rudder-sdk-ios/issues/433)<br> * chore(ci): add steps to generate xcframework files while releasing the sdk ( 428) ([690d8ff](https://github.com/rudderlabs/rudder-sdk-ios/commit/690d8ff)), closes [ 428](https://github.com/rudderlabs/rudder-sdk-ios/issues/428)