### PR TITLE
chore(ci): change the platform from ubuntu to macOS

### DIFF
--- a/.github/workflows/publish-new-release.yml
+++ b/.github/workflows/publish-new-release.yml
@@ -10,7 +10,7 @@ on:
 jobs:
   release:
     name: Publish new release
-    runs-on: ubuntu-latest
+    runs-on: macOS-latest
     if: (startsWith(github.event.pull_request.head.ref, 'release/') || startsWith(github.event.pull_request.head.ref, 'hotfix-release/')) && github.event.pull_request.merged == true # only merged pull requests must trigger this job
     steps:
       - name: Extract version from branch name (for release branches)


### PR DESCRIPTION
# Description

- I've updated the platform to `macOS` to fix the `Publish New Release` GitHub action which failed while installing XCPretty.
