### PR TITLE
chore(release): pulling release/2.4.3 into master

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+### [2.4.3](https://github.com/rudderlabs/rudder-sdk-ios/compare/v2.4.2...v2.4.3) (2024-01-18)
+
+
+### Bug Fixes
+
+* fixed sqlite db path on the tvos platforms ([#417](https://github.com/rudderlabs/rudder-sdk-ios/issues/417)) ([e8bfe4a](https://github.com/rudderlabs/rudder-sdk-ios/commit/e8bfe4aaf8464ca8e1623c382bde1b22a36dd63a))
+
 ### [2.4.2](https://github.com/rudderlabs/rudder-sdk-ios/compare/v2.4.1...v2.4.2) (2023-08-22)
 
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 <p align="center">
   <a href="https://cocoapods.org/pods/Rudder">
-    <img src="https://img.shields.io/static/v1?label=pod&message=v2.4.2&color=blue&style=flat">
+    <img src="https://img.shields.io/static/v1?label=pod&message=v2.4.3&color=blue&style=flat">
     </a>
 </p>
 
@@ -47,7 +47,7 @@ The iOS SDK is available through [**CocoaPods**](https://cocoapods.org), [**Cart
 To install the SDK, simply add the following line to your Podfile:
 
 ```xcode
-pod 'Rudder', '2.4.2'
+pod 'Rudder', '2.4.3'
 ```
 
 ### Carthage
@@ -55,7 +55,7 @@ pod 'Rudder', '2.4.2'
 For Carthage support, add the following line to your `Cartfile`:
 
 ```xcode
-github "rudderlabs/rudder-sdk-ios" "v2.4.2"
+github "rudderlabs/rudder-sdk-ios" "v2.4.3"
 ```
 
 > Remember to include the following code where you want to refer to or use the RudderStack SDK classes, as shown:
@@ -86,7 +86,7 @@ You can also add the RudderStack SDK using the Swift Package Mangaer in one of t
 ![Adding a package](https://user-images.githubusercontent.com/59817155/140903027-286a1d64-f5d5-4041-9827-47b6cef76a46.png)
 
 2. Enter the package repository (`git@github.com:rudderlabs/rudder-sdk-ios.git`) in the search bar.
-3. In **Dependency Rule**, select **Up to Next Major Version**, and enter `2.4.2` as the value, as shown:
+3. In **Dependency Rule**, select **Up to Next Major Version**, and enter `2.4.3` as the value, as shown:
 
 ![Setting the dependency](https://user-images.githubusercontent.com/59817155/145574696-8c849749-13e0-40d5-aacb-3fccb5c8e67d.png)
 
@@ -113,7 +113,7 @@ let package = Package(
     ],
     dependencies: [
         // Dependencies declare other packages that this package depends on.
-        .package(url: "git@github.com:rudderlabs/rudder-sdk-ios.git", from: "2.4.2")
+        .package(url: "git@github.com:rudderlabs/rudder-sdk-ios.git", from: "2.4.3")
     ],
     targets: [
         // Targets are the basic building blocks of a package. A target can define a module or a test suite.

--- a/Sources/Classes/Common/Constants/RSVersion.swift
+++ b/Sources/Classes/Common/Constants/RSVersion.swift
@@ -9,4 +9,4 @@
 import Foundation
 
 // don't edit this line
-let RSVersion = "2.4.2"
+let RSVersion = "2.4.3"

--- a/Sources/Classes/Utility/RSUtils.swift
+++ b/Sources/Classes/Utility/RSUtils.swift
@@ -24,7 +24,11 @@ struct RSUtils {
     }
 
     static func getDBPath() -> String {
+#if os(tvOS)
+        let urlDirectory = FileManager.default.urls(for: FileManager.SearchPathDirectory.cachesDirectory, in: FileManager.SearchPathDomainMask.userDomainMask)[0]
+#else
         let urlDirectory = FileManager.default.urls(for: FileManager.SearchPathDirectory.libraryDirectory, in: FileManager.SearchPathDomainMask.userDomainMask)[0]
+#endif
         let fileUrl = urlDirectory.appendingPathComponent("rl_persistence.sqlite")
         return fileUrl.path
     }

--- a/package.json
+++ b/package.json
@@ -1,4 +1,4 @@
 {
-    "version": "2.4.2",
+    "version": "2.4.3",
     "description": "Rudder is a platform for collecting, storing and routing customer event data to dozens of tools"
 }

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -6,7 +6,7 @@ sonar.qualitygate.wait=false
 sonar.projectKey=rudderlabs_rudder-sdk-ios-v2
 sonar.organization=rudderlabs
 sonar.projectName=RudderStack iOS SDK(v2)
-sonar.projectVersion=2.4.2
+sonar.projectVersion=2.4.3
 
 # Meta-data for the project
 sonar.links.scm=https://github.com/rudderlabs/rudder-sdk-ios


### PR DESCRIPTION
:crown: *An automated PR*

   Unreleased (2024-01-18)<br> * fix: fixed sqlite db path on the tvos platforms ( 417) ([e8bfe4a](https://github.com/rudderlabs/rudder-sdk-ios/commit/e8bfe4a)), closes [ 417](https://github.com/rudderlabs/rudder-sdk-ios/issues/417)