### PR TITLE
ci: fixed failing draft new beta release workflow

### DIFF
--- a/.github/workflows/draft-new-beta-release.yml
+++ b/.github/workflows/draft-new-beta-release.yml
@@ -10,7 +10,7 @@ on:
 jobs:
   draft-new-beta-release:
     name: Draft a new Beta release
-    runs-on: ubuntu-latest
+    runs-on: macOS-latest
     if: startsWith(github.ref, 'refs/heads/fix/') || startsWith(github.ref, 'refs/heads/feat/')
     steps:
       - name: Checkout source branch

--- a/.github/workflows/draft-new-beta-release.yml
+++ b/.github/workflows/draft-new-beta-release.yml
@@ -11,7 +11,7 @@ jobs:
   draft-new-beta-release:
     name: Draft a new Beta release
     runs-on: macOS-latest
-    if: startsWith(github.ref, 'refs/heads/fix/') || startsWith(github.ref, 'refs/heads/feat/')
+    if: startsWith(github.ref, 'refs/heads/fix/') || startsWith(github.ref, 'refs/heads/feat/') || startsWith(github.ref, 'refs/heads/feature/')
     steps:
       - name: Checkout source branch
         uses: actions/checkout@v4


### PR DESCRIPTION
# ci: fixed failing draft new beta release workflow

* Updated the Runnder to macOS-latest so that Cocoapods would be installed.
* Updated the workflow to be executed on `feature/` branches as well.
