### PR TITLE
fix: nil check errors after de-serialization

### DIFF
--- a/Sources/Classes/RSContext.m
+++ b/Sources/Classes/RSContext.m
@@ -50,7 +50,7 @@ static dispatch_queue_t queue;
             [self createAndPersistTraits];
         } else {
             NSDictionary *traitsDict = [RSUtils deserialize:traitsJson];
-            if (traitsDict == nil) {
+            if (traitsDict != nil) {
                 _traits = [traitsDict mutableCopy];
                 _traits[@"anonymousId"] = _anonymousId;
                 [self persistTraits];
@@ -64,7 +64,7 @@ static dispatch_queue_t queue;
         NSString *externalIdJson = [preferenceManager getExternalIds];
         if (externalIdJson != nil) {
             NSDictionary *externalIdDict = [RSUtils deserialize:externalIdJson];
-            if (externalIdDict == nil) {
+            if (externalIdDict != nil) {
                 _externalIds = [externalIdDict mutableCopy];
             }
         }

--- a/Sources/Classes/RSDeviceModeTransformationManager.m
+++ b/Sources/Classes/RSDeviceModeTransformationManager.m
@@ -140,7 +140,7 @@ int deviceModeSleepCount = 0;
     NSMutableArray<NSString *>* messageIds = dbMessage.messageIds;
     for(int i=0; i<messages.count; i++) {
         id object = [RSUtils deserialize:messages[i]];
-        if (object && [object isKindOfClass:[NSDictionary class]]) {
+        if (object != nil && [object isKindOfClass:[NSDictionary class]]) {
             RSMessage* message = [[RSMessage alloc] initWithDict:object];
             NSArray<NSString *>* destinationIds = [self getDestinationIdsWithTransformationsForMessage:message];
             if(destinationIds== nil || [destinationIds count]==0) continue;


### PR DESCRIPTION
# fix: nil check errors after de-serialization

* Fixed in-correct nil checks for de-serializing Traits and ExternalIds from preferences
