### PR TITLE
chore(release): pulling release/1.25.2 into master

### DIFF
--- a/.github/workflows/slack-notify.yml
+++ b/.github/workflows/slack-notify.yml
@@ -11,7 +11,7 @@ jobs:
     steps:
       - name: Send message to Slack channel
         id: slack
-        uses: slackapi/slack-github-action@v1.24.0
+        uses: slackapi/slack-github-action@v1.25.0
         env:
           SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
           PROJECT_NAME: 'iOS SDK'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+### [1.25.2](https://github.com/rudderlabs/rudder-sdk-ios/compare/v1.25.1...v1.25.2) (2024-02-20)
+
+
+### Bug Fixes
+
+* added a persistence layer over keys stored in standard defaults by rudderstack ([#454](https://github.com/rudderlabs/rudder-sdk-ios/issues/454)) ([1c52a07](https://github.com/rudderlabs/rudder-sdk-ios/commit/1c52a078790ac12f40a54aec4b62a6aa26c05bc0))
+
 ### [1.25.1](https://github.com/rudderlabs/rudder-sdk-ios/compare/v1.25.0...v1.25.1) (2024-02-07)
 
 

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -3,7 +3,7 @@ PODS:
     - RSCrashReporter (= 1.0.1)
     - RudderKit (= 1.4.0)
   - RSCrashReporter (1.0.1)
-  - Rudder (1.25.0):
+  - Rudder (1.25.1):
     - MetricsReporter (= 1.2.1)
   - RudderKit (1.4.0)
   - SQLCipher (4.5.4):
@@ -33,10 +33,10 @@ EXTERNAL SOURCES:
 SPEC CHECKSUMS:
   MetricsReporter: 99596ee5003c69949ed2f50acc34aee83c42f843
   RSCrashReporter: 6b8376ac729b0289ebe0908553e5f56d8171f313
-  Rudder: 959b31df6a700432d3535b7d115afe0840d7b6c4
+  Rudder: 34799a1be015f03d7073a919c4b3557cfde428d4
   RudderKit: d9d6997696e1642b753d8bdf94e57af643a68f03
   SQLCipher: 905b145f65f349f26da9e60a19901ad24adcd381
 
 PODFILE CHECKSUM: b6937cee06e0633464427ff0d975d40e17419e9f
 
-COCOAPODS: 1.14.3
+COCOAPODS: 1.14.2

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 <p align="center">
   <a href="https://cocoapods.org/pods/Rudder">
-    <img src="https://img.shields.io/static/v1?label=pod&message=v1.25.1&color=blue&style=flat">
+    <img src="https://img.shields.io/static/v1?label=pod&message=v1.25.2&color=blue&style=flat">
     </a>
 </p>
 
@@ -39,7 +39,7 @@ The iOS SDK is available through [**CocoaPods**](https://cocoapods.org), [**Cart
 To install the SDK, simply add the following line to your Podfile:
 
 ```xcode
-pod 'Rudder', '1.25.1'
+pod 'Rudder', '1.25.2'
 ```
 
 ### Carthage
@@ -47,7 +47,7 @@ pod 'Rudder', '1.25.1'
 For Carthage support, add the following line to your `Cartfile`:
 
 ```xcode
-github "rudderlabs/rudder-sdk-ios" "v1.25.1"
+github "rudderlabs/rudder-sdk-ios" "v1.25.2"
 ```
 
 > Remember to include the following code in all `.m` and `.h` files where you want to refer to or use the RudderStack SDK classes, as shown:
@@ -71,7 +71,7 @@ You can also add the RudderStack iOS SDK via Swift Package Mangaer, via one of t
 
 * Enter the package repository (`git@github.com:rudderlabs/rudder-sdk-ios.git`) in the search bar.
 
-* In **Dependency Rule**, select **Up to Next Major Version** and enter `1.25.1` as the value, as shown:
+* In **Dependency Rule**, select **Up to Next Major Version** and enter `1.25.2` as the value, as shown:
 
 ![Setting dependency](https://user-images.githubusercontent.com/59817155/145574696-8c849749-13e0-40d5-aacb-3fccb5c8e67d.png)
 
@@ -99,7 +99,7 @@ let package = Package(
     ],
     dependencies: [
         // Dependencies declare other packages that this package depends on.
-        .package(url: "git@github.com:rudderlabs/rudder-sdk-ios.git", from: "1.25.1")
+        .package(url: "git@github.com:rudderlabs/rudder-sdk-ios.git", from: "1.25.2")
     ],
     targets: [
         // Targets are the basic building blocks of a package. A target can define a module or a test suite.

--- a/Rudder.xcodeproj/project.pbxproj
+++ b/Rudder.xcodeproj/project.pbxproj
@@ -3,18 +3,18 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 52;
+	objectVersion = 54;
 	objects = {
 
 /* Begin PBXBuildFile section */
 		06CABC332630C6B00097BEFF /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 06CABC322630C6B00097BEFF /* Foundation.framework */; };
 		06CABC352630C6D30097BEFF /* UIKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 06CABC2E2630C6660097BEFF /* UIKit.framework */; };
-		1D5DDBF3C5A9A0D68C4DCC99 /* Pods_RudderTests_iOS.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 568C1D5AB430F01BD4CEC4E8 /* Pods_RudderTests_iOS.framework */; };
-		538850DAB473A7B4EF67C5A1 /* Pods_RudderTests_watchOS.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 73BB5CB3025EF1333EC829A3 /* Pods_RudderTests_watchOS.framework */; };
-		5CC283FA80A5DD6ABCECDF5D /* Pods_RudderTests_tvOS.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 858E45719C417D040F7CD6E0 /* Pods_RudderTests_tvOS.framework */; };
-		69916F668AEF36CF5297393D /* Pods_Rudder_tvOS.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 694E65090E456D8291C08327 /* Pods_Rudder_tvOS.framework */; };
-		8C4C8BBBE37C05B2416E6F67 /* Pods_Rudder_watchOS.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = CBE6B383CC53988816505FCA /* Pods_Rudder_watchOS.framework */; };
-		9E5B402374D94EBF4BFAB648 /* Pods_Rudder_iOS.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 6A275CE257CE8C3C78CB2A16 /* Pods_Rudder_iOS.framework */; };
+		4A0CBF35C3C640065D0D646F /* Pods_Rudder_iOS.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 381A0433AB34802684AA0E86 /* Pods_Rudder_iOS.framework */; };
+		5AC44BE035EE3100A585BC6F /* Pods_RudderTests_iOS.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = AC1E4F4531FB88ACB07A3AB2 /* Pods_RudderTests_iOS.framework */; };
+		5C73508B61CEC3B701DC6D3B /* Pods_RudderTests_watchOS.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 85115045A8289BE3C98C061E /* Pods_RudderTests_watchOS.framework */; };
+		A3F0B1D68989A3188449830A /* Pods_RudderTests_tvOS.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 589F1C04B540ED233C3C15C6 /* Pods_RudderTests_tvOS.framework */; };
+		BB3C914CC6164092BA4F25CB /* Pods_Rudder_watchOS.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 41CEA928EA5423C014B14A13 /* Pods_Rudder_watchOS.framework */; };
+		E3723BFD219B0B95B98161C7 /* Pods_Rudder_tvOS.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = E5D2F78ABE740E1FE40050CC /* Pods_Rudder_tvOS.framework */; };
 		ED0CA6EA2A7D08B900899C1C /* RSTransformationEvent.h in Headers */ = {isa = PBXBuildFile; fileRef = F6F2FA752A53D8310025D510 /* RSTransformationEvent.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		ED0CA6EB2A7D08B900899C1C /* RSTransformationEvent.h in Headers */ = {isa = PBXBuildFile; fileRef = F6F2FA752A53D8310025D510 /* RSTransformationEvent.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		ED0CA6EC2A7D08D800899C1C /* RSTransformationRequest.h in Headers */ = {isa = PBXBuildFile; fileRef = F6F2FA732A53CD9F0025D510 /* RSTransformationRequest.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -692,6 +692,15 @@
 		ED9990922A6926E000031B06 /* RSMetricsReporter.m in Sources */ = {isa = PBXBuildFile; fileRef = ED99908D2A6926E000031B06 /* RSMetricsReporter.m */; };
 		ED9990932A6926E000031B06 /* RSMetricsReporter.m in Sources */ = {isa = PBXBuildFile; fileRef = ED99908D2A6926E000031B06 /* RSMetricsReporter.m */; };
 		EDEF1B312A835A90002B3E57 /* Security.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = EDEF1B302A835A90002B3E57 /* Security.framework */; };
+		F64115FE2B68EBEC0015CB42 /* RSDefaultsPersistence.h in Headers */ = {isa = PBXBuildFile; fileRef = F64115FD2B68EBEC0015CB42 /* RSDefaultsPersistence.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		F64115FF2B68EBEC0015CB42 /* RSDefaultsPersistence.h in Headers */ = {isa = PBXBuildFile; fileRef = F64115FD2B68EBEC0015CB42 /* RSDefaultsPersistence.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		F64116002B68EBEC0015CB42 /* RSDefaultsPersistence.h in Headers */ = {isa = PBXBuildFile; fileRef = F64115FD2B68EBEC0015CB42 /* RSDefaultsPersistence.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		F64116022B68EC4B0015CB42 /* RSDefaultsPersistence.m in Sources */ = {isa = PBXBuildFile; fileRef = F64116012B68EC4B0015CB42 /* RSDefaultsPersistence.m */; };
+		F64116032B68EC4B0015CB42 /* RSDefaultsPersistence.m in Sources */ = {isa = PBXBuildFile; fileRef = F64116012B68EC4B0015CB42 /* RSDefaultsPersistence.m */; };
+		F64116042B68EC4B0015CB42 /* RSDefaultsPersistence.m in Sources */ = {isa = PBXBuildFile; fileRef = F64116012B68EC4B0015CB42 /* RSDefaultsPersistence.m */; };
+		F64116062B6A2DA20015CB42 /* DefaultsPersistenceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F64116052B6A2DA20015CB42 /* DefaultsPersistenceTests.swift */; };
+		F64116072B6A2DA20015CB42 /* DefaultsPersistenceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F64116052B6A2DA20015CB42 /* DefaultsPersistenceTests.swift */; };
+		F64116082B6A2DA20015CB42 /* DefaultsPersistenceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F64116052B6A2DA20015CB42 /* DefaultsPersistenceTests.swift */; };
 		F6B4B52729C8236100344864 /* RSCloudModeManager.h in Headers */ = {isa = PBXBuildFile; fileRef = F6B4B51D29C8236100344864 /* RSCloudModeManager.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		F6B4B52829C8236100344864 /* RSBackGroundModeManager.h in Headers */ = {isa = PBXBuildFile; fileRef = F6B4B51E29C8236100344864 /* RSBackGroundModeManager.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		F6B4B52A29C8236100344864 /* RSDeviceModeManager.h in Headers */ = {isa = PBXBuildFile; fileRef = F6B4B52029C8236100344864 /* RSDeviceModeManager.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -743,27 +752,27 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
-		024DFF0FE82BFA633C7A0ACF /* Pods-Rudder-tvOS.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Rudder-tvOS.release.xcconfig"; path = "Target Support Files/Pods-Rudder-tvOS/Pods-Rudder-tvOS.release.xcconfig"; sourceTree = "<group>"; };
+		010DAF827438C4A823468825 /* Pods-RudderTests-watchOS.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-RudderTests-watchOS.debug.xcconfig"; path = "Target Support Files/Pods-RudderTests-watchOS/Pods-RudderTests-watchOS.debug.xcconfig"; sourceTree = "<group>"; };
 		06CABB842630C3CA0097BEFF /* Rudder.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Rudder.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		06CABC2E2630C6660097BEFF /* UIKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = UIKit.framework; path = Platforms/MacOSX.platform/Developer/SDKs/MacOSX11.1.sdk/System/iOSSupport/System/Library/Frameworks/UIKit.framework; sourceTree = DEVELOPER_DIR; };
 		06CABC322630C6B00097BEFF /* Foundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Foundation.framework; path = Platforms/MacOSX.platform/Developer/SDKs/MacOSX11.1.sdk/System/Library/Frameworks/Foundation.framework; sourceTree = DEVELOPER_DIR; };
-		1826685173321FC0D2D525F6 /* Pods-RudderTests-tvOS.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-RudderTests-tvOS.debug.xcconfig"; path = "Target Support Files/Pods-RudderTests-tvOS/Pods-RudderTests-tvOS.debug.xcconfig"; sourceTree = "<group>"; };
-		4C7350A8F5EF4005A9C8002C /* Pods-Rudder-iOS.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Rudder-iOS.debug.xcconfig"; path = "Target Support Files/Pods-Rudder-iOS/Pods-Rudder-iOS.debug.xcconfig"; sourceTree = "<group>"; };
-		568C1D5AB430F01BD4CEC4E8 /* Pods_RudderTests_iOS.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_RudderTests_iOS.framework; sourceTree = BUILT_PRODUCTS_DIR; };
-		588BDCDCC681265EFA53EC1A /* Pods-Rudder-tvOS.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Rudder-tvOS.debug.xcconfig"; path = "Target Support Files/Pods-Rudder-tvOS/Pods-Rudder-tvOS.debug.xcconfig"; sourceTree = "<group>"; };
-		59CAC564577C2DF84C1C4FA7 /* Pods-RudderTests-iOS.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-RudderTests-iOS.debug.xcconfig"; path = "Target Support Files/Pods-RudderTests-iOS/Pods-RudderTests-iOS.debug.xcconfig"; sourceTree = "<group>"; };
-		694E65090E456D8291C08327 /* Pods_Rudder_tvOS.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_Rudder_tvOS.framework; sourceTree = BUILT_PRODUCTS_DIR; };
-		6A275CE257CE8C3C78CB2A16 /* Pods_Rudder_iOS.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_Rudder_iOS.framework; sourceTree = BUILT_PRODUCTS_DIR; };
-		6EB16DBB6C33BA3C3E7ACCF7 /* Pods-Rudder-iOS.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Rudder-iOS.release.xcconfig"; path = "Target Support Files/Pods-Rudder-iOS/Pods-Rudder-iOS.release.xcconfig"; sourceTree = "<group>"; };
-		73BB5CB3025EF1333EC829A3 /* Pods_RudderTests_watchOS.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_RudderTests_watchOS.framework; sourceTree = BUILT_PRODUCTS_DIR; };
-		791CB89B417016D590354A7F /* Pods-RudderTests-iOS.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-RudderTests-iOS.release.xcconfig"; path = "Target Support Files/Pods-RudderTests-iOS/Pods-RudderTests-iOS.release.xcconfig"; sourceTree = "<group>"; };
-		858E45719C417D040F7CD6E0 /* Pods_RudderTests_tvOS.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_RudderTests_tvOS.framework; sourceTree = BUILT_PRODUCTS_DIR; };
-		8864716542CDA61025379626 /* Pods-Rudder-watchOS.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Rudder-watchOS.release.xcconfig"; path = "Target Support Files/Pods-Rudder-watchOS/Pods-Rudder-watchOS.release.xcconfig"; sourceTree = "<group>"; };
-		8993C949BB21E74269543A5A /* Pods-RudderTests-watchOS.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-RudderTests-watchOS.release.xcconfig"; path = "Target Support Files/Pods-RudderTests-watchOS/Pods-RudderTests-watchOS.release.xcconfig"; sourceTree = "<group>"; };
-		94FCF9CB2A6B261F650FA34A /* Pods-RudderTests-watchOS.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-RudderTests-watchOS.debug.xcconfig"; path = "Target Support Files/Pods-RudderTests-watchOS/Pods-RudderTests-watchOS.debug.xcconfig"; sourceTree = "<group>"; };
-		A5B61F726E782A95371426B4 /* Pods-RudderTests-tvOS.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-RudderTests-tvOS.release.xcconfig"; path = "Target Support Files/Pods-RudderTests-tvOS/Pods-RudderTests-tvOS.release.xcconfig"; sourceTree = "<group>"; };
-		AEA654A683B9C42785EF4586 /* Pods-Rudder-watchOS.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Rudder-watchOS.debug.xcconfig"; path = "Target Support Files/Pods-Rudder-watchOS/Pods-Rudder-watchOS.debug.xcconfig"; sourceTree = "<group>"; };
-		CBE6B383CC53988816505FCA /* Pods_Rudder_watchOS.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_Rudder_watchOS.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		381A0433AB34802684AA0E86 /* Pods_Rudder_iOS.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_Rudder_iOS.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		3C702DB8C75FBD66B10B8EDF /* Pods-RudderTests-watchOS.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-RudderTests-watchOS.release.xcconfig"; path = "Target Support Files/Pods-RudderTests-watchOS/Pods-RudderTests-watchOS.release.xcconfig"; sourceTree = "<group>"; };
+		41CEA928EA5423C014B14A13 /* Pods_Rudder_watchOS.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_Rudder_watchOS.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		51D8D2C7430591C091E783C8 /* Pods-RudderTests-iOS.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-RudderTests-iOS.release.xcconfig"; path = "Target Support Files/Pods-RudderTests-iOS/Pods-RudderTests-iOS.release.xcconfig"; sourceTree = "<group>"; };
+		589F1C04B540ED233C3C15C6 /* Pods_RudderTests_tvOS.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_RudderTests_tvOS.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		6307363FD931C4184D3CB813 /* Pods-Rudder-iOS.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Rudder-iOS.release.xcconfig"; path = "Target Support Files/Pods-Rudder-iOS/Pods-Rudder-iOS.release.xcconfig"; sourceTree = "<group>"; };
+		7DCFD27F69B0AF5419724FC5 /* Pods-Rudder-watchOS.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Rudder-watchOS.release.xcconfig"; path = "Target Support Files/Pods-Rudder-watchOS/Pods-Rudder-watchOS.release.xcconfig"; sourceTree = "<group>"; };
+		80D3FB2299E58D1817A1B0E2 /* Pods-RudderTests-iOS.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-RudderTests-iOS.debug.xcconfig"; path = "Target Support Files/Pods-RudderTests-iOS/Pods-RudderTests-iOS.debug.xcconfig"; sourceTree = "<group>"; };
+		8386A90FCB2E6C483CC34952 /* Pods-Rudder-tvOS.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Rudder-tvOS.debug.xcconfig"; path = "Target Support Files/Pods-Rudder-tvOS/Pods-Rudder-tvOS.debug.xcconfig"; sourceTree = "<group>"; };
+		85115045A8289BE3C98C061E /* Pods_RudderTests_watchOS.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_RudderTests_watchOS.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		985D25DF983E35D9BA1961B7 /* Pods-RudderTests-tvOS.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-RudderTests-tvOS.release.xcconfig"; path = "Target Support Files/Pods-RudderTests-tvOS/Pods-RudderTests-tvOS.release.xcconfig"; sourceTree = "<group>"; };
+		9F810D86FD6A9B76CB56D407 /* Pods-Rudder-watchOS.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Rudder-watchOS.debug.xcconfig"; path = "Target Support Files/Pods-Rudder-watchOS/Pods-Rudder-watchOS.debug.xcconfig"; sourceTree = "<group>"; };
+		AC1E4F4531FB88ACB07A3AB2 /* Pods_RudderTests_iOS.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_RudderTests_iOS.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		CC0F863D62F9D02F7B958FA2 /* Pods-Rudder-tvOS.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Rudder-tvOS.release.xcconfig"; path = "Target Support Files/Pods-Rudder-tvOS/Pods-Rudder-tvOS.release.xcconfig"; sourceTree = "<group>"; };
+		D622D27CE082C02F605707FE /* Pods-Rudder-iOS.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Rudder-iOS.debug.xcconfig"; path = "Target Support Files/Pods-Rudder-iOS/Pods-Rudder-iOS.debug.xcconfig"; sourceTree = "<group>"; };
+		DFF929D4168AFBD1511A4013 /* Pods-RudderTests-tvOS.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-RudderTests-tvOS.debug.xcconfig"; path = "Target Support Files/Pods-RudderTests-tvOS/Pods-RudderTests-tvOS.debug.xcconfig"; sourceTree = "<group>"; };
+		E5D2F78ABE740E1FE40050CC /* Pods_Rudder_tvOS.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_Rudder_tvOS.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		ED04A2482986C1750080A88D /* xccov-to-generic.sh */ = {isa = PBXFileReference; lastKnownFileType = text.script.sh; path = "xccov-to-generic.sh"; sourceTree = "<group>"; };
 		ED056314291AABFD00BAEE65 /* sonar-project.properties */ = {isa = PBXFileReference; lastKnownFileType = text; path = "sonar-project.properties"; sourceTree = "<group>"; };
 		ED1C4C8829E6CCC7007007C9 /* find-tag.sh */ = {isa = PBXFileReference; lastKnownFileType = text.script.sh; path = "find-tag.sh"; sourceTree = "<group>"; };
@@ -996,6 +1005,9 @@
 		F6113D3129EFD25400A05261 /* eu-dataresidency-default-true.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "eu-dataresidency-default-true.json"; sourceTree = "<group>"; };
 		F6113D3229EFD25400A05261 /* us-dataresidency-default-true.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "us-dataresidency-default-true.json"; sourceTree = "<group>"; };
 		F6113D3329EFD25400A05261 /* us-dataresidency-default-false.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "us-dataresidency-default-false.json"; sourceTree = "<group>"; };
+		F64115FD2B68EBEC0015CB42 /* RSDefaultsPersistence.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = RSDefaultsPersistence.h; sourceTree = "<group>"; };
+		F64116012B68EC4B0015CB42 /* RSDefaultsPersistence.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = RSDefaultsPersistence.m; sourceTree = "<group>"; };
+		F64116052B6A2DA20015CB42 /* DefaultsPersistenceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DefaultsPersistenceTests.swift; sourceTree = "<group>"; };
 		F64F9D7529BF171D009D963F /* ContextTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContextTests.swift; sourceTree = "<group>"; };
 		F6B4B51D29C8236100344864 /* RSCloudModeManager.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RSCloudModeManager.h; sourceTree = "<group>"; };
 		F6B4B51E29C8236100344864 /* RSBackGroundModeManager.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RSBackGroundModeManager.h; sourceTree = "<group>"; };
@@ -1031,7 +1043,7 @@
 				06CABC332630C6B00097BEFF /* Foundation.framework in Frameworks */,
 				06CABC352630C6D30097BEFF /* UIKit.framework in Frameworks */,
 				EDEF1B312A835A90002B3E57 /* Security.framework in Frameworks */,
-				9E5B402374D94EBF4BFAB648 /* Pods_Rudder_iOS.framework in Frameworks */,
+				4A0CBF35C3C640065D0D646F /* Pods_Rudder_iOS.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1041,7 +1053,7 @@
 			files = (
 				ED998F0F2A69003600031B06 /* Foundation.framework in Frameworks */,
 				ED998F102A69003600031B06 /* UIKit.framework in Frameworks */,
-				69916F668AEF36CF5297393D /* Pods_Rudder_tvOS.framework in Frameworks */,
+				E3723BFD219B0B95B98161C7 /* Pods_Rudder_tvOS.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1051,7 +1063,7 @@
 			files = (
 				ED998FDF2A69024E00031B06 /* Foundation.framework in Frameworks */,
 				ED998FE02A69024E00031B06 /* UIKit.framework in Frameworks */,
-				8C4C8BBBE37C05B2416E6F67 /* Pods_Rudder_watchOS.framework in Frameworks */,
+				BB3C914CC6164092BA4F25CB /* Pods_Rudder_watchOS.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1060,7 +1072,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				ED9990312A69102400031B06 /* Rudder.framework in Frameworks */,
-				5CC283FA80A5DD6ABCECDF5D /* Pods_RudderTests_tvOS.framework in Frameworks */,
+				A3F0B1D68989A3188449830A /* Pods_RudderTests_tvOS.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1069,7 +1081,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				ED99903F2A69103B00031B06 /* Rudder.framework in Frameworks */,
-				1D5DDBF3C5A9A0D68C4DCC99 /* Pods_RudderTests_iOS.framework in Frameworks */,
+				5AC44BE035EE3100A585BC6F /* Pods_RudderTests_iOS.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1078,7 +1090,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				ED99904D2A69104B00031B06 /* Rudder.framework in Frameworks */,
-				538850DAB473A7B4EF67C5A1 /* Pods_RudderTests_watchOS.framework in Frameworks */,
+				5C73508B61CEC3B701DC6D3B /* Pods_RudderTests_watchOS.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1116,12 +1128,12 @@
 				EDEF1B302A835A90002B3E57 /* Security.framework */,
 				06CABC322630C6B00097BEFF /* Foundation.framework */,
 				06CABC2E2630C6660097BEFF /* UIKit.framework */,
-				6A275CE257CE8C3C78CB2A16 /* Pods_Rudder_iOS.framework */,
-				694E65090E456D8291C08327 /* Pods_Rudder_tvOS.framework */,
-				CBE6B383CC53988816505FCA /* Pods_Rudder_watchOS.framework */,
-				568C1D5AB430F01BD4CEC4E8 /* Pods_RudderTests_iOS.framework */,
-				858E45719C417D040F7CD6E0 /* Pods_RudderTests_tvOS.framework */,
-				73BB5CB3025EF1333EC829A3 /* Pods_RudderTests_watchOS.framework */,
+				381A0433AB34802684AA0E86 /* Pods_Rudder_iOS.framework */,
+				E5D2F78ABE740E1FE40050CC /* Pods_Rudder_tvOS.framework */,
+				41CEA928EA5423C014B14A13 /* Pods_Rudder_watchOS.framework */,
+				AC1E4F4531FB88ACB07A3AB2 /* Pods_RudderTests_iOS.framework */,
+				589F1C04B540ED233C3C15C6 /* Pods_RudderTests_tvOS.framework */,
+				85115045A8289BE3C98C061E /* Pods_RudderTests_watchOS.framework */,
 			);
 			name = Frameworks;
 			sourceTree = "<group>";
@@ -1129,18 +1141,18 @@
 		DFB2363B6EC8D146934DE8DD /* Pods */ = {
 			isa = PBXGroup;
 			children = (
-				4C7350A8F5EF4005A9C8002C /* Pods-Rudder-iOS.debug.xcconfig */,
-				6EB16DBB6C33BA3C3E7ACCF7 /* Pods-Rudder-iOS.release.xcconfig */,
-				588BDCDCC681265EFA53EC1A /* Pods-Rudder-tvOS.debug.xcconfig */,
-				024DFF0FE82BFA633C7A0ACF /* Pods-Rudder-tvOS.release.xcconfig */,
-				AEA654A683B9C42785EF4586 /* Pods-Rudder-watchOS.debug.xcconfig */,
-				8864716542CDA61025379626 /* Pods-Rudder-watchOS.release.xcconfig */,
-				59CAC564577C2DF84C1C4FA7 /* Pods-RudderTests-iOS.debug.xcconfig */,
-				791CB89B417016D590354A7F /* Pods-RudderTests-iOS.release.xcconfig */,
-				1826685173321FC0D2D525F6 /* Pods-RudderTests-tvOS.debug.xcconfig */,
-				A5B61F726E782A95371426B4 /* Pods-RudderTests-tvOS.release.xcconfig */,
-				94FCF9CB2A6B261F650FA34A /* Pods-RudderTests-watchOS.debug.xcconfig */,
-				8993C949BB21E74269543A5A /* Pods-RudderTests-watchOS.release.xcconfig */,
+				D622D27CE082C02F605707FE /* Pods-Rudder-iOS.debug.xcconfig */,
+				6307363FD931C4184D3CB813 /* Pods-Rudder-iOS.release.xcconfig */,
+				8386A90FCB2E6C483CC34952 /* Pods-Rudder-tvOS.debug.xcconfig */,
+				CC0F863D62F9D02F7B958FA2 /* Pods-Rudder-tvOS.release.xcconfig */,
+				9F810D86FD6A9B76CB56D407 /* Pods-Rudder-watchOS.debug.xcconfig */,
+				7DCFD27F69B0AF5419724FC5 /* Pods-Rudder-watchOS.release.xcconfig */,
+				80D3FB2299E58D1817A1B0E2 /* Pods-RudderTests-iOS.debug.xcconfig */,
+				51D8D2C7430591C091E783C8 /* Pods-RudderTests-iOS.release.xcconfig */,
+				DFF929D4168AFBD1511A4013 /* Pods-RudderTests-tvOS.debug.xcconfig */,
+				985D25DF983E35D9BA1961B7 /* Pods-RudderTests-tvOS.release.xcconfig */,
+				010DAF827438C4A823468825 /* Pods-RudderTests-watchOS.debug.xcconfig */,
+				3C702DB8C75FBD66B10B8EDF /* Pods-RudderTests-watchOS.release.xcconfig */,
 			);
 			path = Pods;
 			sourceTree = "<group>";
@@ -1164,6 +1176,7 @@
 				F64F9D7529BF171D009D963F /* ContextTests.swift */,
 				ED38D36C29CB01A0003A7544 /* DataResidencyTests.swift */,
 				ED38D36F29CB01A0003A7544 /* DBPersistentManagerTests.swift */,
+				F64116052B6A2DA20015CB42 /* DefaultsPersistenceTests.swift */,
 				ED38D36E29CB01A0003A7544 /* EventRepositoryTests.swift */,
 				ED38D37029CB01A0003A7544 /* Extensions.swift */,
 				ED38D37129CB01A0003A7544 /* RudderUtilsTest.swift */,
@@ -1233,6 +1246,7 @@
 				ED7DFD91298C091800ED5A8E /* RSUtils.m */,
 				ED7DFD96298C091800ED5A8E /* UIViewController+RSScreen.m */,
 				ED7DFD92298C091800ED5A8E /* WKInterfaceController+RSScreen.m */,
+				F64116012B68EC4B0015CB42 /* RSDefaultsPersistence.m */,
 			);
 			path = Classes;
 			sourceTree = "<group>";
@@ -1302,6 +1316,7 @@
 				ED7DFDA2298C091800ED5A8E /* Rudder.h */,
 				ED7DFDC4298C091800ED5A8E /* UIViewController+RSScreen.h */,
 				ED7DFDC1298C091800ED5A8E /* WKInterfaceController+RSScreen.h */,
+				F64115FD2B68EBEC0015CB42 /* RSDefaultsPersistence.h */,
 			);
 			path = Public;
 			sourceTree = "<group>";
@@ -1609,6 +1624,7 @@
 				ED7DFE55298C091800ED5A8E /* RSVersion.h in Headers */,
 				ED7DFE53298C091800ED5A8E /* RSServerConfigManager.h in Headers */,
 				ED7DFED3298C091800ED5A8E /* RSOrderCompletedEvent.h in Headers */,
+				F64115FE2B68EBEC0015CB42 /* RSDefaultsPersistence.h in Headers */,
 				ED7DFE9D298C091800ED5A8E /* RSECommercePromotion.h in Headers */,
 				ED7DFE67298C091800ED5A8E /* RSDBPersistentManager.h in Headers */,
 				ED8DB01C298E205100907EC4 /* RSConsentFilterHandler.h in Headers */,
@@ -1727,6 +1743,7 @@
 				ED998EA72A69003600031B06 /* RSServerConfigManager.h in Headers */,
 				ED998EA82A69003600031B06 /* RSOrderCompletedEvent.h in Headers */,
 				ED998EA92A69003600031B06 /* RSECommercePromotion.h in Headers */,
+				F64115FF2B68EBEC0015CB42 /* RSDefaultsPersistence.h in Headers */,
 				ED998EAA2A69003600031B06 /* RSDBPersistentManager.h in Headers */,
 				ED998EAB2A69003600031B06 /* RSConsentFilterHandler.h in Headers */,
 				ED998EAC2A69003600031B06 /* RSContext.h in Headers */,
@@ -1841,6 +1858,7 @@
 				ED998F742A69024E00031B06 /* RSTrackPropertyBuilder.h in Headers */,
 				ED998F752A69024E00031B06 /* RSBackGroundModeManager.h in Headers */,
 				ED998F762A69024E00031B06 /* RSVersion.h in Headers */,
+				F64116002B68EBEC0015CB42 /* RSDefaultsPersistence.h in Headers */,
 				ED998F772A69024E00031B06 /* RSServerConfigManager.h in Headers */,
 				ED998F782A69024E00031B06 /* RSOrderCompletedEvent.h in Headers */,
 				ED998F792A69024E00031B06 /* RSECommercePromotion.h in Headers */,
@@ -1858,7 +1876,7 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = 06CABB982630C3CA0097BEFF /* Build configuration list for PBXNativeTarget "Rudder-iOS" */;
 			buildPhases = (
-				3F508465A1EB54A57BCE5026 /* [CP] Check Pods Manifest.lock */,
+				A39CDD690B851FCC6F21BCFF /* [CP] Check Pods Manifest.lock */,
 				06CABB7F2630C3CA0097BEFF /* Headers */,
 				06CABB802630C3CA0097BEFF /* Sources */,
 				06CABB812630C3CA0097BEFF /* Frameworks */,
@@ -1877,7 +1895,7 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = ED998F122A69003600031B06 /* Build configuration list for PBXNativeTarget "Rudder-tvOS" */;
 			buildPhases = (
-				F047EAAD4A3D4944740FAC24 /* [CP] Check Pods Manifest.lock */,
+				323999BD18C1FB7733B120EA /* [CP] Check Pods Manifest.lock */,
 				ED998E482A69003600031B06 /* Headers */,
 				ED998EAE2A69003600031B06 /* Sources */,
 				ED998F0E2A69003600031B06 /* Frameworks */,
@@ -1896,7 +1914,7 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = ED998FE22A69024E00031B06 /* Build configuration list for PBXNativeTarget "Rudder-watchOS" */;
 			buildPhases = (
-				1FB91ACA73E16AC7C0D42A08 /* [CP] Check Pods Manifest.lock */,
+				621FA7787A2A89CB3B813A53 /* [CP] Check Pods Manifest.lock */,
 				ED998F182A69024E00031B06 /* Headers */,
 				ED998F7E2A69024E00031B06 /* Sources */,
 				ED998FDE2A69024E00031B06 /* Frameworks */,
@@ -1915,11 +1933,11 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = ED9990342A69102400031B06 /* Build configuration list for PBXNativeTarget "RudderTests-tvOS" */;
 			buildPhases = (
-				AD6452261C56A78ADD9E66F5 /* [CP] Check Pods Manifest.lock */,
+				B77A79581B274E25A326F22D /* [CP] Check Pods Manifest.lock */,
 				ED9990292A69102400031B06 /* Sources */,
 				ED99902A2A69102400031B06 /* Frameworks */,
 				ED99902B2A69102400031B06 /* Resources */,
-				2CB207CD8FB9B53F4930095F /* [CP] Embed Pods Frameworks */,
+				CFD481FFA7D08854676F4C41 /* [CP] Embed Pods Frameworks */,
 			);
 			buildRules = (
 			);
@@ -1935,11 +1953,11 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = ED9990422A69103B00031B06 /* Build configuration list for PBXNativeTarget "RudderTests-iOS" */;
 			buildPhases = (
-				953A3028C6A5333C104A17FA /* [CP] Check Pods Manifest.lock */,
+				C28C1972688C65E5EAE03471 /* [CP] Check Pods Manifest.lock */,
 				ED9990372A69103A00031B06 /* Sources */,
 				ED9990382A69103A00031B06 /* Frameworks */,
 				ED9990392A69103A00031B06 /* Resources */,
-				2330930E4DE01C746D069354 /* [CP] Embed Pods Frameworks */,
+				10634EA9900CDBB96CD633BE /* [CP] Embed Pods Frameworks */,
 			);
 			buildRules = (
 			);
@@ -1955,11 +1973,11 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = ED9990502A69104B00031B06 /* Build configuration list for PBXNativeTarget "RudderTests-watchOS" */;
 			buildPhases = (
-				3E02581B428CBD1F96FD1A69 /* [CP] Check Pods Manifest.lock */,
+				4AD47650B7F47CE3295D85BA /* [CP] Check Pods Manifest.lock */,
 				ED9990452A69104B00031B06 /* Sources */,
 				ED9990462A69104B00031B06 /* Frameworks */,
 				ED9990472A69104B00031B06 /* Resources */,
-				95609E0B374DE1F330EABE65 /* [CP] Embed Pods Frameworks */,
+				94BE95E0F476DF23895DCB6F /* [CP] Embed Pods Frameworks */,
 			);
 			buildRules = (
 			);
@@ -2097,29 +2115,7 @@
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXShellScriptBuildPhase section */
-		1FB91ACA73E16AC7C0D42A08 /* [CP] Check Pods Manifest.lock */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputFileListPaths = (
-			);
-			inputPaths = (
-				"${PODS_PODFILE_DIR_PATH}/Podfile.lock",
-				"${PODS_ROOT}/Manifest.lock",
-			);
-			name = "[CP] Check Pods Manifest.lock";
-			outputFileListPaths = (
-			);
-			outputPaths = (
-				"$(DERIVED_FILE_DIR)/Pods-Rudder-watchOS-checkManifestLockResult.txt",
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
-			showEnvVarsInLog = 0;
-		};
-		2330930E4DE01C746D069354 /* [CP] Embed Pods Frameworks */ = {
+		10634EA9900CDBB96CD633BE /* [CP] Embed Pods Frameworks */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -2136,24 +2132,29 @@
 			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-RudderTests-iOS/Pods-RudderTests-iOS-frameworks.sh\"\n";
 			showEnvVarsInLog = 0;
 		};
-		2CB207CD8FB9B53F4930095F /* [CP] Embed Pods Frameworks */ = {
+		323999BD18C1FB7733B120EA /* [CP] Check Pods Manifest.lock */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
 			);
 			inputFileListPaths = (
-				"${PODS_ROOT}/Target Support Files/Pods-RudderTests-tvOS/Pods-RudderTests-tvOS-frameworks-${CONFIGURATION}-input-files.xcfilelist",
 			);
-			name = "[CP] Embed Pods Frameworks";
+			inputPaths = (
+				"${PODS_PODFILE_DIR_PATH}/Podfile.lock",
+				"${PODS_ROOT}/Manifest.lock",
+			);
+			name = "[CP] Check Pods Manifest.lock";
 			outputFileListPaths = (
-				"${PODS_ROOT}/Target Support Files/Pods-RudderTests-tvOS/Pods-RudderTests-tvOS-frameworks-${CONFIGURATION}-output-files.xcfilelist",
+			);
+			outputPaths = (
+				"$(DERIVED_FILE_DIR)/Pods-Rudder-tvOS-checkManifestLockResult.txt",
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-RudderTests-tvOS/Pods-RudderTests-tvOS-frameworks.sh\"\n";
+			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
 			showEnvVarsInLog = 0;
 		};
-		3E02581B428CBD1F96FD1A69 /* [CP] Check Pods Manifest.lock */ = {
+		4AD47650B7F47CE3295D85BA /* [CP] Check Pods Manifest.lock */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -2175,7 +2176,46 @@
 			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
 			showEnvVarsInLog = 0;
 		};
-		3F508465A1EB54A57BCE5026 /* [CP] Check Pods Manifest.lock */ = {
+		621FA7787A2A89CB3B813A53 /* [CP] Check Pods Manifest.lock */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+				"${PODS_PODFILE_DIR_PATH}/Podfile.lock",
+				"${PODS_ROOT}/Manifest.lock",
+			);
+			name = "[CP] Check Pods Manifest.lock";
+			outputFileListPaths = (
+			);
+			outputPaths = (
+				"$(DERIVED_FILE_DIR)/Pods-Rudder-watchOS-checkManifestLockResult.txt",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
+			showEnvVarsInLog = 0;
+		};
+		94BE95E0F476DF23895DCB6F /* [CP] Embed Pods Frameworks */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-RudderTests-watchOS/Pods-RudderTests-watchOS-frameworks-${CONFIGURATION}-input-files.xcfilelist",
+			);
+			name = "[CP] Embed Pods Frameworks";
+			outputFileListPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-RudderTests-watchOS/Pods-RudderTests-watchOS-frameworks-${CONFIGURATION}-output-files.xcfilelist",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-RudderTests-watchOS/Pods-RudderTests-watchOS-frameworks.sh\"\n";
+			showEnvVarsInLog = 0;
+		};
+		A39CDD690B851FCC6F21BCFF /* [CP] Check Pods Manifest.lock */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -2197,46 +2237,7 @@
 			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
 			showEnvVarsInLog = 0;
 		};
-		953A3028C6A5333C104A17FA /* [CP] Check Pods Manifest.lock */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputFileListPaths = (
-			);
-			inputPaths = (
-				"${PODS_PODFILE_DIR_PATH}/Podfile.lock",
-				"${PODS_ROOT}/Manifest.lock",
-			);
-			name = "[CP] Check Pods Manifest.lock";
-			outputFileListPaths = (
-			);
-			outputPaths = (
-				"$(DERIVED_FILE_DIR)/Pods-RudderTests-iOS-checkManifestLockResult.txt",
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
-			showEnvVarsInLog = 0;
-		};
-		95609E0B374DE1F330EABE65 /* [CP] Embed Pods Frameworks */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputFileListPaths = (
-				"${PODS_ROOT}/Target Support Files/Pods-RudderTests-watchOS/Pods-RudderTests-watchOS-frameworks-${CONFIGURATION}-input-files.xcfilelist",
-			);
-			name = "[CP] Embed Pods Frameworks";
-			outputFileListPaths = (
-				"${PODS_ROOT}/Target Support Files/Pods-RudderTests-watchOS/Pods-RudderTests-watchOS-frameworks-${CONFIGURATION}-output-files.xcfilelist",
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-RudderTests-watchOS/Pods-RudderTests-watchOS-frameworks.sh\"\n";
-			showEnvVarsInLog = 0;
-		};
-		AD6452261C56A78ADD9E66F5 /* [CP] Check Pods Manifest.lock */ = {
+		B77A79581B274E25A326F22D /* [CP] Check Pods Manifest.lock */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -2258,7 +2259,7 @@
 			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
 			showEnvVarsInLog = 0;
 		};
-		F047EAAD4A3D4944740FAC24 /* [CP] Check Pods Manifest.lock */ = {
+		C28C1972688C65E5EAE03471 /* [CP] Check Pods Manifest.lock */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -2273,11 +2274,28 @@
 			outputFileListPaths = (
 			);
 			outputPaths = (
-				"$(DERIVED_FILE_DIR)/Pods-Rudder-tvOS-checkManifestLockResult.txt",
+				"$(DERIVED_FILE_DIR)/Pods-RudderTests-iOS-checkManifestLockResult.txt",
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
 			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
+			showEnvVarsInLog = 0;
+		};
+		CFD481FFA7D08854676F4C41 /* [CP] Embed Pods Frameworks */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-RudderTests-tvOS/Pods-RudderTests-tvOS-frameworks-${CONFIGURATION}-input-files.xcfilelist",
+			);
+			name = "[CP] Embed Pods Frameworks";
+			outputFileListPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-RudderTests-tvOS/Pods-RudderTests-tvOS-frameworks-${CONFIGURATION}-output-files.xcfilelist",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-RudderTests-tvOS/Pods-RudderTests-tvOS-frameworks.sh\"\n";
 			showEnvVarsInLog = 0;
 		};
 /* End PBXShellScriptBuildPhase section */
@@ -2360,6 +2378,7 @@
 				ED7DFE8F298C091800ED5A8E /* RSECommerceSortBuilder.m in Sources */,
 				ED7DFE3F298C091800ED5A8E /* RSServerDestination.m in Sources */,
 				ED7DFEB6298C091800ED5A8E /* RSOrderRefundedEvent.m in Sources */,
+				F64116022B68EC4B0015CB42 /* RSDefaultsPersistence.m in Sources */,
 				ED7DFEC2298C091800ED5A8E /* RSCouponEnteredEvent.m in Sources */,
 				ED7DFE3E298C091800ED5A8E /* RSApp.m in Sources */,
 				ED7DFEE6298C091800ED5A8E /* RSUserSession.m in Sources */,
@@ -2469,6 +2488,7 @@
 				ED998EEF2A69003600031B06 /* WKInterfaceController+RSScreen.m in Sources */,
 				ED998EF02A69003600031B06 /* RSECommerceSortBuilder.m in Sources */,
 				ED998EF12A69003600031B06 /* RSServerDestination.m in Sources */,
+				F64116032B68EC4B0015CB42 /* RSDefaultsPersistence.m in Sources */,
 				ED998EF22A69003600031B06 /* RSOrderRefundedEvent.m in Sources */,
 				ED998EF32A69003600031B06 /* RSCouponEnteredEvent.m in Sources */,
 				ED998EF42A69003600031B06 /* RSApp.m in Sources */,
@@ -2578,6 +2598,7 @@
 				ED998FBF2A69024E00031B06 /* WKInterfaceController+RSScreen.m in Sources */,
 				ED998FC02A69024E00031B06 /* RSECommerceSortBuilder.m in Sources */,
 				ED998FC12A69024E00031B06 /* RSServerDestination.m in Sources */,
+				F64116042B68EC4B0015CB42 /* RSDefaultsPersistence.m in Sources */,
 				ED998FC22A69024E00031B06 /* RSOrderRefundedEvent.m in Sources */,
 				ED998FC32A69024E00031B06 /* RSCouponEnteredEvent.m in Sources */,
 				ED998FC42A69024E00031B06 /* RSApp.m in Sources */,
@@ -2617,6 +2638,7 @@
 				ED9990752A69109000031B06 /* EventRepositoryTests.swift in Sources */,
 				ED99906E2A69109000031B06 /* ConserFilterHandlerTests.swift in Sources */,
 				ED9990732A69109000031B06 /* DataResidencyTests.swift in Sources */,
+				F64116062B6A2DA20015CB42 /* DefaultsPersistenceTests.swift in Sources */,
 				ED9990762A69109000031B06 /* TestUtils.swift in Sources */,
 				ED9990722A69109000031B06 /* Extensions.swift in Sources */,
 				ED252CF62AA8780600B17ACF /* UserSessionTests.swift in Sources */,
@@ -2634,6 +2656,7 @@
 				ED99907E2A69109100031B06 /* EventRepositoryTests.swift in Sources */,
 				ED9990772A69109100031B06 /* ConserFilterHandlerTests.swift in Sources */,
 				ED99907C2A69109100031B06 /* DataResidencyTests.swift in Sources */,
+				F64116072B6A2DA20015CB42 /* DefaultsPersistenceTests.swift in Sources */,
 				ED99907F2A69109100031B06 /* TestUtils.swift in Sources */,
 				ED99907B2A69109100031B06 /* Extensions.swift in Sources */,
 				ED252CF72AA8780600B17ACF /* UserSessionTests.swift in Sources */,
@@ -2651,6 +2674,7 @@
 				ED9990872A69109100031B06 /* EventRepositoryTests.swift in Sources */,
 				ED9990802A69109100031B06 /* ConserFilterHandlerTests.swift in Sources */,
 				ED9990852A69109100031B06 /* DataResidencyTests.swift in Sources */,
+				F64116082B6A2DA20015CB42 /* DefaultsPersistenceTests.swift in Sources */,
 				ED9990882A69109100031B06 /* TestUtils.swift in Sources */,
 				ED9990842A69109100031B06 /* Extensions.swift in Sources */,
 				ED252CF82AA8780600B17ACF /* UserSessionTests.swift in Sources */,
@@ -2809,7 +2833,7 @@
 		};
 		06CABB992630C3CA0097BEFF /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 4C7350A8F5EF4005A9C8002C /* Pods-Rudder-iOS.debug.xcconfig */;
+			baseConfigurationReference = D622D27CE082C02F605707FE /* Pods-Rudder-iOS.debug.xcconfig */;
 			buildSettings = {
 				ALLOW_TARGET_PLATFORM_SPECIALIZATION = YES;
 				APPLICATION_EXTENSION_API_ONLY = NO;
@@ -2854,7 +2878,7 @@
 		};
 		06CABB9A2630C3CA0097BEFF /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 6EB16DBB6C33BA3C3E7ACCF7 /* Pods-Rudder-iOS.release.xcconfig */;
+			baseConfigurationReference = 6307363FD931C4184D3CB813 /* Pods-Rudder-iOS.release.xcconfig */;
 			buildSettings = {
 				ALLOW_TARGET_PLATFORM_SPECIALIZATION = YES;
 				APPLICATION_EXTENSION_API_ONLY = NO;
@@ -2898,7 +2922,7 @@
 		};
 		ED998F132A69003600031B06 /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 588BDCDCC681265EFA53EC1A /* Pods-Rudder-tvOS.debug.xcconfig */;
+			baseConfigurationReference = 8386A90FCB2E6C483CC34952 /* Pods-Rudder-tvOS.debug.xcconfig */;
 			buildSettings = {
 				ALLOW_TARGET_PLATFORM_SPECIALIZATION = YES;
 				APPLICATION_EXTENSION_API_ONLY = NO;
@@ -2943,7 +2967,7 @@
 		};
 		ED998F142A69003600031B06 /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 024DFF0FE82BFA633C7A0ACF /* Pods-Rudder-tvOS.release.xcconfig */;
+			baseConfigurationReference = CC0F863D62F9D02F7B958FA2 /* Pods-Rudder-tvOS.release.xcconfig */;
 			buildSettings = {
 				ALLOW_TARGET_PLATFORM_SPECIALIZATION = YES;
 				APPLICATION_EXTENSION_API_ONLY = NO;
@@ -2987,7 +3011,7 @@
 		};
 		ED998FE32A69024E00031B06 /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = AEA654A683B9C42785EF4586 /* Pods-Rudder-watchOS.debug.xcconfig */;
+			baseConfigurationReference = 9F810D86FD6A9B76CB56D407 /* Pods-Rudder-watchOS.debug.xcconfig */;
 			buildSettings = {
 				ALLOW_TARGET_PLATFORM_SPECIALIZATION = YES;
 				APPLICATION_EXTENSION_API_ONLY = NO;
@@ -3032,7 +3056,7 @@
 		};
 		ED998FE42A69024E00031B06 /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 8864716542CDA61025379626 /* Pods-Rudder-watchOS.release.xcconfig */;
+			baseConfigurationReference = 7DCFD27F69B0AF5419724FC5 /* Pods-Rudder-watchOS.release.xcconfig */;
 			buildSettings = {
 				ALLOW_TARGET_PLATFORM_SPECIALIZATION = YES;
 				APPLICATION_EXTENSION_API_ONLY = NO;
@@ -3076,7 +3100,7 @@
 		};
 		ED9990352A69102400031B06 /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 1826685173321FC0D2D525F6 /* Pods-RudderTests-tvOS.debug.xcconfig */;
+			baseConfigurationReference = DFF929D4168AFBD1511A4013 /* Pods-RudderTests-tvOS.debug.xcconfig */;
 			buildSettings = {
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
 				CODE_SIGN_STYLE = Automatic;
@@ -3098,7 +3122,7 @@
 		};
 		ED9990362A69102400031B06 /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = A5B61F726E782A95371426B4 /* Pods-RudderTests-tvOS.release.xcconfig */;
+			baseConfigurationReference = 985D25DF983E35D9BA1961B7 /* Pods-RudderTests-tvOS.release.xcconfig */;
 			buildSettings = {
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
 				CODE_SIGN_STYLE = Automatic;
@@ -3120,7 +3144,7 @@
 		};
 		ED9990432A69103B00031B06 /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 59CAC564577C2DF84C1C4FA7 /* Pods-RudderTests-iOS.debug.xcconfig */;
+			baseConfigurationReference = 80D3FB2299E58D1817A1B0E2 /* Pods-RudderTests-iOS.debug.xcconfig */;
 			buildSettings = {
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
 				CODE_SIGN_STYLE = Automatic;
@@ -3152,7 +3176,7 @@
 		};
 		ED9990442A69103B00031B06 /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 791CB89B417016D590354A7F /* Pods-RudderTests-iOS.release.xcconfig */;
+			baseConfigurationReference = 51D8D2C7430591C091E783C8 /* Pods-RudderTests-iOS.release.xcconfig */;
 			buildSettings = {
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
 				CODE_SIGN_STYLE = Automatic;
@@ -3184,7 +3208,7 @@
 		};
 		ED9990512A69104B00031B06 /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 94FCF9CB2A6B261F650FA34A /* Pods-RudderTests-watchOS.debug.xcconfig */;
+			baseConfigurationReference = 010DAF827438C4A823468825 /* Pods-RudderTests-watchOS.debug.xcconfig */;
 			buildSettings = {
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
 				CODE_SIGN_STYLE = Automatic;
@@ -3206,7 +3230,7 @@
 		};
 		ED9990522A69104B00031B06 /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 8993C949BB21E74269543A5A /* Pods-RudderTests-watchOS.release.xcconfig */;
+			baseConfigurationReference = 3C702DB8C75FBD66B10B8EDF /* Pods-RudderTests-watchOS.release.xcconfig */;
 			buildSettings = {
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
 				CODE_SIGN_STYLE = Automatic;

--- a/Rudder.xcodeproj/xcshareddata/xcschemes/RudderTests-iOS.xcscheme
+++ b/Rudder.xcodeproj/xcshareddata/xcschemes/RudderTests-iOS.xcscheme
@@ -14,11 +14,10 @@
       onlyGenerateCoverageForSpecifiedTargets = "YES">
       <Testables>
          <TestableReference
-            skipped = "NO"
-            parallelizable = "YES">
+            skipped = "NO">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "ED04A23B29839DCC0080A88D"
+               BlueprintIdentifier = "ED99903A2A69103A00031B06"
                BuildableName = "RudderTests-iOS.xctest"
                BlueprintName = "RudderTests-iOS"
                ReferencedContainer = "container:Rudder.xcodeproj">

--- a/Rudder.xcodeproj/xcshareddata/xcschemes/RudderTests-tvOS.xcscheme
+++ b/Rudder.xcodeproj/xcshareddata/xcschemes/RudderTests-tvOS.xcscheme
@@ -14,8 +14,7 @@
       shouldAutocreateTestPlan = "YES">
       <Testables>
          <TestableReference
-            skipped = "NO"
-            parallelizable = "YES">
+            skipped = "NO">
             <BuildableReference
                BuildableIdentifier = "primary"
                BlueprintIdentifier = "ED99902C2A69102400031B06"

--- a/Rudder.xcodeproj/xcshareddata/xcschemes/RudderTests-watchOS.xcscheme
+++ b/Rudder.xcodeproj/xcshareddata/xcschemes/RudderTests-watchOS.xcscheme
@@ -14,8 +14,7 @@
       shouldAutocreateTestPlan = "YES">
       <Testables>
          <TestableReference
-            skipped = "NO"
-            parallelizable = "YES">
+            skipped = "NO">
             <BuildableReference
                BuildableIdentifier = "primary"
                BlueprintIdentifier = "ED9990482A69104B00031B06"

--- a/Sources/Classes/Headers/Public/RSDefaultsPersistence.h
+++ b/Sources/Classes/Headers/Public/RSDefaultsPersistence.h
@@ -1,0 +1,22 @@
+//
+//  RSDefaultsPersistence.h
+//  Rudder
+//
+//  Created by Desu Sai Venkat on 30/01/24.
+//
+
+@interface RSDefaultsPersistence : NSObject {
+    NSMutableDictionary *data;
+    NSURL *fileURL;
+    dispatch_queue_t dataAccessQueue;
+}
+
+- (instancetype)init NS_UNAVAILABLE NS_SWIFT_UNAVAILABLE("Use `RSDefaultsPersistence.sharedInstance()` instead.");
++ (instancetype)sharedInstance;
+- (void) copyStandardDefaultsToPersistenceIfNeeded;
+- (void) clearState;
+- (void)writeObject:(id)object forKey:(NSString *)key;
+- (id)readObjectForKey:(NSString *)key;
+- (void)removeObjectForKey:(NSString *)key;
+
+@end

--- a/Sources/Classes/Headers/Public/RSEventRepository.h
+++ b/Sources/Classes/Headers/Public/RSEventRepository.h
@@ -17,6 +17,7 @@
 #import "RSElementCache.h"
 #import "RSCloudModeManager.h"
 #import "RSDeviceModeManager.h"
+#import "RSDefaultsPersistence.h"
 #import "RSPreferenceManager.h"
 #import "RSDBPersistentManager.h"
 #import "RSDataResidencyManager.h"
@@ -37,6 +38,7 @@ NS_ASSUME_NONNULL_BEGIN
     RSDataResidencyManager* dataResidencyManager;
     RSServerConfigManager* configManager;
     RSNetworkManager* networkManager;
+    RSDefaultsPersistence* defaultsPersistence;
     RSPreferenceManager *preferenceManager;
     RSCloudModeManager *cloudModeManager;
     RSDeviceModeManager *deviceModeManager;

--- a/Sources/Classes/Headers/Public/RSPreferenceManager.h
+++ b/Sources/Classes/Headers/Public/RSPreferenceManager.h
@@ -1,11 +1,12 @@
 //
 //  RSPreferenceManager.h
-//  Pods-DummyTestProject
+//  Rudder
 //
 //  Created by Arnab Pal on 27/01/20.
 //
 
 #import <Foundation/Foundation.h>
+#import "RSDefaultsPersistence.h"
 
 NS_ASSUME_NONNULL_BEGIN
 
@@ -25,6 +26,7 @@ extern NSString *const RSLastActiveTimestamp;
 extern NSString *const RSSessionAutoTrackStatus;
 
 + (instancetype) getInstance;
++ (NSArray *) getPreferenceKeys;
 
 - (void) updateLastUpdatedTime: (long) updatedTime;
 - (long) getLastUpdatedTime;
@@ -41,6 +43,7 @@ extern NSString *const RSSessionAutoTrackStatus;
 - (void) deleteBuildVersionCode;
 
 - (void) performMigration;
+- (void) restoreMissingDefaultsFromPersistence;
 
 - (NSString* __nullable) getBuildNumber;
 - (void) saveBuildNumber: (NSString* __nonnull) buildNumber;

--- a/Sources/Classes/Headers/Public/RSUtils.h
+++ b/Sources/Classes/Headers/Public/RSUtils.h
@@ -22,6 +22,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 + (NSString*) getTimestamp;
 + (NSString *)getFilePath:(NSString *)fileName;
++ (NSURL *)getFileURL:(NSString *) fileName;
 + (long) getTimeStampLong;
 + (NSString*) getUniqueId;
 + (NSString*) getLocale;
@@ -42,6 +43,7 @@ NS_ASSUME_NONNULL_BEGIN
 + (BOOL) isApplicationUpdated;
 + (NSString* _Nullable) getDeviceId;
 + (BOOL)isFileExists:(NSString *)fileName;
++ (BOOL)doesFileExistsAtURL:(NSURL *)fileURL;
 + (BOOL)removeFile:(NSString *)fileName;
 + (BOOL) isDBMessageEmpty:(RSDBMessage*)dbMessage;
 + (BOOL) isEmptyString:(NSString *)value;

--- a/Sources/Classes/Headers/RSVersion.h
+++ b/Sources/Classes/Headers/RSVersion.h
@@ -8,6 +8,6 @@
 #ifndef RSVersion_h
 #define RSVersion_h
 
-NSString *const SDK_VERSION = @"1.25.1";
+NSString *const SDK_VERSION = @"1.25.2";
 
 #endif /* RSVersion_h */

--- a/Sources/Classes/RSDefaultsPersistence.m
+++ b/Sources/Classes/RSDefaultsPersistence.m
@@ -1,0 +1,115 @@
+//
+//  RSDefaultsPersistence.m
+//  Rudder
+//
+//  Created by Desu Sai Venkat on 30/01/24.
+//
+
+#import <Foundation/Foundation.h>
+#import "RSUtils.h"
+#import "RSLogger.h"
+#import "RSDefaultsPersistence.h"
+
+static RSDefaultsPersistence *instance;
+static NSString * const standardDefaultsCopied = @"standardDefaultsCopied";
+
+@implementation RSDefaultsPersistence
+
++ (instancetype)sharedInstance {
+    if(instance == nil) {
+        static dispatch_once_t onceToken;
+        dispatch_once(&onceToken, ^{
+            instance = [[self alloc] init];
+        });
+    }
+    return instance;
+}
+
+- (instancetype)init {
+    self = [super init];
+    if (self) {
+        data = [NSMutableDictionary dictionary];
+        fileURL = [RSUtils getFileURL:@"rsDefaultsPersistence.plist"];
+        dataAccessQueue = dispatch_queue_create("com.rudderstack.defaultspersistence", DISPATCH_QUEUE_SERIAL);
+        [self loadFromFile];
+    }
+    return self;
+}
+
+- (void)loadFromFile {
+    if ([RSUtils doesFileExistsAtURL:fileURL]) {
+        NSError *error = nil;
+        NSDictionary* dictFromFile = [NSMutableDictionary dictionaryWithContentsOfURL:fileURL error:&error];
+        if (error == nil && dictFromFile != nil) {
+            [data addEntriesFromDictionary:dictFromFile];
+        }
+    }
+}
+
+// this would be executed only once after the SDK has been updated from a version without DefaultsPersistence
+// to a version with DefaultsPersistence to ensure that the persistence layer and standard defaults are in same state.
+- (void)copyStandardDefaultsToPersistenceIfNeeded {
+    BOOL userDefaultsCopiedAlready = [self readObjectForKey:standardDefaultsCopied];
+    if(!userDefaultsCopiedAlready) {
+        [RSLogger logDebug:@"RSDefaultsPersistence: copyStandardDefaultsToPersistenceIfNeeded: Copying Standard Defaults to Persistence layer"];
+        NSArray* preferenceKeys = [RSPreferenceManager getPreferenceKeys];
+        for(NSString* key in preferenceKeys) {
+            id value = [[NSUserDefaults standardUserDefaults] objectForKey:key];
+            if(value != nil) {
+                [self writeObject:value forKey:key];
+            }
+        }
+        // Set the flag to indicate that standard defaults have been copied to the persistence layer
+        [self writeObject:@YES forKey:standardDefaultsCopied];
+    }
+}
+
+// the caller of this method should ensure that this is dispatched to the dataAccessQueue synchronously
+- (void)writeToFile {
+    NSError* error = nil;
+    [data writeToURL:fileURL error:&error];
+    if (error != nil) {
+        [RSLogger logError: [NSString stringWithFormat:@"RSDefaultsPersistence: writeToFile: Error writing to file: %@", error]];
+    }
+}
+
+- (void) writeToFileSync {
+    dispatch_sync(dataAccessQueue, ^{
+        [self writeToFile];
+    });
+}
+
+- (void)writeObject:(id)object forKey:(NSString *)key {
+    dispatch_sync(dataAccessQueue, ^{
+        if (object && key) {
+            data[key] = object;
+            [self writeToFile];
+        }
+    });
+}
+
+- (id)readObjectForKey:(NSString *)key {
+    __block id result;
+    dispatch_sync(dataAccessQueue, ^{
+        result = data[key];
+    });
+    return result;
+    
+}
+
+- (void)removeObjectForKey:(NSString *)key {
+    dispatch_sync(dataAccessQueue, ^{
+        [data removeObjectForKey:key];
+        [self writeToFile];
+    });
+}
+
+// for testing purpose only
+- (void) clearState {
+    dispatch_sync(dataAccessQueue, ^{
+        [data removeAllObjects];
+        [self writeToFile];
+    });
+}
+
+@end

--- a/Sources/Classes/RSEventRepository.m
+++ b/Sources/Classes/RSEventRepository.m
@@ -57,9 +57,14 @@ static RSEventRepository* _instance;
         
         self->authToken = [RSUtils getBase64EncodedString: [[NSString alloc] initWithFormat:@"%@:", self->writeKey]];
         
+        [RSLogger logDebug:@"EventRepository: Initiating DefaultsPersistence"];
+        self->defaultsPersistence = [RSDefaultsPersistence sharedInstance];
+        [self->defaultsPersistence copyStandardDefaultsToPersistenceIfNeeded];
+        
         [RSLogger logDebug:@"EventRepository: Initiating RSPreferenceManager"];
         self->preferenceManager = [RSPreferenceManager getInstance];
         [self->preferenceManager performMigration];
+        [self->preferenceManager restoreMissingDefaultsFromPersistence];
         
         [self clearAnonymousIdIfRequired];
         

--- a/Sources/Classes/RSUtils.m
+++ b/Sources/Classes/RSUtils.m
@@ -45,9 +45,22 @@
     return [directory stringByAppendingPathComponent:fileName];
 }
 
++ (NSURL *)getFileURL:(NSString *) fileName {
+    NSString *filePath = [self getFilePath:fileName];
+    return [NSURL fileURLWithPath:filePath isDirectory:NO];
+}
+
 + (BOOL)isFileExists:(NSString *)fileName {
     NSString *path = [self getFilePath:fileName];
     return [[NSFileManager defaultManager] fileExistsAtPath:path];
+}
+
++ (BOOL)doesFileExistsAtURL:(NSURL *)fileURL {
+    NSString* filePath = [fileURL path];
+    if(filePath != nil) {
+        return [[NSFileManager defaultManager] fileExistsAtPath:filePath];
+    }
+    return NO;
 }
 
 + (BOOL)removeFile:(NSString *)fileName {

--- a/Tests/DefaultsPersistenceTests.swift
+++ b/Tests/DefaultsPersistenceTests.swift
@@ -1,0 +1,100 @@
+//
+//  DefaultsPersistenceTests.swift
+//  Rudder
+//
+//  Created by Desu Sai Venkat on 31/01/24.
+//
+
+import XCTest
+import Foundation
+@testable import Rudder
+
+
+class DefaultsPersistenceTests: XCTestCase {
+    
+    override func setUp() {
+        clearDefaults()
+        RSDefaultsPersistence.sharedInstance().clearState()
+        super.setUp()
+    }
+    
+    override func tearDown() {
+        clearDefaults()
+        RSDefaultsPersistence.sharedInstance().clearState()
+        super.tearDown()
+    }
+    
+    func testCopyingFromStandardDefaultsIfNeeded() {
+        UserDefaults.standard.setValue("{\"name\": \"John\"}", forKey: RSTraitsKey)
+        UserDefaults.standard.setValue(false, forKey: RSOptStatus)
+        UserDefaults.standard.setValue("1.4.4", forKey: RSApplicationInfoKey)
+        UserDefaults.standard.setValue(1706686541, forKey: RSLastActiveTimestamp)
+        UserDefaults.standard.setValue("RudderStack India", forKey: "Company")
+        
+        let defaultsPersistence = RSDefaultsPersistence.sharedInstance()
+        defaultsPersistence?.clearState()
+        defaultsPersistence?.copyStandardDefaultsToPersistenceIfNeeded()
+        XCTAssertEqual(defaultsPersistence?.readObject(forKey: RSTraitsKey) as? String, "{\"name\": \"John\"}")
+        XCTAssertEqual(defaultsPersistence?.readObject(forKey: RSOptStatus) as? Bool, false)
+        XCTAssertEqual(defaultsPersistence?.readObject(forKey: RSApplicationInfoKey) as? String, "1.4.4")
+        XCTAssertNil(defaultsPersistence?.readObject(forKey: "Company"))
+        XCTAssertEqual(defaultsPersistence?.readObject(forKey: RSLastActiveTimestamp) as? Int, 1706686541)
+    }
+    
+    func testIfFallingBackToPersistenceLayer() {
+        
+        let preferenceManager = RSPreferenceManager.getInstance()
+        preferenceManager.saveTraits("{\"name\": \"Adam\"}")
+        preferenceManager.saveOptStatus(false)
+        preferenceManager.saveBuildVersionCode("1.4.5")
+        preferenceManager.saveLastActiveTimestamp(1706686542)
+        
+        XCTAssertEqual(preferenceManager.getTraits() as String, "{\"name\": \"Adam\"}")
+        
+        // now simulate that the app developer directly clears the standard defaults
+        // and check if the preference manager is falling back to persistence layer
+        clearDefaults()
+        XCTAssertEqual(preferenceManager.getTraits() as String, "{\"name\": \"Adam\"}")
+        XCTAssertEqual(preferenceManager.getOptStatus(), false)
+        XCTAssertEqual(preferenceManager.getBuildVersionCode(), "1.4.5")
+        XCTAssertEqual(preferenceManager.getLastActiveTimestamp(), 1706686542)
+    }
+    
+    func testRestoringDefaultsFromPersistence() {
+        let preferenceManager = RSPreferenceManager.getInstance()
+        preferenceManager.saveTraits("{\"name\": \"David\"}")
+        preferenceManager.saveOptStatus(true)
+        preferenceManager.saveBuildVersionCode("1.4.6")
+        preferenceManager.saveLastActiveTimestamp(1706686543)
+        
+        XCTAssertEqual(preferenceManager.getTraits() as String, "{\"name\": \"David\"}")
+        
+        clearDefaults()
+        
+        // preference manager would return back the values from persistence layer and will also set the value in user defaults
+        XCTAssertEqual(preferenceManager.getTraits() as String, "{\"name\": \"David\"}")
+        XCTAssertEqual(UserDefaults.standard.value(forKey: RSTraitsKey) as? String, "{\"name\": \"David\"}")
+        XCTAssertEqual(preferenceManager.getOptStatus(), true)
+        XCTAssertEqual(UserDefaults.standard.value(forKey: RSOptStatus) as? Bool, true)
+        XCTAssertEqual(preferenceManager.getBuildVersionCode(), "1.4.6")
+        XCTAssertEqual(UserDefaults.standard.value(forKey: RSApplicationInfoKey) as? String, "1.4.6")
+        XCTAssertEqual(preferenceManager.getLastActiveTimestamp(), 1706686543)
+        XCTAssertEqual(UserDefaults.standard.value(forKey: RSLastActiveTimestamp) as? Int, 1706686543)
+        
+        clearDefaults()
+        
+        // now we are restoring the missing keys to defaults from persistence, post which defaults should contain the values
+        preferenceManager.restoreMissingDefaultsFromPersistence()
+        
+        XCTAssertEqual(UserDefaults.standard.value(forKey: RSTraitsKey) as? String, "{\"name\": \"David\"}")
+        XCTAssertEqual(UserDefaults.standard.value(forKey: RSOptStatus) as? Bool, true)
+        XCTAssertEqual(UserDefaults.standard.value(forKey: RSApplicationInfoKey) as? String, "1.4.6")
+        XCTAssertEqual(UserDefaults.standard.value(forKey: RSLastActiveTimestamp) as? Int, 1706686543)
+    }
+    
+    func clearDefaults() {
+        for key in [RSTraitsKey, RSOptStatus, RSApplicationInfoKey, RSLastActiveTimestamp, "Company"] {
+            UserDefaults.standard.removeObject(forKey: key)
+        }
+    }
+}

--- a/package.json
+++ b/package.json
@@ -1,4 +1,4 @@
 {
-    "version": "1.25.1",
+    "version": "1.25.2",
     "description": "Rudder is a platform for collecting, storing and routing customer event data to dozens of tools"
 }

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -6,7 +6,7 @@ sonar.qualitygate.wait=false
 sonar.projectKey=rudderlabs_rudder-sdk-ios
 sonar.organization=rudderlabs
 sonar.projectName=RudderStack iOS SDK
-sonar.projectVersion=1.25.1
+sonar.projectVersion=1.25.2
 
 # C/C++/Objective-C related details
 # sonar.cfamily.compile-commands=compile_commands.json


### PR DESCRIPTION
:crown: *An automated PR*

   Unreleased (2024-02-20)<br> * fix: added a persistence layer over keys stored in standard defaults by rudderstack ( 454) ([1c52a07](https://github.com/rudderlabs/rudder-sdk-ios/commit/1c52a07)), closes [ 454](https://github.com/rudderlabs/rudder-sdk-ios/issues/454)<br> * chore(deps): bump slackapi/slack-github-action from 1.24.0 to 1.25.0 ( 451) ([f633573](https://github.com/rudderlabs/rudder-sdk-ios/commit/f633573)), closes [ 451](https://github.com/rudderlabs/rudder-sdk-ios/issues/451)