### PR TITLE
fix: fix SwiftUI mangled names

### DIFF
--- a/Sources/Classes/Helpers/Platforms/iOS/RSiOSScreenViewEvents.swift
+++ b/Sources/Classes/Helpers/Platforms/iOS/RSiOSScreenViewEvents.swift
@@ -42,7 +42,12 @@ extension UIViewController {
     
     @objc
     func rsViewDidAppear(_ animated: Bool) {
-        var name = NSStringFromClass(type(of: self))
+        var name = String(describing: type(of: self))
+        if name.starts(with: "UIHostingController") {
+            name.removeFirst("UIHostingController".count + 1) // Remove `UIHostingController<`
+            if name.hasSuffix(">") { name.removeLast(1) } // Remove last `>`
+        }
+
         name = name.replacingOccurrences(of: "ViewController", with: "")
         let screenMessage = ScreenMessage(title: name, properties: ["automatic": true, "name": name])
         UIViewController.client?.process(message: screenMessage)


### PR DESCRIPTION
# Description

This PR fixes the name mangling of the screen events when the automatic screen tracking tries to capture SwiftUI's views.

The issue was cause by the usage of `NSStringFromClass`, that takes the unique mangled name of a Swift class as seen from the ObjC runtime. Using Swift's standard library `String(describing: type(of: self))` instead returns us the demangled name.

I have implemented this feature on top of the 2.4.3 tag. I'm unsure of what branch to target.

Here's an example: 
| Before | After |
| --- | --- |
| <img width="1036" alt="Screenshot 2024-02-28 at 15 23 00" src="https://github.com/rudderlabs/rudder-sdk-ios/assets/15340382/aca97d20-a464-4e9e-aa1e-6707fd8898af"> | <img width="564" alt="Screenshot 2024-02-28 at 15 22 48" src="https://github.com/rudderlabs/rudder-sdk-ios/assets/15340382/1f9df6e9-e1fa-4b8f-bbe0-0564b80ddf31"> `LoadingView<ActiveEventsFilters, BrowseEventsView>` |

