### PR TITLE
fix: fixed issues with the database migration when moving from v1 to v2.

### DIFF
--- a/RudderTests/Core/SourceConfigDownload/SourceConfigDownloadTests.swift
+++ b/RudderTests/Core/SourceConfigDownload/SourceConfigDownloadTests.swift
@@ -64,7 +64,7 @@ final class SourceConfigDownloadTests: XCTestCase {
         
         // Then
         var count = 0
-        download.sourceConfig = { sourceConfig, _ in
+        download.sourceConfig = { sourceConfig in
             expectation.fulfill()
             if count == 0 {
                 XCTAssertEqual(cachedSourceConfig, sourceConfig)
@@ -116,7 +116,7 @@ final class SourceConfigDownloadTests: XCTestCase {
         let download = SourceConfigDownload(downloader: worker)
         
         // Then
-        download.sourceConfig = { sourceConfig, _ in
+        download.sourceConfig = { sourceConfig in
             expectation.fulfill()
             XCTAssertEqual(downloadedSourceConfig, sourceConfig)
         }

--- a/RudderTests/Core/SourceConfigDownload/SourceConfigDownloadWorkerTests.swift
+++ b/RudderTests/Core/SourceConfigDownload/SourceConfigDownloadWorkerTests.swift
@@ -53,7 +53,7 @@ final class SourceConfigDownloadWorkerTests: XCTestCase {
             retryStrategy: retryStrategy
         )
         
-        worker.sourceConfig = { expectedSourceConfig, _ in
+        worker.sourceConfig = { expectedSourceConfig in
             XCTAssertEqual(expectedSourceConfig, sourceConfig)
         }
         
@@ -96,7 +96,7 @@ final class SourceConfigDownloadWorkerTests: XCTestCase {
             retryStrategy: retryStrategy
         )
         
-        worker.sourceConfig = { _, _ in }
+        worker.sourceConfig = { _ in }
         
         wait(for: [expectation], timeout: 6.0)
     }

--- a/RudderTests/Core/Storage/StorageMigratorTests.swift
+++ b/RudderTests/Core/Storage/StorageMigratorTests.swift
@@ -11,50 +11,108 @@ import XCTest
 
 final class StorageMigratorTests: XCTestCase {
     
-    func test_migrate() throws {
+    let legacyStorageName = "rl_persistence.sqlite"
+    let currentStorageName = "rl_persistence_default_test.sqlite"
+    
+    func test_migration_when_sourceId_matches() {
         // Given
-        let path = FileManager.default.urls(for: .cachesDirectory, in: FileManager.SearchPathDomainMask.userDomainMask)[0]
-        let oldDatabase = SQLiteDatabase(path: path, name: "rl_persistence_test.sqlite")
-        let oldSQLiteStorage = SQLiteStorage(
-            database: oldDatabase,
-            logger: Logger(logger: NOLogger())
-        )
+        /// creating legacy storage, and then opening it and deleting if there are any events already in the storage
+        let legacyStorage = createStorage(storageName: legacyStorageName)
+        legacyStorage.open()
+        legacyStorage.deleteAll()
+        /// adding some dummy events to the legacy storage to test the migration
+        addDummyEventsToStorage(storage: legacyStorage, count: 5)
+        XCTAssertEqual(try legacyStorage.count().get(), 5)
+        legacyStorage.close()
         
-        oldSQLiteStorage.open()
-        oldSQLiteStorage.deleteAll()
-        
-        let databasePath = path.appendingPathComponent("rl_persistence_test.sqlite").path
-        XCTAssertTrue(FileManager.default.fileExists(atPath: databasePath))
-        
-        oldSQLiteStorage.save(StorageMessage(id: "", message: "message_3", updated: 1234567890))
-        oldSQLiteStorage.save(StorageMessage(id: "", message: "message_4", updated: 1235454094))
-        oldSQLiteStorage.save(StorageMessage(id: "", message: "message_5", updated: 1245935445))
-        oldSQLiteStorage.save(StorageMessage(id: "", message: "message_6", updated: 1223465723))
-
-        let currentDatabase = SQLiteDatabase(path: path, name: "rl_persistence_default_test.sqlite")
-        let currentStorage = SQLiteStorage(
-            database: currentDatabase,
-            logger: Logger(logger: NOLogger())
-        )
-        
+        /// creating current storage, and then opening it and deleting if there are any events already in the storage
+        let currentStorage = createStorage(storageName: currentStorageName)
         currentStorage.open()
         currentStorage.deleteAll()
-        
-        currentStorage.save(StorageMessage(id: "", message: "message_1", updated: 1246573777))
-        currentStorage.save(StorageMessage(id: "", message: "message_2", updated: 1223546723))
-        
+        /// adding some dummy events to the current storage to test the migration
+        addDummyEventsToStorage(storage: currentStorage, count: 2)
         XCTAssertEqual(try currentStorage.count().get(), 2)
         
-        let storageMigrator = StorageMigratorV1V2(oldSQLiteStorage: oldSQLiteStorage, currentStorage: currentStorage)
+        let currentSourceConfig = getSourceConfig(sourceId: "source1")
+        /// Setting the legacy SourceConfig to same value as the current SourceConfig so that the migrator performs migration
+        UserDefaults.standard.setValue(String(decoding: try! JSONEncoder().encode(currentSourceConfig), as: UTF8.self), forKey: UserDefaultsKeys.legacySourceConfig.rawValue)
+        
         
         // When
-        try storageMigrator.migrate()
+        let storageMigrator = StorageMigratorV1V2(currentStorage: currentStorage, currentSourceConfig: currentSourceConfig, logger: Logger(logger: NOLogger()))
+        storageMigrator.migrate()
         
         // Then
-        XCTAssertEqual(try currentStorage.count().get(), 6)
-        XCTAssertFalse(FileManager.default.fileExists(atPath: databasePath))
+        XCTAssertEqual(try currentStorage.count().get(), 7)
+        XCTAssertFalse(FileManager.default.fileExists(atPath: getStoragePath(name: legacyStorageName)))
         
-        oldSQLiteStorage.close()
         currentStorage.close()
+        deleteStorage(name: legacyStorageName)
+        deleteStorage(name: currentStorageName)
+    }
+    
+    func test_migration_when_sourceIds_are_different() {
+        // Given
+        /// creating legacy storage, and then opening it and deleting if there are any events already in the storage
+        let legacyStorage = createStorage(storageName: legacyStorageName)
+        legacyStorage.open()
+        legacyStorage.deleteAll()
+        /// adding some dummy events to the legacy storage to test the migration
+        addDummyEventsToStorage(storage: legacyStorage, count: 5)
+        XCTAssertEqual(try legacyStorage.count().get(), 5)
+        legacyStorage.close()
+        
+        /// creating current storage, and then opening it and deleting if there are any events already in the storage
+        let currentStorage = createStorage(storageName: currentStorageName)
+        currentStorage.open()
+        currentStorage.deleteAll()
+        /// adding some dummy events to the current storage to test the migration
+        addDummyEventsToStorage(storage: currentStorage, count: 2)
+        XCTAssertEqual(try currentStorage.count().get(), 2)
+        
+        let currentSourceConfig = getSourceConfig(sourceId: "source1")
+        let legacySourceConfig = getSourceConfig(sourceId: "source2")
+        /// Setting the legacy SourceConfig to a value different from current SourceConfig so that the migration will not happen
+        UserDefaults.standard.setValue(String(decoding: try! JSONEncoder().encode(legacySourceConfig), as: UTF8.self), forKey: UserDefaultsKeys.legacySourceConfig.rawValue)
+        
+        
+        // When
+        let storageMigrator = StorageMigratorV1V2(currentStorage: currentStorage, currentSourceConfig: currentSourceConfig, logger: Logger(logger: NOLogger()))
+        storageMigrator.migrate()
+        
+        // Then
+        XCTAssertEqual(try currentStorage.count().get(), 2)
+        XCTAssertTrue(FileManager.default.fileExists(atPath: getStoragePath(name: legacyStorageName)))
+        
+        currentStorage.close()
+        deleteStorage(name: legacyStorageName)
+        deleteStorage(name: currentStorageName)
+    }
+    
+    func createStorage(storageName: String) -> SQLiteStorage {
+        let database = SQLiteDatabase(path: Device.current.directoryPath, name: storageName)
+        let storage = SQLiteStorage(
+            database: database,
+            logger: Logger(logger: NOLogger())
+        )
+        return storage
+    }
+    
+    func addDummyEventsToStorage(storage: SQLiteStorage, count: Int) {
+        for i in 1...count {
+            storage.save(StorageMessage(id: "", message: "message_\(storage.database.name)_\(i)", updated: Utility.getTimeStamp()))
+        }
+    }
+    
+    func getStoragePath(name: String) -> String {
+        Device.current.directoryPath.appendingPathComponent(name).path
+    }
+    
+    func deleteStorage(name: String) {
+        try? FileManager.default.removeItem(atPath: getStoragePath(name: name))
+    }
+    
+    func getSourceConfig(sourceId: String) -> SourceConfig {
+        SourceConfig(source: SourceConfig.Source(id: sourceId, name: nil, writeKey: nil, enabled: nil, sourceDefinitionId: nil, createdBy: nil, workspaceId: nil, deleted: nil, createdAt: nil, updatedAt: nil, destinations: nil, dataPlanes: nil))
     }
 }

--- a/RudderTests/Mocks/CoreMocks.swift
+++ b/RudderTests/Mocks/CoreMocks.swift
@@ -348,11 +348,3 @@ extension RSClient {
         )
     }
 }
-
-class StorageMigratorMock: StorageMigrator {
-    var currentStorage: Storage = StorageMock()
-    
-    func migrate() throws {
-        
-    }
-}

--- a/Sources/Classes/Core/Common/Constants/LogMessages.swift
+++ b/Sources/Classes/Core/Common/Constants/LogMessages.swift
@@ -56,7 +56,9 @@ enum LogMessages {
     case eventFiltered
     case storageMigrationFailed(StorageError)
     case storageMigrationSuccess
-    case oldDatabaseNotExists
+    case legacyDatabaseDoesNotExists
+    case storageMigrationFailedToReadSourceConfig
+    case failedToDeleteLegacyDatabase(String)
     case apiError(API, APIError)
     
     var description: String {
@@ -128,9 +130,13 @@ enum LogMessages {
         case .storageMigrationFailed(let error):
             return "Storage migration failed. Reason: \(error.description)"
         case .storageMigrationSuccess:
-            return "Storage migration is successful"
-        case .oldDatabaseNotExists:
-            return "Old database not exists, hence no migration needed"
+            return "Successfully migrated data from legacy storage and deleted the legacy database."
+        case .legacyDatabaseDoesNotExists:
+            return "Legacy database does not exists, hence no migration needed"
+        case .storageMigrationFailedToReadSourceConfig:
+            return "Legacy database exists, but failed to read legacy SourceConfig, so cannot migrate data, hence deleting the legacy database"
+        case .failedToDeleteLegacyDatabase(let reason):
+            return "Failed to delete legacy database due to \(reason)"
         case .apiError(let api, let error):
             switch error {
             case .httpError(let statusCode):

--- a/Sources/Classes/Core/Helpers/UserDefaultsWorker.swift
+++ b/Sources/Classes/Core/Helpers/UserDefaultsWorker.swift
@@ -13,6 +13,7 @@ public enum UserDefaultsKeys: String {
     case traits = "rs_traits"
     case anonymousId = "rs_anonymous_id"
     case sourceConfig = "rs_server_config"
+    case legacySourceConfig = "rl_server_config"
     case optStatus = "rs_opt_status"
     case optInTime = "rs_opt_in_time"
     case optOutTime = "rs_opt_out_time"

--- a/Sources/Classes/Core/RSClient.swift
+++ b/Sources/Classes/Core/RSClient.swift
@@ -67,7 +67,6 @@ public class RSClient: RSClientProtocol {
     ///   - apiClient: The developer-choice networking client. Can be used `Alamofire`, `Moya`, etc....
     ///   - sourceConfigDownloader: The developer-choice source config download implementation.
     ///   - dataUploader: The developer-choice source upload data(events) to server implementation.
-    ///   - storageMigrator: The developer-choice storage migration implementation, if any.
     ///   - logger: The developer-choice logger.
     required init(
         configuration: Configuration,
@@ -77,8 +76,7 @@ public class RSClient: RSClientProtocol {
         userDefaults: UserDefaults? = nil,
         apiClient: APIClient? = nil,
         sourceConfigDownloader: SourceConfigDownloaderType? = nil,
-        dataUploader: DataUploaderType? = nil,
-        storageMigrator: StorageMigrator? = nil
+        dataUploader: DataUploaderType? = nil
     ) {
         core = RSClientCore(
             configuration: configuration,
@@ -119,7 +117,6 @@ public class RSClient: RSClientProtocol {
     ///   - sourceConfigDownloader: The developer-choice source config download implementation, if any.
     ///   - dataUploader: The developer-choice source upload data(events) to server implementation, if any.
     ///   - logger: The developer-choice logger, if any.
-    ///   - storageMigrator: The developer-choice storage migration implementation, if any.
     /// - Returns: An instance of `RSClient`.
     ///
     @discardableResult

--- a/Sources/Classes/Core/RSClientCore.swift
+++ b/Sources/Classes/Core/RSClientCore.swift
@@ -168,7 +168,7 @@ extension RSClientCore {
         
         sourceConfigDownload = SourceConfigDownload(downloader: downloader)
         
-        sourceConfigDownload?.sourceConfig = { [weak self] sourceConfig, needsDatabaseMigration in
+        sourceConfigDownload?.sourceConfig = { [weak self] sourceConfig in
             guard let self = self else { return }
             if needsDatabaseMigration {
                 self.migrateStorage()

--- a/Sources/Classes/Core/RSClientCore.swift
+++ b/Sources/Classes/Core/RSClientCore.swift
@@ -25,8 +25,6 @@ class RSClientCore {
     var dataUpload: DataUpload?
     var dataUploader: DataUploaderType?
     var sourceConfigDownload: SourceConfigDownload?
-    var storageMigration: StorageMigration?
-    var storageMigrator: StorageMigrator?
     var flushPolicies: [FlushPolicy]
     @ReadWriteLock var pluginList: [PluginType: [Plugin]] = [
         .default: [Plugin](),
@@ -53,8 +51,7 @@ class RSClientCore {
         sourceConfigDownloader: SourceConfigDownloaderType? = nil,
         dataUploader: DataUploaderType? = nil,
         apiClient: APIClient? = nil,
-        applicationState: ApplicationState? = nil,
-        storageMigrator: StorageMigrator? = nil
+        applicationState: ApplicationState? = nil
     ) {
         self.configuration = configuration
         self.instanceName = instanceName
@@ -107,7 +104,6 @@ class RSClientCore {
         if !configuration.flushPolicies.isEmpty {
             self.flushPolicies.append(contentsOf: configuration.flushPolicies)
         }
-        self.storageMigrator = storageMigrator
         trackApplicationState()
         recordScreenViews()
         fetchSourceConfig()

--- a/Sources/Classes/Core/SourceConfigDownload/SourceConfigDownload.swift
+++ b/Sources/Classes/Core/SourceConfigDownload/SourceConfigDownload.swift
@@ -10,12 +10,12 @@ import Foundation
 
 class SourceConfigDownload {
     private var downloader: SourceConfigDownloadWorkerType
-    var sourceConfig: ((SourceConfig, NeedsDatabaseMigration) -> Void) = { _, _ in }
+    var sourceConfig: ((SourceConfig) -> Void) = { _ in }
     
     init(downloader: SourceConfigDownloadWorkerType) {
         self.downloader = downloader
-        self.downloader.sourceConfig = { sourceConfig, needsDatabaseMigration in
-            self.sourceConfig(sourceConfig, needsDatabaseMigration)
+        self.downloader.sourceConfig = { sourceConfig in
+            self.sourceConfig(sourceConfig)
         }
     }
 }

--- a/Sources/Classes/Core/SourceConfigDownload/SourceConfigDownloadWorker.swift
+++ b/Sources/Classes/Core/SourceConfigDownload/SourceConfigDownloadWorker.swift
@@ -11,11 +11,11 @@ import Foundation
 typealias NeedsDatabaseMigration = Bool
 
 protocol SourceConfigDownloadWorkerType {
-    var sourceConfig: ((SourceConfig, NeedsDatabaseMigration) -> Void) { get set }
+    var sourceConfig: ((SourceConfig) -> Void) { get set }
 }
 
 class SourceConfigDownloadWorker: SourceConfigDownloadWorkerType {
-    var sourceConfig: ((SourceConfig, NeedsDatabaseMigration) -> Void) = { _, _ in }
+    var sourceConfig: ((SourceConfig) -> Void) = { _ in }
     
     let sourceConfigDownloader: SourceConfigDownloaderType
     let downloadBlockers: DownloadUploadBlockersProtocol
@@ -50,7 +50,7 @@ class SourceConfigDownloadWorker: SourceConfigDownloadWorkerType {
             guard let self = self else { return }
             if let sourceConfig: SourceConfig = userDefaults.read(.sourceConfig) {
                 self.cachedSourceConfig = sourceConfig
-                self.sourceConfig(sourceConfig, false)
+                self.sourceConfig(sourceConfig)
             }
             let blockersForDownload = downloadBlockers.get()
             if blockersForDownload.isEmpty {
@@ -69,7 +69,7 @@ class SourceConfigDownloadWorker: SourceConfigDownloadWorkerType {
             if let sourceConfig = response.sourceConfig {
                 self.retryStrategy.reset()
                 self.logger.logDebug(.sourceConfigDownloadSuccess)
-                self.sourceConfig(sourceConfig, self.needsMigration(freshSourceConfig: sourceConfig))
+                self.sourceConfig(sourceConfig)
             }
             let downloadStatus = response.status
             if downloadStatus.needsRetry {
@@ -95,14 +95,5 @@ class SourceConfigDownloadWorker: SourceConfigDownloadWorkerType {
             return
         }
         queue.asyncAfter(deadline: .now() + retryStrategy.current, execute: readWorkItem)
-    }
-}
-
-extension SourceConfigDownloadWorker {
-    func needsMigration(freshSourceConfig: SourceConfig) -> Bool {
-        guard let cachedSourceConfig = cachedSourceConfig else {
-            return false
-        }
-        return freshSourceConfig.id == cachedSourceConfig.id
     }
 }

--- a/Sources/Classes/Core/Storage/Migration/StorageMigration.swift
+++ b/Sources/Classes/Core/Storage/Migration/StorageMigration.swift
@@ -15,7 +15,7 @@ class StorageMigration {
         self.storageMigrator = storageMigrator
     }
     
-    func migrate() throws {
-        try storageMigrator.migrate()
+    func migrate() {
+        storageMigrator.migrate()
     }
 }

--- a/Sources/Classes/Core/Storage/Migration/StorageMigrator.swift
+++ b/Sources/Classes/Core/Storage/Migration/StorageMigrator.swift
@@ -10,18 +10,28 @@ import Foundation
 
 protocol StorageMigrator {
     var currentStorage: Storage { get set }
-    func migrate() throws
+    func migrate()
 }
 
 class StorageMigratorV1V2: StorageMigrator {
-    let oldSQLiteStorage: SQLiteStorage
-    var currentStorage: Storage
     
-    init(oldSQLiteStorage: SQLiteStorage, currentStorage: Storage) {
-        self.oldSQLiteStorage = oldSQLiteStorage
+    let legacyDatabaseName = "rl_persistence.sqlite"
+    lazy var legacyDatabasePath : String = { Device.current.directoryPath.appendingPathComponent(legacyDatabaseName).path
+    }()
+    
+    let logger: Logger
+    var currentStorage: Storage
+    let currentSourceConfig: SourceConfig
+    
+    
+    init(currentStorage: Storage, currentSourceConfig: SourceConfig, logger: Logger) {
         self.currentStorage = currentStorage
+        self.currentSourceConfig = currentSourceConfig
+        self.logger = logger
     }
     
+    func migrate() {
+        if isMigrationNeeded() {
     func migrate() throws {
         let databasePath = oldSQLiteStorage.database.path.appendingPathComponent(oldSQLiteStorage.database.name).path
         guard FileManager.default.fileExists(atPath: databasePath) else {
@@ -35,6 +45,58 @@ class StorageMigratorV1V2: StorageMigrator {
             try FileManager.default.removeItem(atPath: databasePath)
         case .failure(let error):
             throw error
+            let legacyDatabase = SQLiteDatabase(path: Device.current.directoryPath, name:legacyDatabaseName)
+            let legacyStorage = SQLiteStorage(database: legacyDatabase, logger: logger)
+            legacyStorage.open()
+            let result = legacyStorage.objects(limit: .max)
+            switch result {
+            case .success(let list):
+                list.forEach({ _ = currentStorage.save($0) })
+                _ = legacyStorage.close()
+                deleteLegacyDatabase()
+                logger.logDebug(.storageMigrationSuccess)
+            case .failure(let error):
+                logger.logError(.storageMigrationFailed(.storageError(error.localizedDescription)))
+            }
+        }
+    }
+    
+    func isMigrationNeeded() -> Bool {
+        guard doesLegacyDatabaseExists() else {
+            logger.logDebug(.legacyDatabaseDoesNotExists)
+            return false
+        }
+        guard let legacySourceConfig = getLegacySourceConfig()  else {
+            logger.logError(.storageMigrationFailedToReadSourceConfig)
+            deleteLegacyDatabase()
+            return false
+        }
+        if legacySourceConfig.source?.id == currentSourceConfig.source?.id {
+            return true
+        }
+        return false
+    }
+    
+    func doesLegacyDatabaseExists() -> Bool {
+        FileManager.default.fileExists(atPath: legacyDatabasePath)
+    }
+    
+    /// We are reading legacy SourceConfig from Standard Defaults as v1 iOS SDK uses StandardDefaults
+    /// SourceConfig saved by v1 iOS SDK to StandardDefaults needs to be decoded using JSONDecoder opposed to PropertyListDecoder by v2 SDK.
+    func getLegacySourceConfig() -> SourceConfig? {
+        let standardDefaultsWorker = UserDefaultsWorker(userDefaults: UserDefaults.standard, queue: DispatchQueue(label: "standardDefaults".queueLabel()))
+        let sourceConfigString: String? = standardDefaultsWorker.read(.legacySourceConfig)
+        if let sourceConfigString = sourceConfigString {
+            return try? JSONDecoder().decode(SourceConfig.self, from: Data(sourceConfigString.utf8))
+        }
+        return nil
+    }
+    
+    func deleteLegacyDatabase() {
+        do {
+            try FileManager.default.removeItem(atPath: legacyDatabasePath)
+        } catch {
+            logger.logError(.failedToDeleteLegacyDatabase(error.localizedDescription))
         }
     }
 }

--- a/Sources/Classes/Core/Storage/Migration/StorageMigrator.swift
+++ b/Sources/Classes/Core/Storage/Migration/StorageMigrator.swift
@@ -32,19 +32,6 @@ class StorageMigratorV1V2: StorageMigrator {
     
     func migrate() {
         if isMigrationNeeded() {
-    func migrate() throws {
-        let databasePath = oldSQLiteStorage.database.path.appendingPathComponent(oldSQLiteStorage.database.name).path
-        guard FileManager.default.fileExists(atPath: databasePath) else {
-            throw StorageError.databaseNotExists
-        }
-        let result = oldSQLiteStorage.objects(limit: .max)
-        switch result {
-        case .success(let list):
-            list.forEach({ _ = currentStorage.save($0) })
-            _ = oldSQLiteStorage.close()
-            try FileManager.default.removeItem(atPath: databasePath)
-        case .failure(let error):
-            throw error
             let legacyDatabase = SQLiteDatabase(path: Device.current.directoryPath, name:legacyDatabaseName)
             let legacyStorage = SQLiteStorage(database: legacyDatabase, logger: logger)
             legacyStorage.open()


### PR DESCRIPTION
# fix: fixed issues with the database migration when moving from v1 to v2.

* Fixed the issue of reading Legacy Source Config from Suited Name instance of User Defaults and started reading it from Standard Defaults
* Fixed the issue of Legacy SQLiteStorage not opened while performing migration. 
* Removed the responsibility of determining if database migration is required from the SourceConfig Downloader Module and handed it over to each migrator to determine if migration is needed.
* Removed the support for Customising the Storage Migrator by the user.
* Added tests for successful and failed migration scenarios.
