### PR TITLE
fix: merging of externalId in identify event

### DIFF
--- a/Examples/RudderSampleAppObjC/RudderSampleAppObjC.xcodeproj/project.pbxproj
+++ b/Examples/RudderSampleAppObjC/RudderSampleAppObjC.xcodeproj/project.pbxproj
@@ -24,7 +24,6 @@
 		ED761A062727E28800B086F4 /* CustomFactory.m in Sources */ = {isa = PBXBuildFile; fileRef = ED7619FC2727E28800B086F4 /* CustomFactory.m */; };
 		ED761A072727E28800B086F4 /* _AppDelegate.m in Sources */ = {isa = PBXBuildFile; fileRef = ED7619FD2727E28800B086F4 /* _AppDelegate.m */; };
 		ED8738CE2AB363A80076D24A /* EncryptedDatabaseProvider.m in Sources */ = {isa = PBXBuildFile; fileRef = ED8738CC2AB363A80076D24A /* EncryptedDatabaseProvider.m */; };
-		F6149CC52B32FBC2006995B7 /* RudderConfig.plist in Resources */ = {isa = PBXBuildFile; fileRef = F6149CC42B32FBC2006995B7 /* RudderConfig.plist */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -57,7 +56,6 @@
 		ED7619FD2727E28800B086F4 /* _AppDelegate.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = _AppDelegate.m; sourceTree = "<group>"; };
 		ED8738CA2AB363A80076D24A /* EncryptedDatabaseProvider.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = EncryptedDatabaseProvider.h; sourceTree = "<group>"; };
 		ED8738CC2AB363A80076D24A /* EncryptedDatabaseProvider.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = EncryptedDatabaseProvider.m; sourceTree = "<group>"; };
-		F6149CC42B32FBC2006995B7 /* RudderConfig.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = RudderConfig.plist; sourceTree = "<group>"; };
 		F928F8A942558010CC7088BF /* Pods-RudderSampleAppObjC.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-RudderSampleAppObjC.debug.xcconfig"; path = "Target Support Files/Pods-RudderSampleAppObjC/Pods-RudderSampleAppObjC.debug.xcconfig"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
@@ -137,7 +135,6 @@
 				ED7619FD2727E28800B086F4 /* _AppDelegate.m */,
 				ED7619F02727E28700B086F4 /* _ViewController.h */,
 				ED7619F92727E28800B086F4 /* _ViewController.m */,
-				F6149CC42B32FBC2006995B7 /* RudderConfig.plist */,
 				ED7619F22727E28700B086F4 /* CustomFactory.h */,
 				ED7619FC2727E28800B086F4 /* CustomFactory.m */,
 				ED7619FB2727E28800B086F4 /* CustomIntegration.h */,
@@ -219,7 +216,6 @@
 			files = (
 				ED761A012727E28800B086F4 /* LaunchScreen.storyboard in Resources */,
 				ED0CA6DE2A7D049E00899C1C /* SampleRudderConfig.plist in Resources */,
-				F6149CC52B32FBC2006995B7 /* RudderConfig.plist in Resources */,
 				ED761A052727E28800B086F4 /* Images.xcassets in Resources */,
 				ED7619FF2727E28800B086F4 /* InfoPlist.strings in Resources */,
 				ED761A022727E28800B086F4 /* Main.storyboard in Resources */,

--- a/Sources/Classes/RSContext.m
+++ b/Sources/Classes/RSContext.m
@@ -192,7 +192,7 @@ static dispatch_queue_t queue;
         
         NSMutableDictionary<NSString *, NSMutableDictionary<NSString *, NSObject *> *> *mergedValues = [NSMutableDictionary dictionary];
         
-        for (NSMutableDictionary<NSString *, NSObject *> *externalId in self.externalIds) {
+        for (NSMutableDictionary<NSString *, NSObject *> *externalId in self->_externalIds) {
             NSString *type = [NSString stringWithFormat:@"%@", externalId[@"type"]];
             mergedValues[type] = [externalId mutableCopy];
         }
@@ -211,7 +211,7 @@ static dispatch_queue_t queue;
             }
         }
         
-        self.externalIds = [[mergedValues allValues] mutableCopy];
+        self->_externalIds = [[mergedValues allValues] mutableCopy];
     });
 }
 

--- a/Sources/Classes/RSContext.m
+++ b/Sources/Classes/RSContext.m
@@ -184,31 +184,34 @@ static dispatch_queue_t queue;
     });
 }
 
-- (void)updateExternalIds:(NSMutableArray *)externalIds {
+- (void)updateExternalIds:(NSMutableArray *)newExternalIds {
     dispatch_sync(queue, ^{
-        if(self->_externalIds == nil)
-        {
+        if(self->_externalIds == nil){
             self->_externalIds = [[NSMutableArray alloc] init];
         }
         
-        NSMutableArray *newExternalIds = [externalIds mutableCopy];
-        if (self->_externalIds.count > 0) {
-            NSMutableArray *repeatingExternalIds = [[NSMutableArray alloc] init];
-            for (NSMutableDictionary *newExternalId in newExternalIds) {
-                for (NSMutableDictionary *externalId in self->_externalIds) {
-                    if ([externalId[@"type"] isEqualToString:newExternalId[@"type"]]){
-                        externalId[@"id"] = newExternalId[@"id"];
-                        [repeatingExternalIds addObject:newExternalId];
-                        break;
-                    }
-                }
-            }
-            [newExternalIds removeObjectsInArray:repeatingExternalIds];
+        NSMutableDictionary<NSString *, NSMutableDictionary<NSString *, NSObject *> *> *mergedValues = [NSMutableDictionary dictionary];
+        
+        for (NSMutableDictionary<NSString *, NSObject *> *externalId in self.externalIds) {
+            NSString *type = [NSString stringWithFormat:@"%@", externalId[@"type"]];
+            mergedValues[type] = [externalId mutableCopy];
         }
         
-        if ([newExternalIds count]) {
-            [self->_externalIds addObjectsFromArray: newExternalIds];
+        // Merge new externalIds into the existing merged values
+        for (NSMutableDictionary<NSString *, NSObject *> *newExternalId in newExternalIds) {
+            NSString *type = [NSString stringWithFormat:@"%@", newExternalId[@"type"]];
+            NSMutableDictionary<NSString *, NSObject *> *existingMergedValue = mergedValues[type];
+            
+            if (existingMergedValue) {
+                // Merge values for the same "type"
+                [existingMergedValue addEntriesFromDictionary:newExternalId];
+            } else {
+                // No existing merged value for this "type," add a copy of the newExternalId
+                mergedValues[type] = [newExternalId mutableCopy];
+            }
         }
+        
+        self.externalIds = [[mergedValues allValues] mutableCopy];
     });
 }
 


### PR DESCRIPTION
# Description

-When someone calls the 'identify' event twice with the same `userId` and the same `externalId` (ensuring that the `type` field is also the same), an error is thrown.
- I've refactored the code to fix this merging issue.
