### PR TITLE
chore(release): pulling release/1.26.0 into master

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+## [1.26.0](https://github.com/rudderlabs/rudder-sdk-ios/compare/v1.25.3...v1.26.0) (2024-03-19)
+
+
+### Features
+
+* add support for global customContext option ([#485](https://github.com/rudderlabs/rudder-sdk-ios/issues/485)) ([27f21b9](https://github.com/rudderlabs/rudder-sdk-ios/commit/27f21b9274fee6f80da6f25b3b73d4491e4f9925))
+* added support for setting advertisingId before sdk init and also persisting it ([#481](https://github.com/rudderlabs/rudder-sdk-ios/issues/481)) ([2075910](https://github.com/rudderlabs/rudder-sdk-ios/commit/2075910109d17c41da1d2800936aaa8d0ae03b97))
+
 ### [1.25.3](https://github.com/rudderlabs/rudder-sdk-ios/compare/v1.25.2...v1.25.3) (2024-03-11)
 
 

--- a/Examples/RudderSampleAppObjC/RudderSampleAppObjC.xcodeproj/project.pbxproj
+++ b/Examples/RudderSampleAppObjC/RudderSampleAppObjC.xcodeproj/project.pbxproj
@@ -24,6 +24,7 @@
 		ED761A062727E28800B086F4 /* CustomFactory.m in Sources */ = {isa = PBXBuildFile; fileRef = ED7619FC2727E28800B086F4 /* CustomFactory.m */; };
 		ED761A072727E28800B086F4 /* _AppDelegate.m in Sources */ = {isa = PBXBuildFile; fileRef = ED7619FD2727E28800B086F4 /* _AppDelegate.m */; };
 		ED8738CE2AB363A80076D24A /* EncryptedDatabaseProvider.m in Sources */ = {isa = PBXBuildFile; fileRef = ED8738CC2AB363A80076D24A /* EncryptedDatabaseProvider.m */; };
+		F6A9BB0A2B9F30CA0076FE23 /* RudderConfig.plist in Resources */ = {isa = PBXBuildFile; fileRef = F6A9BB092B9F30CA0076FE23 /* RudderConfig.plist */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -56,6 +57,8 @@
 		ED7619FD2727E28800B086F4 /* _AppDelegate.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = _AppDelegate.m; sourceTree = "<group>"; };
 		ED8738CA2AB363A80076D24A /* EncryptedDatabaseProvider.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = EncryptedDatabaseProvider.h; sourceTree = "<group>"; };
 		ED8738CC2AB363A80076D24A /* EncryptedDatabaseProvider.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = EncryptedDatabaseProvider.m; sourceTree = "<group>"; };
+		F6A9BB092B9F30CA0076FE23 /* RudderConfig.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = RudderConfig.plist; sourceTree = "<group>"; };
+
 		F928F8A942558010CC7088BF /* Pods-RudderSampleAppObjC.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-RudderSampleAppObjC.debug.xcconfig"; path = "Target Support Files/Pods-RudderSampleAppObjC/Pods-RudderSampleAppObjC.debug.xcconfig"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
@@ -119,6 +122,7 @@
 		ED0CA6D92A7D049E00899C1C /* RudderConfig */ = {
 			isa = PBXGroup;
 			children = (
+				F6A9BB092B9F30CA0076FE23 /* RudderConfig.plist */,
 				ED0CA6DB2A7D049E00899C1C /* SampleRudderConfig.plist */,
 				ED0CA6DC2A7D049E00899C1C /* RudderConfig.swift */,
 			);
@@ -214,6 +218,7 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				F6A9BB0A2B9F30CA0076FE23 /* RudderConfig.plist in Resources */,
 				ED761A012727E28800B086F4 /* LaunchScreen.storyboard in Resources */,
 				ED0CA6DE2A7D049E00899C1C /* SampleRudderConfig.plist in Resources */,
 				ED761A052727E28800B086F4 /* Images.xcassets in Resources */,

--- a/Examples/RudderSampleAppObjC/RudderSampleAppObjC/Base.lproj/Main.storyboard
+++ b/Examples/RudderSampleAppObjC/RudderSampleAppObjC/Base.lproj/Main.storyboard
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="21507" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES" initialViewController="whP-gf-Uak">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="32700.99.1234" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES" initialViewController="whP-gf-Uak">
     <device id="retina4_7" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="21505"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="22684"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <scenes>
@@ -20,7 +20,7 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="z9H-GZ-JuV">
-                                <rect key="frame" x="150" y="243" width="66" height="35"/>
+                                <rect key="frame" x="154" y="260" width="66" height="35"/>
                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                 <state key="normal" title="Button"/>
                                 <buttonConfiguration key="configuration" style="plain" title="Track"/>
@@ -38,7 +38,7 @@
                                 </connections>
                             </button>
                             <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="yd2-WE-9Hv">
-                                <rect key="frame" x="146" y="385" width="72" height="35"/>
+                                <rect key="frame" x="152" y="362" width="72" height="35"/>
                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                 <state key="normal" title="Button"/>
                                 <buttonConfiguration key="configuration" style="plain" title="Group"/>
@@ -47,7 +47,7 @@
                                 </connections>
                             </button>
                             <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="gZF-RJ-EZv">
-                                <rect key="frame" x="152" y="463" width="61" height="35"/>
+                                <rect key="frame" x="158" y="416" width="61" height="35"/>
                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                 <state key="normal" title="Button"/>
                                 <buttonConfiguration key="configuration" style="plain" title="Alias"/>
@@ -56,7 +56,7 @@
                                 </connections>
                             </button>
                             <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="o3a-wr-ziU">
-                                <rect key="frame" x="148" y="547" width="68" height="35"/>
+                                <rect key="frame" x="154" y="469" width="68" height="35"/>
                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                 <state key="normal" title="Button"/>
                                 <buttonConfiguration key="configuration" style="plain" title="Reset"/>
@@ -64,8 +64,35 @@
                                     <action selector="sendReset:" destination="whP-gf-Uak" eventType="touchUpInside" id="DJR-le-sQ9"/>
                                 </connections>
                             </button>
+                            <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="1Hr-gQ-IKc">
+                                <rect key="frame" x="114" y="521" width="149" height="35"/>
+                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                <state key="normal" title="Button"/>
+                                <buttonConfiguration key="configuration" style="plain" title="putAdvertisingId"/>
+                                <connections>
+                                    <action selector="putAdvertisingId:" destination="whP-gf-Uak" eventType="touchUpInside" id="LRB-Rd-dt1"/>
+                                </connections>
+                            </button>
+                            <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="mdi-fO-d84">
+                                <rect key="frame" x="108" y="587" width="161" height="35"/>
+                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                <state key="normal" title="Button"/>
+                                <buttonConfiguration key="configuration" style="plain" title="clearAdvertisingId"/>
+                                <connections>
+                                    <action selector="clearAdvertisingId:" destination="whP-gf-Uak" eventType="touchUpInside" id="wa0-7Z-dEX"/>
+                                </connections>
+                            </button>
+                            <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="sfg-Ge-Q7M">
+                                <rect key="frame" x="146" y="162" width="86" height="35"/>
+                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                <state key="normal" title="Button"/>
+                                <buttonConfiguration key="configuration" style="plain" title="Initialize"/>
+                                <connections>
+                                    <action selector="initializeSDK:" destination="whP-gf-Uak" eventType="touchUpInside" id="4mD-ZA-RRg"/>
+                                </connections>
+                            </button>
                             <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="bGR-O2-oAe">
-                                <rect key="frame" x="146" y="176" width="81" height="35"/>
+                                <rect key="frame" x="148" y="205" width="81" height="35"/>
                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                 <state key="normal" title="Button"/>
                                 <buttonConfiguration key="configuration" style="plain" title="Identify"/>

--- a/Examples/RudderSampleAppObjC/RudderSampleAppObjC/_AppDelegate.h
+++ b/Examples/RudderSampleAppObjC/RudderSampleAppObjC/_AppDelegate.h
@@ -13,11 +13,14 @@
 
 @property (strong, nonatomic) UIWindow *window;
 
++ (void) initializeSDK;
 + (void) sendIdentify;
 + (void) sendTrack;
 + (void) sendScreen;
 + (void) sendGroup;
 + (void) sendAlias;
 + (void) sendReset;
++ (void) putAdvertisingId;
++ (void) clearAdvertisingId;
 
 @end

--- a/Examples/RudderSampleAppObjC/RudderSampleAppObjC/_AppDelegate.m
+++ b/Examples/RudderSampleAppObjC/RudderSampleAppObjC/_AppDelegate.m
@@ -23,6 +23,11 @@ static int screenCount = 1;
 
 - (BOOL)application:(UIApplication *)application didFinishLaunchingWithOptions:(NSDictionary *)launchOptions
 {
+    [_AppDelegate initializeSDK];
+    return YES;
+}
+
++ (void) initializeSDK {
     NSString *path = [[NSBundle mainBundle] pathForResource:@"RudderConfig" ofType:@"plist"];
     if (path != nil) {
         NSURL *url = [NSURL fileURLWithPath:path];
@@ -34,13 +39,11 @@ static int screenCount = 1;
             [builder withTrackLifecycleEvens:YES];
             [builder withCollectDeviceId:NO];
             [builder withRecordScreenViews:YES];
-            [builder withDataPlaneUrl:rudderConfig.DEV_DATA_PLANE_URL];
-            [builder withControlPlaneUrl:rudderConfig.DEV_CONTROL_PLANE_URL];
+            [builder withDataPlaneUrl:rudderConfig.PROD_DATA_PLANE_URL];
             [builder withDBEncryption:[[RSDBEncryption alloc] initWithKey:@"test1234" enable:NO databaseProvider:[EncryptedDatabaseProvider new]]];
             [RSClient getInstance:rudderConfig.WRITE_KEY config:[builder build]];
         }
     }
-    return YES;
 }
 
 + (void) sendIdentify {
@@ -87,6 +90,14 @@ static int screenCount = 1;
 
 + (void) sendReset {
     [[RSClient sharedInstance] reset:YES];
+}
+
++ (void) putAdvertisingId {
+    [RSClient putAdvertisingId:@"desuAdvertId"];
+}
+
++ (void) clearAdvertisingId {
+    [[RSClient sharedInstance] clearAdvertisingId];
 }
 
 @end

--- a/Examples/RudderSampleAppObjC/RudderSampleAppObjC/_ViewController.m
+++ b/Examples/RudderSampleAppObjC/RudderSampleAppObjC/_ViewController.m
@@ -27,6 +27,9 @@
     [super didReceiveMemoryWarning];
     // Dispose of any resources that can be recreated.
 }
+- (IBAction)initializeSDK:(id)sender {
+    [_AppDelegate initializeSDK];
+}
 - (IBAction)sendIdentify:(id)sender {
     [_AppDelegate sendIdentify];
 }
@@ -45,5 +48,12 @@
 - (IBAction)sendReset:(id)sender {
     [_AppDelegate sendReset];
 }
+- (IBAction)putAdvertisingId:(id)sender {
+    [_AppDelegate putAdvertisingId];
+}
+- (IBAction)clearAdvertisingId:(id)sender {
+    [_AppDelegate clearAdvertisingId];
+}
+
 
 @end

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -3,7 +3,7 @@ PODS:
     - RSCrashReporter (= 1.0.1)
     - RudderKit (= 1.4.0)
   - RSCrashReporter (1.0.1)
-  - Rudder (1.25.1):
+  - Rudder (1.25.2):
     - MetricsReporter (= 1.2.1)
   - RudderKit (1.4.0)
   - SQLCipher (4.5.4):
@@ -33,7 +33,7 @@ EXTERNAL SOURCES:
 SPEC CHECKSUMS:
   MetricsReporter: 99596ee5003c69949ed2f50acc34aee83c42f843
   RSCrashReporter: 6b8376ac729b0289ebe0908553e5f56d8171f313
-  Rudder: 34799a1be015f03d7073a919c4b3557cfde428d4
+  Rudder: c6f6c7b266136c7d7990bccec40d2b0a3057abc6
   RudderKit: d9d6997696e1642b753d8bdf94e57af643a68f03
   SQLCipher: 905b145f65f349f26da9e60a19901ad24adcd381
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 <p align="center">
   <a href="https://cocoapods.org/pods/Rudder">
-    <img src="https://img.shields.io/static/v1?label=pod&message=v1.25.3&color=blue&style=flat">
+    <img src="https://img.shields.io/static/v1?label=pod&message=v1.26.0&color=blue&style=flat">
     </a>
 </p>
 
@@ -39,7 +39,7 @@ The iOS SDK is available through [**CocoaPods**](https://cocoapods.org), [**Cart
 To install the SDK, simply add the following line to your Podfile:
 
 ```xcode
-pod 'Rudder', '1.25.3'
+pod 'Rudder', '1.26.0'
 ```
 
 ### Carthage
@@ -47,7 +47,7 @@ pod 'Rudder', '1.25.3'
 For Carthage support, add the following line to your `Cartfile`:
 
 ```xcode
-github "rudderlabs/rudder-sdk-ios" "v1.25.3"
+github "rudderlabs/rudder-sdk-ios" "v1.26.0"
 ```
 
 > Remember to include the following code in all `.m` and `.h` files where you want to refer to or use the RudderStack SDK classes, as shown:
@@ -71,7 +71,7 @@ You can also add the RudderStack iOS SDK via Swift Package Mangaer, via one of t
 
 * Enter the package repository (`git@github.com:rudderlabs/rudder-sdk-ios.git`) in the search bar.
 
-* In **Dependency Rule**, select **Up to Next Major Version** and enter `1.25.3` as the value, as shown:
+* In **Dependency Rule**, select **Up to Next Major Version** and enter `1.26.0` as the value, as shown:
 
 ![Setting dependency](https://user-images.githubusercontent.com/59817155/145574696-8c849749-13e0-40d5-aacb-3fccb5c8e67d.png)
 
@@ -99,7 +99,7 @@ let package = Package(
     ],
     dependencies: [
         // Dependencies declare other packages that this package depends on.
-        .package(url: "git@github.com:rudderlabs/rudder-sdk-ios.git", from: "1.25.3")
+        .package(url: "git@github.com:rudderlabs/rudder-sdk-ios.git", from: "1.26.0")
     ],
     targets: [
         // Targets are the basic building blocks of a package. A target can define a module or a test suite.

--- a/Rudder.xcodeproj/project.pbxproj
+++ b/Rudder.xcodeproj/project.pbxproj
@@ -9,12 +9,12 @@
 /* Begin PBXBuildFile section */
 		06CABC332630C6B00097BEFF /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 06CABC322630C6B00097BEFF /* Foundation.framework */; };
 		06CABC352630C6D30097BEFF /* UIKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 06CABC2E2630C6660097BEFF /* UIKit.framework */; };
-		4A0CBF35C3C640065D0D646F /* Pods_Rudder_iOS.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 381A0433AB34802684AA0E86 /* Pods_Rudder_iOS.framework */; };
-		5AC44BE035EE3100A585BC6F /* Pods_RudderTests_iOS.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = AC1E4F4531FB88ACB07A3AB2 /* Pods_RudderTests_iOS.framework */; };
-		5C73508B61CEC3B701DC6D3B /* Pods_RudderTests_watchOS.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 85115045A8289BE3C98C061E /* Pods_RudderTests_watchOS.framework */; };
-		A3F0B1D68989A3188449830A /* Pods_RudderTests_tvOS.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 589F1C04B540ED233C3C15C6 /* Pods_RudderTests_tvOS.framework */; };
-		BB3C914CC6164092BA4F25CB /* Pods_Rudder_watchOS.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 41CEA928EA5423C014B14A13 /* Pods_Rudder_watchOS.framework */; };
-		E3723BFD219B0B95B98161C7 /* Pods_Rudder_tvOS.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = E5D2F78ABE740E1FE40050CC /* Pods_Rudder_tvOS.framework */; };
+		2FA4A3E2DF0696E8D68B640A /* Pods_Rudder_watchOS.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 9F631D98DB26309EFE5E0A24 /* Pods_Rudder_watchOS.framework */; };
+		5C11F10C96D80DF73DBED732 /* Pods_Rudder_iOS.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 447958A767B9B6F9BB3AC36A /* Pods_Rudder_iOS.framework */; };
+		60DF93A1FA405B16F4D273AB /* Pods_RudderTests_iOS.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 3F00C6B89DB926A1271D979A /* Pods_RudderTests_iOS.framework */; };
+		7275AF62B3887AFD09CF49CF /* Pods_RudderTests_watchOS.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = E5E0F163A9A54245F87BB53E /* Pods_RudderTests_watchOS.framework */; };
+		884A55BB19EDB6A5634388BF /* Pods_Rudder_tvOS.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = EB87B9413194FE5EF1466A94 /* Pods_Rudder_tvOS.framework */; };
+		9EC62E0F3BA85A4979CA97C2 /* Pods_RudderTests_tvOS.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = EF8F93F0FE564ED32831E4DE /* Pods_RudderTests_tvOS.framework */; };
 		ED0CA6EA2A7D08B900899C1C /* RSTransformationEvent.h in Headers */ = {isa = PBXBuildFile; fileRef = F6F2FA752A53D8310025D510 /* RSTransformationEvent.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		ED0CA6EB2A7D08B900899C1C /* RSTransformationEvent.h in Headers */ = {isa = PBXBuildFile; fileRef = F6F2FA752A53D8310025D510 /* RSTransformationEvent.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		ED0CA6EC2A7D08D800899C1C /* RSTransformationRequest.h in Headers */ = {isa = PBXBuildFile; fileRef = F6F2FA732A53CD9F0025D510 /* RSTransformationRequest.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -752,27 +752,26 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
-		010DAF827438C4A823468825 /* Pods-RudderTests-watchOS.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-RudderTests-watchOS.debug.xcconfig"; path = "Target Support Files/Pods-RudderTests-watchOS/Pods-RudderTests-watchOS.debug.xcconfig"; sourceTree = "<group>"; };
+		02107210BC6C6469C1537DDD /* Pods-Rudder-watchOS.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Rudder-watchOS.release.xcconfig"; path = "Target Support Files/Pods-Rudder-watchOS/Pods-Rudder-watchOS.release.xcconfig"; sourceTree = "<group>"; };
+		0358E5A80DA154A90CDF4BF0 /* Pods-RudderTests-iOS.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-RudderTests-iOS.debug.xcconfig"; path = "Target Support Files/Pods-RudderTests-iOS/Pods-RudderTests-iOS.debug.xcconfig"; sourceTree = "<group>"; };
 		06CABB842630C3CA0097BEFF /* Rudder.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Rudder.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		06CABC2E2630C6660097BEFF /* UIKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = UIKit.framework; path = Platforms/MacOSX.platform/Developer/SDKs/MacOSX11.1.sdk/System/iOSSupport/System/Library/Frameworks/UIKit.framework; sourceTree = DEVELOPER_DIR; };
 		06CABC322630C6B00097BEFF /* Foundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Foundation.framework; path = Platforms/MacOSX.platform/Developer/SDKs/MacOSX11.1.sdk/System/Library/Frameworks/Foundation.framework; sourceTree = DEVELOPER_DIR; };
-		381A0433AB34802684AA0E86 /* Pods_Rudder_iOS.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_Rudder_iOS.framework; sourceTree = BUILT_PRODUCTS_DIR; };
-		3C702DB8C75FBD66B10B8EDF /* Pods-RudderTests-watchOS.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-RudderTests-watchOS.release.xcconfig"; path = "Target Support Files/Pods-RudderTests-watchOS/Pods-RudderTests-watchOS.release.xcconfig"; sourceTree = "<group>"; };
-		41CEA928EA5423C014B14A13 /* Pods_Rudder_watchOS.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_Rudder_watchOS.framework; sourceTree = BUILT_PRODUCTS_DIR; };
-		51D8D2C7430591C091E783C8 /* Pods-RudderTests-iOS.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-RudderTests-iOS.release.xcconfig"; path = "Target Support Files/Pods-RudderTests-iOS/Pods-RudderTests-iOS.release.xcconfig"; sourceTree = "<group>"; };
-		589F1C04B540ED233C3C15C6 /* Pods_RudderTests_tvOS.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_RudderTests_tvOS.framework; sourceTree = BUILT_PRODUCTS_DIR; };
-		6307363FD931C4184D3CB813 /* Pods-Rudder-iOS.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Rudder-iOS.release.xcconfig"; path = "Target Support Files/Pods-Rudder-iOS/Pods-Rudder-iOS.release.xcconfig"; sourceTree = "<group>"; };
-		7DCFD27F69B0AF5419724FC5 /* Pods-Rudder-watchOS.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Rudder-watchOS.release.xcconfig"; path = "Target Support Files/Pods-Rudder-watchOS/Pods-Rudder-watchOS.release.xcconfig"; sourceTree = "<group>"; };
-		80D3FB2299E58D1817A1B0E2 /* Pods-RudderTests-iOS.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-RudderTests-iOS.debug.xcconfig"; path = "Target Support Files/Pods-RudderTests-iOS/Pods-RudderTests-iOS.debug.xcconfig"; sourceTree = "<group>"; };
-		8386A90FCB2E6C483CC34952 /* Pods-Rudder-tvOS.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Rudder-tvOS.debug.xcconfig"; path = "Target Support Files/Pods-Rudder-tvOS/Pods-Rudder-tvOS.debug.xcconfig"; sourceTree = "<group>"; };
-		85115045A8289BE3C98C061E /* Pods_RudderTests_watchOS.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_RudderTests_watchOS.framework; sourceTree = BUILT_PRODUCTS_DIR; };
-		985D25DF983E35D9BA1961B7 /* Pods-RudderTests-tvOS.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-RudderTests-tvOS.release.xcconfig"; path = "Target Support Files/Pods-RudderTests-tvOS/Pods-RudderTests-tvOS.release.xcconfig"; sourceTree = "<group>"; };
-		9F810D86FD6A9B76CB56D407 /* Pods-Rudder-watchOS.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Rudder-watchOS.debug.xcconfig"; path = "Target Support Files/Pods-Rudder-watchOS/Pods-Rudder-watchOS.debug.xcconfig"; sourceTree = "<group>"; };
-		AC1E4F4531FB88ACB07A3AB2 /* Pods_RudderTests_iOS.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_RudderTests_iOS.framework; sourceTree = BUILT_PRODUCTS_DIR; };
-		CC0F863D62F9D02F7B958FA2 /* Pods-Rudder-tvOS.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Rudder-tvOS.release.xcconfig"; path = "Target Support Files/Pods-Rudder-tvOS/Pods-Rudder-tvOS.release.xcconfig"; sourceTree = "<group>"; };
-		D622D27CE082C02F605707FE /* Pods-Rudder-iOS.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Rudder-iOS.debug.xcconfig"; path = "Target Support Files/Pods-Rudder-iOS/Pods-Rudder-iOS.debug.xcconfig"; sourceTree = "<group>"; };
-		DFF929D4168AFBD1511A4013 /* Pods-RudderTests-tvOS.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-RudderTests-tvOS.debug.xcconfig"; path = "Target Support Files/Pods-RudderTests-tvOS/Pods-RudderTests-tvOS.debug.xcconfig"; sourceTree = "<group>"; };
-		E5D2F78ABE740E1FE40050CC /* Pods_Rudder_tvOS.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_Rudder_tvOS.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		22FB9A6823E80938F3F912C0 /* Pods-RudderTests-iOS.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-RudderTests-iOS.release.xcconfig"; path = "Target Support Files/Pods-RudderTests-iOS/Pods-RudderTests-iOS.release.xcconfig"; sourceTree = "<group>"; };
+		273057E4FA7F2B0952AF241D /* Pods-Rudder-iOS.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Rudder-iOS.debug.xcconfig"; path = "Target Support Files/Pods-Rudder-iOS/Pods-Rudder-iOS.debug.xcconfig"; sourceTree = "<group>"; };
+		3C44A9E8F4B06BD7D1881CC6 /* Pods-RudderTests-watchOS.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-RudderTests-watchOS.debug.xcconfig"; path = "Target Support Files/Pods-RudderTests-watchOS/Pods-RudderTests-watchOS.debug.xcconfig"; sourceTree = "<group>"; };
+		3F00C6B89DB926A1271D979A /* Pods_RudderTests_iOS.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_RudderTests_iOS.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		447958A767B9B6F9BB3AC36A /* Pods_Rudder_iOS.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_Rudder_iOS.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		767A0EEE9A76F43CF631573B /* Pods-Rudder-watchOS.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Rudder-watchOS.debug.xcconfig"; path = "Target Support Files/Pods-Rudder-watchOS/Pods-Rudder-watchOS.debug.xcconfig"; sourceTree = "<group>"; };
+		83C9949585CD3C274CCE6A27 /* Pods-Rudder-iOS.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Rudder-iOS.release.xcconfig"; path = "Target Support Files/Pods-Rudder-iOS/Pods-Rudder-iOS.release.xcconfig"; sourceTree = "<group>"; };
+		9B4BB7D91351507AD413A9B4 /* Pods-Rudder-tvOS.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Rudder-tvOS.release.xcconfig"; path = "Target Support Files/Pods-Rudder-tvOS/Pods-Rudder-tvOS.release.xcconfig"; sourceTree = "<group>"; };
+		9F631D98DB26309EFE5E0A24 /* Pods_Rudder_watchOS.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_Rudder_watchOS.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		A79972EA5B187EF23B242B09 /* Pods-RudderTests-tvOS.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-RudderTests-tvOS.debug.xcconfig"; path = "Target Support Files/Pods-RudderTests-tvOS/Pods-RudderTests-tvOS.debug.xcconfig"; sourceTree = "<group>"; };
+		AF1E8F07C3B20B7CC3AB9F3D /* Pods-RudderTests-tvOS.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-RudderTests-tvOS.release.xcconfig"; path = "Target Support Files/Pods-RudderTests-tvOS/Pods-RudderTests-tvOS.release.xcconfig"; sourceTree = "<group>"; };
+		C607C3351E8D2620CFE41964 /* Pods-RudderTests-watchOS.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-RudderTests-watchOS.release.xcconfig"; path = "Target Support Files/Pods-RudderTests-watchOS/Pods-RudderTests-watchOS.release.xcconfig"; sourceTree = "<group>"; };
+		E5E0F163A9A54245F87BB53E /* Pods_RudderTests_watchOS.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_RudderTests_watchOS.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		E891EDD19ECD40A0BCF5FDFA /* Pods-Rudder-tvOS.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Rudder-tvOS.debug.xcconfig"; path = "Target Support Files/Pods-Rudder-tvOS/Pods-Rudder-tvOS.debug.xcconfig"; sourceTree = "<group>"; };
+		EB87B9413194FE5EF1466A94 /* Pods_Rudder_tvOS.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_Rudder_tvOS.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		ED04A2482986C1750080A88D /* xccov-to-generic.sh */ = {isa = PBXFileReference; lastKnownFileType = text.script.sh; path = "xccov-to-generic.sh"; sourceTree = "<group>"; };
 		ED056314291AABFD00BAEE65 /* sonar-project.properties */ = {isa = PBXFileReference; lastKnownFileType = text; path = "sonar-project.properties"; sourceTree = "<group>"; };
 		ED1C4C8829E6CCC7007007C9 /* find-tag.sh */ = {isa = PBXFileReference; lastKnownFileType = text.script.sh; path = "find-tag.sh"; sourceTree = "<group>"; };
@@ -996,6 +995,7 @@
 		ED99908D2A6926E000031B06 /* RSMetricsReporter.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = RSMetricsReporter.m; sourceTree = "<group>"; };
 		EDEC3CDA29ADEF87007DDE07 /* github-release.config.js */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.javascript; path = "github-release.config.js"; sourceTree = "<group>"; };
 		EDEF1B302A835A90002B3E57 /* Security.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Security.framework; path = System/Library/Frameworks/Security.framework; sourceTree = SDKROOT; };
+		EF8F93F0FE564ED32831E4DE /* Pods_RudderTests_tvOS.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_RudderTests_tvOS.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		F6113D2B29EFD25400A05261 /* multi-dataresidency-us-true.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "multi-dataresidency-us-true.json"; sourceTree = "<group>"; };
 		F6113D2C29EFD25400A05261 /* eu-dataresidency-default-false.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "eu-dataresidency-default-false.json"; sourceTree = "<group>"; };
 		F6113D2D29EFD25400A05261 /* multi-dataresidency-default-false.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "multi-dataresidency-default-false.json"; sourceTree = "<group>"; };
@@ -1043,7 +1043,7 @@
 				06CABC332630C6B00097BEFF /* Foundation.framework in Frameworks */,
 				06CABC352630C6D30097BEFF /* UIKit.framework in Frameworks */,
 				EDEF1B312A835A90002B3E57 /* Security.framework in Frameworks */,
-				4A0CBF35C3C640065D0D646F /* Pods_Rudder_iOS.framework in Frameworks */,
+				5C11F10C96D80DF73DBED732 /* Pods_Rudder_iOS.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1053,7 +1053,7 @@
 			files = (
 				ED998F0F2A69003600031B06 /* Foundation.framework in Frameworks */,
 				ED998F102A69003600031B06 /* UIKit.framework in Frameworks */,
-				E3723BFD219B0B95B98161C7 /* Pods_Rudder_tvOS.framework in Frameworks */,
+				884A55BB19EDB6A5634388BF /* Pods_Rudder_tvOS.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1063,7 +1063,7 @@
 			files = (
 				ED998FDF2A69024E00031B06 /* Foundation.framework in Frameworks */,
 				ED998FE02A69024E00031B06 /* UIKit.framework in Frameworks */,
-				BB3C914CC6164092BA4F25CB /* Pods_Rudder_watchOS.framework in Frameworks */,
+				2FA4A3E2DF0696E8D68B640A /* Pods_Rudder_watchOS.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1072,7 +1072,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				ED9990312A69102400031B06 /* Rudder.framework in Frameworks */,
-				A3F0B1D68989A3188449830A /* Pods_RudderTests_tvOS.framework in Frameworks */,
+				9EC62E0F3BA85A4979CA97C2 /* Pods_RudderTests_tvOS.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1081,7 +1081,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				ED99903F2A69103B00031B06 /* Rudder.framework in Frameworks */,
-				5AC44BE035EE3100A585BC6F /* Pods_RudderTests_iOS.framework in Frameworks */,
+				60DF93A1FA405B16F4D273AB /* Pods_RudderTests_iOS.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1090,7 +1090,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				ED99904D2A69104B00031B06 /* Rudder.framework in Frameworks */,
-				5C73508B61CEC3B701DC6D3B /* Pods_RudderTests_watchOS.framework in Frameworks */,
+				7275AF62B3887AFD09CF49CF /* Pods_RudderTests_watchOS.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1128,12 +1128,12 @@
 				EDEF1B302A835A90002B3E57 /* Security.framework */,
 				06CABC322630C6B00097BEFF /* Foundation.framework */,
 				06CABC2E2630C6660097BEFF /* UIKit.framework */,
-				381A0433AB34802684AA0E86 /* Pods_Rudder_iOS.framework */,
-				E5D2F78ABE740E1FE40050CC /* Pods_Rudder_tvOS.framework */,
-				41CEA928EA5423C014B14A13 /* Pods_Rudder_watchOS.framework */,
-				AC1E4F4531FB88ACB07A3AB2 /* Pods_RudderTests_iOS.framework */,
-				589F1C04B540ED233C3C15C6 /* Pods_RudderTests_tvOS.framework */,
-				85115045A8289BE3C98C061E /* Pods_RudderTests_watchOS.framework */,
+				447958A767B9B6F9BB3AC36A /* Pods_Rudder_iOS.framework */,
+				EB87B9413194FE5EF1466A94 /* Pods_Rudder_tvOS.framework */,
+				9F631D98DB26309EFE5E0A24 /* Pods_Rudder_watchOS.framework */,
+				3F00C6B89DB926A1271D979A /* Pods_RudderTests_iOS.framework */,
+				EF8F93F0FE564ED32831E4DE /* Pods_RudderTests_tvOS.framework */,
+				E5E0F163A9A54245F87BB53E /* Pods_RudderTests_watchOS.framework */,
 			);
 			name = Frameworks;
 			sourceTree = "<group>";
@@ -1141,18 +1141,18 @@
 		DFB2363B6EC8D146934DE8DD /* Pods */ = {
 			isa = PBXGroup;
 			children = (
-				D622D27CE082C02F605707FE /* Pods-Rudder-iOS.debug.xcconfig */,
-				6307363FD931C4184D3CB813 /* Pods-Rudder-iOS.release.xcconfig */,
-				8386A90FCB2E6C483CC34952 /* Pods-Rudder-tvOS.debug.xcconfig */,
-				CC0F863D62F9D02F7B958FA2 /* Pods-Rudder-tvOS.release.xcconfig */,
-				9F810D86FD6A9B76CB56D407 /* Pods-Rudder-watchOS.debug.xcconfig */,
-				7DCFD27F69B0AF5419724FC5 /* Pods-Rudder-watchOS.release.xcconfig */,
-				80D3FB2299E58D1817A1B0E2 /* Pods-RudderTests-iOS.debug.xcconfig */,
-				51D8D2C7430591C091E783C8 /* Pods-RudderTests-iOS.release.xcconfig */,
-				DFF929D4168AFBD1511A4013 /* Pods-RudderTests-tvOS.debug.xcconfig */,
-				985D25DF983E35D9BA1961B7 /* Pods-RudderTests-tvOS.release.xcconfig */,
-				010DAF827438C4A823468825 /* Pods-RudderTests-watchOS.debug.xcconfig */,
-				3C702DB8C75FBD66B10B8EDF /* Pods-RudderTests-watchOS.release.xcconfig */,
+				273057E4FA7F2B0952AF241D /* Pods-Rudder-iOS.debug.xcconfig */,
+				83C9949585CD3C274CCE6A27 /* Pods-Rudder-iOS.release.xcconfig */,
+				E891EDD19ECD40A0BCF5FDFA /* Pods-Rudder-tvOS.debug.xcconfig */,
+				9B4BB7D91351507AD413A9B4 /* Pods-Rudder-tvOS.release.xcconfig */,
+				767A0EEE9A76F43CF631573B /* Pods-Rudder-watchOS.debug.xcconfig */,
+				02107210BC6C6469C1537DDD /* Pods-Rudder-watchOS.release.xcconfig */,
+				0358E5A80DA154A90CDF4BF0 /* Pods-RudderTests-iOS.debug.xcconfig */,
+				22FB9A6823E80938F3F912C0 /* Pods-RudderTests-iOS.release.xcconfig */,
+				A79972EA5B187EF23B242B09 /* Pods-RudderTests-tvOS.debug.xcconfig */,
+				AF1E8F07C3B20B7CC3AB9F3D /* Pods-RudderTests-tvOS.release.xcconfig */,
+				3C44A9E8F4B06BD7D1881CC6 /* Pods-RudderTests-watchOS.debug.xcconfig */,
+				C607C3351E8D2620CFE41964 /* Pods-RudderTests-watchOS.release.xcconfig */,
 			);
 			path = Pods;
 			sourceTree = "<group>";
@@ -1876,7 +1876,7 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = 06CABB982630C3CA0097BEFF /* Build configuration list for PBXNativeTarget "Rudder-iOS" */;
 			buildPhases = (
-				A39CDD690B851FCC6F21BCFF /* [CP] Check Pods Manifest.lock */,
+				5FB70CA39CF2A35323E7A81A /* [CP] Check Pods Manifest.lock */,
 				06CABB7F2630C3CA0097BEFF /* Headers */,
 				06CABB802630C3CA0097BEFF /* Sources */,
 				06CABB812630C3CA0097BEFF /* Frameworks */,
@@ -1895,7 +1895,7 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = ED998F122A69003600031B06 /* Build configuration list for PBXNativeTarget "Rudder-tvOS" */;
 			buildPhases = (
-				323999BD18C1FB7733B120EA /* [CP] Check Pods Manifest.lock */,
+				A8327BC7AFC7B7A01B7A86A1 /* [CP] Check Pods Manifest.lock */,
 				ED998E482A69003600031B06 /* Headers */,
 				ED998EAE2A69003600031B06 /* Sources */,
 				ED998F0E2A69003600031B06 /* Frameworks */,
@@ -1914,7 +1914,7 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = ED998FE22A69024E00031B06 /* Build configuration list for PBXNativeTarget "Rudder-watchOS" */;
 			buildPhases = (
-				621FA7787A2A89CB3B813A53 /* [CP] Check Pods Manifest.lock */,
+				6A6591BA32490D7B807F9B5C /* [CP] Check Pods Manifest.lock */,
 				ED998F182A69024E00031B06 /* Headers */,
 				ED998F7E2A69024E00031B06 /* Sources */,
 				ED998FDE2A69024E00031B06 /* Frameworks */,
@@ -1933,11 +1933,11 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = ED9990342A69102400031B06 /* Build configuration list for PBXNativeTarget "RudderTests-tvOS" */;
 			buildPhases = (
-				B77A79581B274E25A326F22D /* [CP] Check Pods Manifest.lock */,
+				AE7D1576B7EE7ED6F5478C79 /* [CP] Check Pods Manifest.lock */,
 				ED9990292A69102400031B06 /* Sources */,
 				ED99902A2A69102400031B06 /* Frameworks */,
 				ED99902B2A69102400031B06 /* Resources */,
-				CFD481FFA7D08854676F4C41 /* [CP] Embed Pods Frameworks */,
+				CC89EA7B31270EE4D0FA72E1 /* [CP] Embed Pods Frameworks */,
 			);
 			buildRules = (
 			);
@@ -1953,11 +1953,11 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = ED9990422A69103B00031B06 /* Build configuration list for PBXNativeTarget "RudderTests-iOS" */;
 			buildPhases = (
-				C28C1972688C65E5EAE03471 /* [CP] Check Pods Manifest.lock */,
+				C464092C7DB2520EDF77448B /* [CP] Check Pods Manifest.lock */,
 				ED9990372A69103A00031B06 /* Sources */,
 				ED9990382A69103A00031B06 /* Frameworks */,
 				ED9990392A69103A00031B06 /* Resources */,
-				10634EA9900CDBB96CD633BE /* [CP] Embed Pods Frameworks */,
+				240CBC51DE1AFB51489BA0FE /* [CP] Embed Pods Frameworks */,
 			);
 			buildRules = (
 			);
@@ -1973,11 +1973,11 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = ED9990502A69104B00031B06 /* Build configuration list for PBXNativeTarget "RudderTests-watchOS" */;
 			buildPhases = (
-				4AD47650B7F47CE3295D85BA /* [CP] Check Pods Manifest.lock */,
+				5D1C0501DD0050D2503231EE /* [CP] Check Pods Manifest.lock */,
 				ED9990452A69104B00031B06 /* Sources */,
 				ED9990462A69104B00031B06 /* Frameworks */,
 				ED9990472A69104B00031B06 /* Resources */,
-				94BE95E0F476DF23895DCB6F /* [CP] Embed Pods Frameworks */,
+				837D75C23E52CDD20D6D07BF /* [CP] Embed Pods Frameworks */,
 			);
 			buildRules = (
 			);
@@ -2115,7 +2115,7 @@
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXShellScriptBuildPhase section */
-		10634EA9900CDBB96CD633BE /* [CP] Embed Pods Frameworks */ = {
+		240CBC51DE1AFB51489BA0FE /* [CP] Embed Pods Frameworks */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -2132,29 +2132,7 @@
 			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-RudderTests-iOS/Pods-RudderTests-iOS-frameworks.sh\"\n";
 			showEnvVarsInLog = 0;
 		};
-		323999BD18C1FB7733B120EA /* [CP] Check Pods Manifest.lock */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputFileListPaths = (
-			);
-			inputPaths = (
-				"${PODS_PODFILE_DIR_PATH}/Podfile.lock",
-				"${PODS_ROOT}/Manifest.lock",
-			);
-			name = "[CP] Check Pods Manifest.lock";
-			outputFileListPaths = (
-			);
-			outputPaths = (
-				"$(DERIVED_FILE_DIR)/Pods-Rudder-tvOS-checkManifestLockResult.txt",
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
-			showEnvVarsInLog = 0;
-		};
-		4AD47650B7F47CE3295D85BA /* [CP] Check Pods Manifest.lock */ = {
+		5D1C0501DD0050D2503231EE /* [CP] Check Pods Manifest.lock */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -2176,46 +2154,7 @@
 			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
 			showEnvVarsInLog = 0;
 		};
-		621FA7787A2A89CB3B813A53 /* [CP] Check Pods Manifest.lock */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputFileListPaths = (
-			);
-			inputPaths = (
-				"${PODS_PODFILE_DIR_PATH}/Podfile.lock",
-				"${PODS_ROOT}/Manifest.lock",
-			);
-			name = "[CP] Check Pods Manifest.lock";
-			outputFileListPaths = (
-			);
-			outputPaths = (
-				"$(DERIVED_FILE_DIR)/Pods-Rudder-watchOS-checkManifestLockResult.txt",
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
-			showEnvVarsInLog = 0;
-		};
-		94BE95E0F476DF23895DCB6F /* [CP] Embed Pods Frameworks */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputFileListPaths = (
-				"${PODS_ROOT}/Target Support Files/Pods-RudderTests-watchOS/Pods-RudderTests-watchOS-frameworks-${CONFIGURATION}-input-files.xcfilelist",
-			);
-			name = "[CP] Embed Pods Frameworks";
-			outputFileListPaths = (
-				"${PODS_ROOT}/Target Support Files/Pods-RudderTests-watchOS/Pods-RudderTests-watchOS-frameworks-${CONFIGURATION}-output-files.xcfilelist",
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-RudderTests-watchOS/Pods-RudderTests-watchOS-frameworks.sh\"\n";
-			showEnvVarsInLog = 0;
-		};
-		A39CDD690B851FCC6F21BCFF /* [CP] Check Pods Manifest.lock */ = {
+		5FB70CA39CF2A35323E7A81A /* [CP] Check Pods Manifest.lock */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -2237,7 +2176,68 @@
 			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
 			showEnvVarsInLog = 0;
 		};
-		B77A79581B274E25A326F22D /* [CP] Check Pods Manifest.lock */ = {
+		6A6591BA32490D7B807F9B5C /* [CP] Check Pods Manifest.lock */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+				"${PODS_PODFILE_DIR_PATH}/Podfile.lock",
+				"${PODS_ROOT}/Manifest.lock",
+			);
+			name = "[CP] Check Pods Manifest.lock";
+			outputFileListPaths = (
+			);
+			outputPaths = (
+				"$(DERIVED_FILE_DIR)/Pods-Rudder-watchOS-checkManifestLockResult.txt",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
+			showEnvVarsInLog = 0;
+		};
+		837D75C23E52CDD20D6D07BF /* [CP] Embed Pods Frameworks */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-RudderTests-watchOS/Pods-RudderTests-watchOS-frameworks-${CONFIGURATION}-input-files.xcfilelist",
+			);
+			name = "[CP] Embed Pods Frameworks";
+			outputFileListPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-RudderTests-watchOS/Pods-RudderTests-watchOS-frameworks-${CONFIGURATION}-output-files.xcfilelist",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-RudderTests-watchOS/Pods-RudderTests-watchOS-frameworks.sh\"\n";
+			showEnvVarsInLog = 0;
+		};
+		A8327BC7AFC7B7A01B7A86A1 /* [CP] Check Pods Manifest.lock */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+				"${PODS_PODFILE_DIR_PATH}/Podfile.lock",
+				"${PODS_ROOT}/Manifest.lock",
+			);
+			name = "[CP] Check Pods Manifest.lock";
+			outputFileListPaths = (
+			);
+			outputPaths = (
+				"$(DERIVED_FILE_DIR)/Pods-Rudder-tvOS-checkManifestLockResult.txt",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
+			showEnvVarsInLog = 0;
+		};
+		AE7D1576B7EE7ED6F5478C79 /* [CP] Check Pods Manifest.lock */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -2259,7 +2259,7 @@
 			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
 			showEnvVarsInLog = 0;
 		};
-		C28C1972688C65E5EAE03471 /* [CP] Check Pods Manifest.lock */ = {
+		C464092C7DB2520EDF77448B /* [CP] Check Pods Manifest.lock */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -2281,7 +2281,7 @@
 			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
 			showEnvVarsInLog = 0;
 		};
-		CFD481FFA7D08854676F4C41 /* [CP] Embed Pods Frameworks */ = {
+		CC89EA7B31270EE4D0FA72E1 /* [CP] Embed Pods Frameworks */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -2833,7 +2833,7 @@
 		};
 		06CABB992630C3CA0097BEFF /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = D622D27CE082C02F605707FE /* Pods-Rudder-iOS.debug.xcconfig */;
+			baseConfigurationReference = 273057E4FA7F2B0952AF241D /* Pods-Rudder-iOS.debug.xcconfig */;
 			buildSettings = {
 				ALLOW_TARGET_PLATFORM_SPECIALIZATION = YES;
 				APPLICATION_EXTENSION_API_ONLY = NO;
@@ -2878,7 +2878,7 @@
 		};
 		06CABB9A2630C3CA0097BEFF /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 6307363FD931C4184D3CB813 /* Pods-Rudder-iOS.release.xcconfig */;
+			baseConfigurationReference = 83C9949585CD3C274CCE6A27 /* Pods-Rudder-iOS.release.xcconfig */;
 			buildSettings = {
 				ALLOW_TARGET_PLATFORM_SPECIALIZATION = YES;
 				APPLICATION_EXTENSION_API_ONLY = NO;
@@ -2922,7 +2922,7 @@
 		};
 		ED998F132A69003600031B06 /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 8386A90FCB2E6C483CC34952 /* Pods-Rudder-tvOS.debug.xcconfig */;
+			baseConfigurationReference = E891EDD19ECD40A0BCF5FDFA /* Pods-Rudder-tvOS.debug.xcconfig */;
 			buildSettings = {
 				ALLOW_TARGET_PLATFORM_SPECIALIZATION = YES;
 				APPLICATION_EXTENSION_API_ONLY = NO;
@@ -2967,7 +2967,7 @@
 		};
 		ED998F142A69003600031B06 /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = CC0F863D62F9D02F7B958FA2 /* Pods-Rudder-tvOS.release.xcconfig */;
+			baseConfigurationReference = 9B4BB7D91351507AD413A9B4 /* Pods-Rudder-tvOS.release.xcconfig */;
 			buildSettings = {
 				ALLOW_TARGET_PLATFORM_SPECIALIZATION = YES;
 				APPLICATION_EXTENSION_API_ONLY = NO;
@@ -3011,7 +3011,7 @@
 		};
 		ED998FE32A69024E00031B06 /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 9F810D86FD6A9B76CB56D407 /* Pods-Rudder-watchOS.debug.xcconfig */;
+			baseConfigurationReference = 767A0EEE9A76F43CF631573B /* Pods-Rudder-watchOS.debug.xcconfig */;
 			buildSettings = {
 				ALLOW_TARGET_PLATFORM_SPECIALIZATION = YES;
 				APPLICATION_EXTENSION_API_ONLY = NO;
@@ -3056,7 +3056,7 @@
 		};
 		ED998FE42A69024E00031B06 /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 7DCFD27F69B0AF5419724FC5 /* Pods-Rudder-watchOS.release.xcconfig */;
+			baseConfigurationReference = 02107210BC6C6469C1537DDD /* Pods-Rudder-watchOS.release.xcconfig */;
 			buildSettings = {
 				ALLOW_TARGET_PLATFORM_SPECIALIZATION = YES;
 				APPLICATION_EXTENSION_API_ONLY = NO;
@@ -3100,7 +3100,7 @@
 		};
 		ED9990352A69102400031B06 /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = DFF929D4168AFBD1511A4013 /* Pods-RudderTests-tvOS.debug.xcconfig */;
+			baseConfigurationReference = A79972EA5B187EF23B242B09 /* Pods-RudderTests-tvOS.debug.xcconfig */;
 			buildSettings = {
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
 				CODE_SIGN_STYLE = Automatic;
@@ -3122,7 +3122,7 @@
 		};
 		ED9990362A69102400031B06 /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 985D25DF983E35D9BA1961B7 /* Pods-RudderTests-tvOS.release.xcconfig */;
+			baseConfigurationReference = AF1E8F07C3B20B7CC3AB9F3D /* Pods-RudderTests-tvOS.release.xcconfig */;
 			buildSettings = {
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
 				CODE_SIGN_STYLE = Automatic;
@@ -3144,7 +3144,7 @@
 		};
 		ED9990432A69103B00031B06 /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 80D3FB2299E58D1817A1B0E2 /* Pods-RudderTests-iOS.debug.xcconfig */;
+			baseConfigurationReference = 0358E5A80DA154A90CDF4BF0 /* Pods-RudderTests-iOS.debug.xcconfig */;
 			buildSettings = {
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
 				CODE_SIGN_STYLE = Automatic;
@@ -3176,7 +3176,7 @@
 		};
 		ED9990442A69103B00031B06 /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 51D8D2C7430591C091E783C8 /* Pods-RudderTests-iOS.release.xcconfig */;
+			baseConfigurationReference = 22FB9A6823E80938F3F912C0 /* Pods-RudderTests-iOS.release.xcconfig */;
 			buildSettings = {
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
 				CODE_SIGN_STYLE = Automatic;
@@ -3208,7 +3208,7 @@
 		};
 		ED9990512A69104B00031B06 /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 010DAF827438C4A823468825 /* Pods-RudderTests-watchOS.debug.xcconfig */;
+			baseConfigurationReference = 3C44A9E8F4B06BD7D1881CC6 /* Pods-RudderTests-watchOS.debug.xcconfig */;
 			buildSettings = {
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
 				CODE_SIGN_STYLE = Automatic;
@@ -3230,7 +3230,7 @@
 		};
 		ED9990522A69104B00031B06 /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 3C702DB8C75FBD66B10B8EDF /* Pods-RudderTests-watchOS.release.xcconfig */;
+			baseConfigurationReference = C607C3351E8D2620CFE41964 /* Pods-RudderTests-watchOS.release.xcconfig */;
 			buildSettings = {
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
 				CODE_SIGN_STYLE = Automatic;

--- a/Sources/Classes/Headers/Public/RSClient.h
+++ b/Sources/Classes/Headers/Public/RSClient.h
@@ -77,6 +77,7 @@ typedef void (^Callback)(NSObject *_Nullable);
 + (void) putAnonymousId: (NSString *_Nonnull) anonymousId;
 + (void) putDeviceToken: (NSString *_Nonnull) deviceToken;
 + (void) putAuthToken: (NSString *_Nonnull) authToken;
++ (void) putAdvertisingId: (NSString *_Nonnull) advertisingId;
 
 + (void) setAnonymousId: (NSString *__nullable) anonymousId __attribute((deprecated("Discontinuing support. Use putAnonymousId method instead.")));;
 
@@ -90,6 +91,7 @@ typedef void (^Callback)(NSObject *_Nullable);
 - (RSContext *) getContext __attribute((deprecated("This method will be deprecated soon. Use instance property(context) instead.")));
 
 - (void) onIntegrationReady:(id<RSIntegrationFactory>)factory withCallback:(Callback)callback;
+- (void) clearAdvertisingId;
 
 @property (strong, nonatomic, readonly) NSNumber* _Nullable sessionId;
 @property (strong, nonatomic, readonly) NSString* _Nullable anonymousId;

--- a/Sources/Classes/Headers/Public/RSContext.h
+++ b/Sources/Classes/Headers/Public/RSContext.h
@@ -56,6 +56,7 @@ extern int const RSATTAuthorize;
 - (void) updateTraitsAnonymousId;
 - (void) putDeviceToken: (NSString*) deviceToken;
 - (void) putAdvertisementId: (NSString *_Nonnull) idfa;
+- (void) clearAdvertisingId;
 - (void) putAppTrackingConsent: (int) att;
 - (void) updateExternalIds: (NSMutableArray* __nullable) externalIds;
 - (void) resetExternalIdsOnQueue;

--- a/Sources/Classes/Headers/Public/RSDeviceInfo.h
+++ b/Sources/Classes/Headers/Public/RSDeviceInfo.h
@@ -24,7 +24,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, readwrite) NSString* type;
 @property (nonatomic, readwrite) NSString* token;
 @property (nonatomic, readwrite) BOOL adTrackingEnabled;
-@property (nonatomic, readwrite) NSString* advertisingId;
+@property (nonatomic, readwrite, nullable) NSString* advertisingId;
 @property (nonatomic, readwrite) int attTrackingStatus;
 
 @end

--- a/Sources/Classes/Headers/Public/RSPreferenceManager.h
+++ b/Sources/Classes/Headers/Public/RSPreferenceManager.h
@@ -83,6 +83,10 @@ extern NSString *const RSSessionAutoTrackStatus;
 - (void) saveAutoTrackingStatus: (BOOL) autoTrackingStatus;
 - (BOOL) getAutoTrackingStatus;
 
+- (void) saveAdvertisingId: (NSString *) advertisingId;
+- (NSString*) getAdvertisingId;
+- (void) clearAdvertisingId;
+
 @property (nonatomic, readwrite) BOOL isMetricsCollectionEnabled;
 @property (nonatomic, readwrite) BOOL isErrorsCollectionEnabled;
 

--- a/Sources/Classes/Headers/Public/RSUtils.h
+++ b/Sources/Classes/Headers/Public/RSUtils.h
@@ -47,6 +47,7 @@ NS_ASSUME_NONNULL_BEGIN
 + (BOOL)removeFile:(NSString *)fileName;
 + (BOOL) isDBMessageEmpty:(RSDBMessage*)dbMessage;
 + (BOOL) isEmptyString:(NSString *)value;
++ (BOOL) isValidIDFA:(NSString*)idfa;
 + (BOOL) isSpecialFloatingNumber:(NSNumber *)number;
 
 extern unsigned int MAX_EVENT_SIZE;

--- a/Sources/Classes/Headers/RSVersion.h
+++ b/Sources/Classes/Headers/RSVersion.h
@@ -8,6 +8,6 @@
 #ifndef RSVersion_h
 #define RSVersion_h
 
-NSString *const SDK_VERSION = @"1.25.3";
+NSString *const SDK_VERSION = @"1.26.0";
 
 #endif /* RSVersion_h */

--- a/Sources/Classes/RSClient.m
+++ b/Sources/Classes/RSClient.m
@@ -19,6 +19,7 @@ static RSEventRepository *_repository = nil;
 static RSUserSession *_userSession = nil;
 static RSOption* _defaultOptions = nil;
 static NSString* _deviceToken = nil;
+static NSString* _advertisingId = nil;
 
 @implementation RSClient
 
@@ -54,6 +55,9 @@ static NSString* _deviceToken = nil;
             _repository = [RSEventRepository initiate:writeKey config:_config client:_instance options:options];
             if(_deviceToken != nil && [_deviceToken length] != 0) {
                 [_instance.context putDeviceToken:_deviceToken];
+            }
+            if([RSUtils isValidIDFA:_advertisingId]) {
+                [_instance.context putAdvertisementId:_advertisingId];
             }
         });
     }
@@ -478,6 +482,27 @@ static NSString* _deviceToken = nil;
             [preferenceManager saveAuthToken:base64EncodedAuthToken];
         }
     }
+}
+
++ (void)putAdvertisingId:(NSString *_Nonnull) advertisingId {
+    if([RSUtils isValidIDFA:advertisingId]) {
+        RSPreferenceManager *preferenceManager = [RSPreferenceManager getInstance];
+        if([preferenceManager getOptStatus]) {
+            [RSLogger logDebug:@"User Opted out for tracking the activity, hence dropping the advertising Id"];
+            return;
+        }
+        if(_instance == nil) {
+            _advertisingId = advertisingId;
+            return;
+        }
+        [_instance.context putAdvertisementId:advertisingId];
+    } else {
+        [RSLogger logError:@"RSClient: putAdvertisingId: Invalid value passed for advertisingId, hence dropping it"];
+    }
+}
+
+- (void) clearAdvertisingId {
+    [_instance.context clearAdvertisingId];
 }
 
 #pragma mark - Session Tracking

--- a/Sources/Classes/RSContext.m
+++ b/Sources/Classes/RSContext.m
@@ -172,15 +172,22 @@ static dispatch_queue_t queue;
     // This isn't ideal.  We're doing this because we can't actually check if IDFA is enabled on
     // the customer device.  Apple docs and tests show that if it is disabled, one gets back all 0's.
     dispatch_sync(queue, ^{
-        if( idfa != nil && [idfa length] != 0) {
+        if([RSUtils isValidIDFA:idfa]) {
             [RSLogger logDebug:[[NSString alloc] initWithFormat:@"IDFA: %@", idfa]];
-            BOOL adTrackingEnabled = (![idfa isEqualToString:@"00000000-0000-0000-0000-000000000000"]);
-            self->_device.adTrackingEnabled = adTrackingEnabled;
-            
-            if (adTrackingEnabled) {
-                self->_device.advertisingId = idfa;
-            }
+            [[RSPreferenceManager getInstance] saveAdvertisingId:idfa];
+            self->_device.adTrackingEnabled = YES;
+            self->_device.advertisingId = idfa;
+        } else {
+            [RSLogger logError:@"RSContext: putAdvertisementId: Invalid value passed as advertisingId, hence dropping it"];
         }
+    });
+}
+
+- (void) clearAdvertisingId {
+    dispatch_sync(queue, ^{
+        [[RSPreferenceManager getInstance] clearAdvertisingId];
+        self->_device.adTrackingEnabled = nil;
+        self->_device.advertisingId = nil;
     });
 }
 

--- a/Sources/Classes/RSDeviceInfo.m
+++ b/Sources/Classes/RSDeviceInfo.m
@@ -33,6 +33,10 @@
         _model = [self getDeviceModel];
         _manufacturer = @"Apple";
         _attTrackingStatus = RSATTNotDetermined;
+        _advertisingId = [[RSPreferenceManager getInstance] getAdvertisingId];
+        if(_advertisingId != nil) {
+            _adTrackingEnabled = YES;
+        }
     }
     return self;
 }

--- a/Sources/Classes/RSPreferenceManager.m
+++ b/Sources/Classes/RSPreferenceManager.m
@@ -28,6 +28,7 @@ NSString *const RSOptStatus = @"rl_opt_status";
 NSString *const RSOptInTimeKey = @"rl_opt_in_time";
 NSString *const RSOptOutTimeKey = @"rl_opt_out_time";
 NSString *const RSSessionIdKey = @"rl_session_id";
+NSString *const RSAdvertisingIdKey = @"rl_advertising_id";
 NSString *const RSLastActiveTimestamp = @"rl_last_event_time_stamp";
 NSString *const RSSessionAutoTrackStatus = @"rl_session_auto_track_status";
 NSString *const RSEventDeletionStatus = @"rl_event_deletion_status";
@@ -293,6 +294,18 @@ NSString *const RSEventDeletionStatus = @"rl_event_deletion_status";
         return serverSourceConfig.isMetricsCollectionEnabled;
     }
     return NO;
+}
+
+- (void) saveAdvertisingId:(NSString *) advertisingId {
+    [self writeObject:advertisingId forKey:RSAdvertisingIdKey];
+}
+
+- (NSString*) getAdvertisingId {
+    return [self readObjectForKey:RSAdvertisingIdKey];
+}
+
+- (void) clearAdvertisingId {
+    [self removeObjectForKey:RSAdvertisingIdKey];
 }
 
 - (RSServerConfigSource * __nullable)getServerSourceConfig {

--- a/Sources/Classes/RSUtils.m
+++ b/Sources/Classes/RSUtils.m
@@ -171,6 +171,10 @@
     return (value == nil || value.length == 0);
 }
 
++ (BOOL) isValidIDFA:(NSString*)idfa {
+    return ![RSUtils isEmptyString:idfa] && ![idfa isEqualToString:@"00000000-0000-0000-0000-000000000000"];
+}
+
 + (NSString* _Nullable) serialize:(id) object {
     @try {
         id sanitizedObject = [self sanitizeObject:object];

--- a/package.json
+++ b/package.json
@@ -1,4 +1,4 @@
 {
-    "version": "1.25.3",
+    "version": "1.26.0",
     "description": "Rudder is a platform for collecting, storing and routing customer event data to dozens of tools"
 }

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -6,7 +6,7 @@ sonar.qualitygate.wait=false
 sonar.projectKey=rudderlabs_rudder-sdk-ios
 sonar.organization=rudderlabs
 sonar.projectName=RudderStack iOS SDK
-sonar.projectVersion=1.25.3
+sonar.projectVersion=1.26.0
 
 # C/C++/Objective-C related details
 # sonar.cfamily.compile-commands=compile_commands.json


### PR DESCRIPTION
:crown: *An automated PR*

   Unreleased (2024-03-19)<br> * feat: add support for global customContext option ( 485) ([27f21b9](https://github.com/rudderlabs/rudder-sdk-ios/commit/27f21b9)), closes [ 485](https://github.com/rudderlabs/rudder-sdk-ios/issues/485)<br> * feat: added support for setting advertisingId before sdk init and also persisting it ( 481) ([2075910](https://github.com/rudderlabs/rudder-sdk-ios/commit/2075910)), closes [ 481](https://github.com/rudderlabs/rudder-sdk-ios/issues/481)