### PR TITLE
chore(release): pulling release/1.26.1 into master

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+### [1.26.1](https://github.com/rudderlabs/rudder-sdk-ios/compare/v1.26.0...v1.26.1) (2024-03-28)
+
+
+### Bug Fixes
+
+* initializing MetricsReporter and CrashReporter only if it's enabled for a customer ([#491](https://github.com/rudderlabs/rudder-sdk-ios/issues/491)) ([48c4ae1](https://github.com/rudderlabs/rudder-sdk-ios/commit/48c4ae18354d66cae9b14f039c6826a7bbb72d50))
+
 ## [1.26.0](https://github.com/rudderlabs/rudder-sdk-ios/compare/v1.25.3...v1.26.0) (2024-03-19)
 
 

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,1 @@
-* @pallabmaiti @itsdebs
+* @rudderlabs/sdk-ios

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 <p align="center">
   <a href="https://cocoapods.org/pods/Rudder">
-    <img src="https://img.shields.io/static/v1?label=pod&message=v1.26.0&color=blue&style=flat">
+    <img src="https://img.shields.io/static/v1?label=pod&message=v1.26.1&color=blue&style=flat">
     </a>
 </p>
 
@@ -39,7 +39,7 @@ The iOS SDK is available through [**CocoaPods**](https://cocoapods.org), [**Cart
 To install the SDK, simply add the following line to your Podfile:
 
 ```xcode
-pod 'Rudder', '1.26.0'
+pod 'Rudder', '1.26.1'
 ```
 
 ### Carthage
@@ -47,7 +47,7 @@ pod 'Rudder', '1.26.0'
 For Carthage support, add the following line to your `Cartfile`:
 
 ```xcode
-github "rudderlabs/rudder-sdk-ios" "v1.26.0"
+github "rudderlabs/rudder-sdk-ios" "v1.26.1"
 ```
 
 > Remember to include the following code in all `.m` and `.h` files where you want to refer to or use the RudderStack SDK classes, as shown:
@@ -71,7 +71,7 @@ You can also add the RudderStack iOS SDK via Swift Package Mangaer, via one of t
 
 * Enter the package repository (`git@github.com:rudderlabs/rudder-sdk-ios.git`) in the search bar.
 
-* In **Dependency Rule**, select **Up to Next Major Version** and enter `1.26.0` as the value, as shown:
+* In **Dependency Rule**, select **Up to Next Major Version** and enter `1.26.1` as the value, as shown:
 
 ![Setting dependency](https://user-images.githubusercontent.com/59817155/145574696-8c849749-13e0-40d5-aacb-3fccb5c8e67d.png)
 
@@ -99,7 +99,7 @@ let package = Package(
     ],
     dependencies: [
         // Dependencies declare other packages that this package depends on.
-        .package(url: "git@github.com:rudderlabs/rudder-sdk-ios.git", from: "1.26.0")
+        .package(url: "git@github.com:rudderlabs/rudder-sdk-ios.git", from: "1.26.1")
     ],
     targets: [
         // Targets are the basic building blocks of a package. A target can define a module or a test suite.

--- a/Sources/Classes/Headers/RSVersion.h
+++ b/Sources/Classes/Headers/RSVersion.h
@@ -8,6 +8,6 @@
 #ifndef RSVersion_h
 #define RSVersion_h
 
-NSString *const SDK_VERSION = @"1.26.0";
+NSString *const SDK_VERSION = @"1.26.1";
 
 #endif /* RSVersion_h */

--- a/Sources/Classes/RSMetricsReporter.m
+++ b/Sources/Classes/RSMetricsReporter.m
@@ -30,11 +30,15 @@ RSMetricsClient * _Nullable _metricsClient;
 - (instancetype)initWithWriteKey:(NSString *)writeKey preferenceManager:(RSPreferenceManager *)preferenceManager andConfig:(RSConfig *)config {
     self = [super init];
     if (self) {
-        RSMetricConfiguration *configuration = [[RSMetricConfiguration alloc] initWithLogLevel:config.logLevel writeKey:writeKey sdkVersion:RS_VERSION];
-        [configuration dbCountThreshold:config.dbCountThreshold];
-        _metricsClient = [[RSMetricsClient alloc] initWithConfiguration:configuration];
-        _metricsClient.isMetricsCollectionEnabled = preferenceManager.isMetricsCollectionEnabled;
-        _metricsClient.isErrorsCollectionEnabled = preferenceManager.isErrorsCollectionEnabled;
+        if (preferenceManager.isMetricsCollectionEnabled || preferenceManager.isErrorsCollectionEnabled) {
+            RSMetricConfiguration *configuration = [[RSMetricConfiguration alloc] initWithLogLevel:config.logLevel writeKey:writeKey sdkVersion:RS_VERSION];
+            [configuration dbCountThreshold:config.dbCountThreshold];
+            _metricsClient = [[RSMetricsClient alloc] initWithConfiguration:configuration];
+            _metricsClient.isMetricsCollectionEnabled = preferenceManager.isMetricsCollectionEnabled;
+            _metricsClient.isErrorsCollectionEnabled = preferenceManager.isErrorsCollectionEnabled;
+        } else {
+            [RSLogger logWarn:@"RSMetricsReporter: Metrics and Errors collection is disabled."]; 
+        }
     }
     return self;
 }

--- a/package.json
+++ b/package.json
@@ -1,4 +1,4 @@
 {
-    "version": "1.26.0",
+    "version": "1.26.1",
     "description": "Rudder is a platform for collecting, storing and routing customer event data to dozens of tools"
 }

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -6,7 +6,7 @@ sonar.qualitygate.wait=false
 sonar.projectKey=rudderlabs_rudder-sdk-ios
 sonar.organization=rudderlabs
 sonar.projectName=RudderStack iOS SDK
-sonar.projectVersion=1.26.0
+sonar.projectVersion=1.26.1
 
 # C/C++/Objective-C related details
 # sonar.cfamily.compile-commands=compile_commands.json


### PR DESCRIPTION
:crown: *An automated PR*

   Unreleased (2024-03-28)<br> * chore: updated CODEOWNERS to point to iOS team ([45646af](https://github.com/rudderlabs/rudder-sdk-ios/commit/45646af))<br> * fix: initializing MetricsReporter and CrashReporter only if it's enabled for a customer ( 491) ([48c4ae1](https://github.com/rudderlabs/rudder-sdk-ios/commit/48c4ae1)), closes [ 491](https://github.com/rudderlabs/rudder-sdk-ios/issues/491)