### PR TITLE
feat: add privacy manifest file support for ios v2 sdk

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -17,7 +17,10 @@ let package = Package(
         .target(
             name: "Rudder",
             path: "Sources",
-            sources: ["Classes/"]
+            sources: ["Classes/"],
+            resources: [
+                .copy("Resources/PrivacyInfo.xcprivacy")
+            ]
         ),
         .testTarget(
             name: "RudderTests",

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -1,5 +1,5 @@
 PODS:
-  - Rudder (2.3.0)
+  - Rudder (2.4.3)
 
 DEPENDENCIES:
   - Rudder (from `.`)
@@ -9,8 +9,8 @@ EXTERNAL SOURCES:
     :path: "."
 
 SPEC CHECKSUMS:
-  Rudder: 368691bcf2588f00cc99004cbc2026675b9cb16f
+  Rudder: 831e9e84722969781103845b287bdbe7b0c9f833
 
 PODFILE CHECKSUM: ee379229e6a0b60bc98226700ace2de002171547
 
-COCOAPODS: 1.11.3
+COCOAPODS: 1.14.3

--- a/Rudder.podspec
+++ b/Rudder.podspec
@@ -14,6 +14,7 @@ Pod::Spec.new do |s|
   s.license          = { :type => "Apache", :file => "LICENSE" }
   s.author           = { "RudderStack" => "sdk@rudderstack.com" }
   s.source           = { :git => "https://github.com/rudderlabs/rudder-sdk-ios.git", :tag => "v#{s.version}" }
+  s.resource_bundles = { s.name => 'Sources/Resources/PrivacyInfo.xcprivacy' }
 
   s.swift_version = '5.3'
   s.ios.deployment_target = '12.0'

--- a/Rudder.podspec
+++ b/Rudder.podspec
@@ -12,7 +12,7 @@ Pod::Spec.new do |s|
 
   s.homepage         = "https://github.com/rudderlabs/rudder-sdk-ios"
   s.license          = { :type => "Apache", :file => "LICENSE" }
-  s.author           = { "RudderStack" => "arnab@rudderlabs.com" }
+  s.author           = { "RudderStack" => "sdk@rudderstack.com" }
   s.source           = { :git => "https://github.com/rudderlabs/rudder-sdk-ios.git", :tag => "v#{s.version}" }
 
   s.swift_version = '5.3'

--- a/Sources/Classes/Common/Constants/RSConstants.swift
+++ b/Sources/Classes/Common/Constants/RSConstants.swift
@@ -8,11 +8,11 @@
 
 import Foundation
 
-public let RSDataPlaneUrl = "https://hosted.rudderlabs.com"
+public let RSDataPlaneUrl = "https://hosted.rudderstack.com"
 public let RSFlushQueueSize: Int = 30
 public let RSDBCountThreshold: Int = 10000
 public let RSSleepTimeout: Int = 10
-public let RSControlPlaneUrl = "https://api.rudderlabs.com"
+public let RSControlPlaneUrl = "https://api.rudderstack.com"
 public let RSTrackLifeCycleEvents = true
 public let RSRecordScreenViews = false
 let RETRY_FLUSH_COUNT = 3

--- a/Sources/Resources/PrivacyInfo.xcprivacy
+++ b/Sources/Resources/PrivacyInfo.xcprivacy
@@ -1,0 +1,64 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>NSPrivacyAccessedAPITypes</key>
+	<array>
+		<dict>
+			<key>NSPrivacyAccessedAPIType</key>
+			<string>NSPrivacyAccessedAPICategoryUserDefaults</string>
+			<key>NSPrivacyAccessedAPITypeReasons</key>
+			<array>
+				<string>CA92.1</string>
+			</array>
+		</dict>
+	</array>
+	<key>NSPrivacyCollectedDataTypes</key>
+	<array>
+		<dict>
+			<key>NSPrivacyCollectedDataType</key>
+			<string>App Version</string>
+			<key>NSPrivacyCollectedDataTypeLinked</key>
+			<false/>
+			<key>NSPrivacyCollectedDataTypeTracking</key>
+			<false/>
+			<key>NSPrivacyCollectedDataTypePurposes</key>
+			<array>
+				<string>NSPrivacyCollectedDataTypePurposeDeveloperAdvertising</string>
+				<string>NSPrivacyCollectedDataTypePurposeAnalytics</string>
+			</array>
+		</dict>
+		<dict>
+			<key>NSPrivacyCollectedDataType</key>
+			<string>App Name</string>
+			<key>NSPrivacyCollectedDataTypeLinked</key>
+			<false/>
+			<key>NSPrivacyCollectedDataTypeTracking</key>
+			<false/>
+			<key>NSPrivacyCollectedDataTypePurposes</key>
+			<array>
+				<string>NSPrivacyCollectedDataTypePurposeDeveloperAdvertising</string>
+				<string>NSPrivacyCollectedDataTypePurposeAnalytics</string>
+			</array>
+		</dict>
+		<dict>
+			<key>NSPrivacyCollectedDataType</key>
+			<string>NSPrivacyCollectedDataTypeDeviceID</string>
+			<key>NSPrivacyCollectedDataTypeLinked</key>
+			<false/>
+			<key>NSPrivacyCollectedDataTypeTracking</key>
+			<false/>
+			<key>NSPrivacyCollectedDataTypePurposes</key>
+			<array>
+				<string>NSPrivacyCollectedDataTypePurposeAnalytics</string>
+				<string>NSPrivacyCollectedDataTypePurposeDeveloperAdvertising</string>
+				<string>NSPrivacyCollectedDataTypePurposeThirdPartyAdvertising</string>
+			</array>
+		</dict>
+	</array>
+	<key>NSPrivacyTrackingDomains</key>
+	<array>
+		<string>rudderstack.com</string>
+	</array>
+</dict>
+</plist>

--- a/Sources/Resources/PrivacyInfo.xcprivacy
+++ b/Sources/Resources/PrivacyInfo.xcprivacy
@@ -58,7 +58,7 @@
 	</array>
 	<key>NSPrivacyTrackingDomains</key>
 	<array>
-		<string>rudderstack.com</string>
+		<string>rudderstack.com/</string>
 	</array>
 </dict>
 </plist>


### PR DESCRIPTION
# Description

- Added Privacy Manifest file support for iOS v2 SDK: Implemented support for Privacy Manifest file in both CocoaPods and Swift Package Manager (SPM) distributions.
- Changed `rudderlabs` domain to `rudderstack.com` for default dataPlane and controlPlaneUrl.
- Changed mail to `sdk@rudderstack.com`.

Here is the Privacy Report:
<img width="1643" alt="image" src="https://github.com/rudderlabs/rudder-sdk-ios/assets/64667840/a79496fe-e3f1-4fe3-99b2-9fc6817e1341">

