### PR TITLE
chore(release): pulling release/2.4.4-beta into master-v2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+### [2.4.4](https://github.com/rudderlabs/rudder-sdk-ios/compare/v2.4.3...v2.4.4) (2024-04-05)
+
+
+### Bug Fixes
+
+* fix swift name mangling for SwiftUI hosting controllers ([#475](https://github.com/rudderlabs/rudder-sdk-ios/issues/475)) ([dbb04b5](https://github.com/rudderlabs/rudder-sdk-ios/commit/dbb04b5481e6aae0e801a29664846bcbba2a76de))
+
 ### [2.4.3](https://github.com/rudderlabs/rudder-sdk-ios/compare/v2.4.2...v2.4.3) (2024-01-18)
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
-### [2.4.4](https://github.com/rudderlabs/rudder-sdk-ios/compare/v2.4.3...v2.4.4) (2024-04-05)
+### [2.4.4-beta](https://github.com/rudderlabs/rudder-sdk-ios/compare/v2.4.3...v2.4.4-beta) (2024-04-05)
 
 
 ### Bug Fixes

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,1 @@
-* @pallabmaiti @itsdebs
+* @rudderlabs/sdk-ios

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 <p align="center">
   <a href="https://cocoapods.org/pods/Rudder">
-    <img src="https://img.shields.io/static/v1?label=pod&message=v2.4.4&color=blue&style=flat">
+    <img src="https://img.shields.io/static/v1?label=pod&message=v2.4.4-beta&color=blue&style=flat">
     </a>
 </p>
 
@@ -47,7 +47,7 @@ The iOS SDK is available through [**CocoaPods**](https://cocoapods.org), [**Cart
 To install the SDK, simply add the following line to your Podfile:
 
 ```xcode
-pod 'Rudder', '2.4.4'
+pod 'Rudder', '2.4.4-beta'
 ```
 
 ### Carthage
@@ -55,7 +55,7 @@ pod 'Rudder', '2.4.4'
 For Carthage support, add the following line to your `Cartfile`:
 
 ```xcode
-github "rudderlabs/rudder-sdk-ios" "v2.4.4"
+github "rudderlabs/rudder-sdk-ios" "v2.4.4-beta"
 ```
 
 > Remember to include the following code where you want to refer to or use the RudderStack SDK classes, as shown:
@@ -86,7 +86,7 @@ You can also add the RudderStack SDK using the Swift Package Mangaer in one of t
 ![Adding a package](https://user-images.githubusercontent.com/59817155/140903027-286a1d64-f5d5-4041-9827-47b6cef76a46.png)
 
 2. Enter the package repository (`git@github.com:rudderlabs/rudder-sdk-ios.git`) in the search bar.
-3. In **Dependency Rule**, select **Up to Next Major Version**, and enter `2.4.4` as the value, as shown:
+3. In **Dependency Rule**, select **Up to Next Major Version**, and enter `2.4.4-beta` as the value, as shown:
 
 ![Setting the dependency](https://user-images.githubusercontent.com/59817155/145574696-8c849749-13e0-40d5-aacb-3fccb5c8e67d.png)
 
@@ -113,7 +113,7 @@ let package = Package(
     ],
     dependencies: [
         // Dependencies declare other packages that this package depends on.
-        .package(url: "git@github.com:rudderlabs/rudder-sdk-ios.git", from: "2.4.4")
+        .package(url: "git@github.com:rudderlabs/rudder-sdk-ios.git", from: "2.4.4-beta")
     ],
     targets: [
         // Targets are the basic building blocks of a package. A target can define a module or a test suite.

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 <p align="center">
   <a href="https://cocoapods.org/pods/Rudder">
-    <img src="https://img.shields.io/static/v1?label=pod&message=v2.4.3&color=blue&style=flat">
+    <img src="https://img.shields.io/static/v1?label=pod&message=v2.4.4&color=blue&style=flat">
     </a>
 </p>
 
@@ -47,7 +47,7 @@ The iOS SDK is available through [**CocoaPods**](https://cocoapods.org), [**Cart
 To install the SDK, simply add the following line to your Podfile:
 
 ```xcode
-pod 'Rudder', '2.4.3'
+pod 'Rudder', '2.4.4'
 ```
 
 ### Carthage
@@ -55,7 +55,7 @@ pod 'Rudder', '2.4.3'
 For Carthage support, add the following line to your `Cartfile`:
 
 ```xcode
-github "rudderlabs/rudder-sdk-ios" "v2.4.3"
+github "rudderlabs/rudder-sdk-ios" "v2.4.4"
 ```
 
 > Remember to include the following code where you want to refer to or use the RudderStack SDK classes, as shown:
@@ -86,7 +86,7 @@ You can also add the RudderStack SDK using the Swift Package Mangaer in one of t
 ![Adding a package](https://user-images.githubusercontent.com/59817155/140903027-286a1d64-f5d5-4041-9827-47b6cef76a46.png)
 
 2. Enter the package repository (`git@github.com:rudderlabs/rudder-sdk-ios.git`) in the search bar.
-3. In **Dependency Rule**, select **Up to Next Major Version**, and enter `2.4.3` as the value, as shown:
+3. In **Dependency Rule**, select **Up to Next Major Version**, and enter `2.4.4` as the value, as shown:
 
 ![Setting the dependency](https://user-images.githubusercontent.com/59817155/145574696-8c849749-13e0-40d5-aacb-3fccb5c8e67d.png)
 
@@ -113,7 +113,7 @@ let package = Package(
     ],
     dependencies: [
         // Dependencies declare other packages that this package depends on.
-        .package(url: "git@github.com:rudderlabs/rudder-sdk-ios.git", from: "2.4.3")
+        .package(url: "git@github.com:rudderlabs/rudder-sdk-ios.git", from: "2.4.4")
     ],
     targets: [
         // Targets are the basic building blocks of a package. A target can define a module or a test suite.

--- a/Sources/Classes/Common/Constants/RSVersion.swift
+++ b/Sources/Classes/Common/Constants/RSVersion.swift
@@ -9,4 +9,4 @@
 import Foundation
 
 // don't edit this line
-let RSVersion = "2.4.3"
+let RSVersion = "2.4.4"

--- a/Sources/Classes/Common/Constants/RSVersion.swift
+++ b/Sources/Classes/Common/Constants/RSVersion.swift
@@ -9,4 +9,4 @@
 import Foundation
 
 // don't edit this line
-let RSVersion = "2.4.4"
+let RSVersion = "2.4.4-beta"

--- a/Sources/Classes/Helpers/Platforms/iOS/RSiOSScreenViewEvents.swift
+++ b/Sources/Classes/Helpers/Platforms/iOS/RSiOSScreenViewEvents.swift
@@ -42,7 +42,12 @@ extension UIViewController {
     
     @objc
     func rsViewDidAppear(_ animated: Bool) {
-        var name = NSStringFromClass(type(of: self))
+        var name = String(describing: type(of: self))
+        if name.starts(with: "UIHostingController") {
+            name.removeFirst("UIHostingController".count + 1) // Remove `UIHostingController<`
+            if name.hasSuffix(">") { name.removeLast(1) } // Remove last `>`
+        }
+
         name = name.replacingOccurrences(of: "ViewController", with: "")
         let screenMessage = ScreenMessage(title: name, properties: ["automatic": true, "name": name])
         UIViewController.client?.process(message: screenMessage)

--- a/package.json
+++ b/package.json
@@ -1,4 +1,4 @@
 {
-    "version": "2.4.3",
+    "version": "2.4.4",
     "description": "Rudder is a platform for collecting, storing and routing customer event data to dozens of tools"
 }

--- a/package.json
+++ b/package.json
@@ -1,4 +1,4 @@
 {
-    "version": "2.4.4",
+    "version": "2.4.4-beta",
     "description": "Rudder is a platform for collecting, storing and routing customer event data to dozens of tools"
 }

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -6,7 +6,7 @@ sonar.qualitygate.wait=false
 sonar.projectKey=rudderlabs_rudder-sdk-ios-v2
 sonar.organization=rudderlabs
 sonar.projectName=RudderStack iOS SDK(v2)
-sonar.projectVersion=2.4.3
+sonar.projectVersion=2.4.4
 
 # Meta-data for the project
 sonar.links.scm=https://github.com/rudderlabs/rudder-sdk-ios

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -6,7 +6,7 @@ sonar.qualitygate.wait=false
 sonar.projectKey=rudderlabs_rudder-sdk-ios-v2
 sonar.organization=rudderlabs
 sonar.projectName=RudderStack iOS SDK(v2)
-sonar.projectVersion=2.4.4
+sonar.projectVersion=2.4.4-beta
 
 # Meta-data for the project
 sonar.links.scm=https://github.com/rudderlabs/rudder-sdk-ios


### PR DESCRIPTION


   Unreleased (2024-04-05)<br> * fix: fix swift name mangling for SwiftUI hosting controllers ( 475) ([dbb04b5](https://github.com/rudderlabs/rudder-sdk-ios/commit/dbb04b5)), closes [ 475](https://github.com/rudderlabs/rudder-sdk-ios/issues/475)<br> * chore: updated CODEOWNERS to point to a team ([d2bad2d](https://github.com/rudderlabs/rudder-sdk-ios/commit/d2bad2d))