### PR TITLE
fix: remove tracking domain url from Privacy Manifest file

### DIFF
--- a/Sources/Resources/PrivacyInfo.xcprivacy
+++ b/Sources/Resources/PrivacyInfo.xcprivacy
@@ -92,9 +92,5 @@
 			</array>
 		</dict>
 	</array>
-	<key>NSPrivacyTrackingDomains</key>
-	<array>
-		<string>rudderstack.com/</string>
-	</array>
 </dict>
 </plist>


### PR DESCRIPTION
# Description

- We've decided to remove the tracking domain URL from the Privacy Manifest file. This change aims to resolve the error that occurs when a request to our tracking domain gets blocked after the user denies tracking permission.