### PR TITLE
chore(release): pulling release/1.26.3 into master

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+### [1.26.3](https://github.com/rudderlabs/rudder-sdk-ios/compare/v1.26.2...v1.26.3) (2024-04-22)
+
+
+### Bug Fixes
+
+* remove tracking domain url from Privacy Manifest file ([#509](https://github.com/rudderlabs/rudder-sdk-ios/issues/509)) ([759a9f3](https://github.com/rudderlabs/rudder-sdk-ios/commit/759a9f35d658c54ce801207dc4f9a09a04f63903))
+
 ### [1.26.2](https://github.com/rudderlabs/rudder-sdk-ios/compare/v1.26.1...v1.26.2) (2024-04-08)
 
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 <p align="center">
   <a href="https://cocoapods.org/pods/Rudder">
-    <img src="https://img.shields.io/static/v1?label=pod&message=v1.26.2&color=blue&style=flat">
+    <img src="https://img.shields.io/static/v1?label=pod&message=v1.26.3&color=blue&style=flat">
     </a>
 </p>
 
@@ -39,7 +39,7 @@ The iOS SDK is available through [**CocoaPods**](https://cocoapods.org), [**Cart
 To install the SDK, simply add the following line to your Podfile:
 
 ```xcode
-pod 'Rudder', '1.26.2'
+pod 'Rudder', '1.26.3'
 ```
 
 ### Carthage
@@ -47,7 +47,7 @@ pod 'Rudder', '1.26.2'
 For Carthage support, add the following line to your `Cartfile`:
 
 ```xcode
-github "rudderlabs/rudder-sdk-ios" "v1.26.2"
+github "rudderlabs/rudder-sdk-ios" "v1.26.3"
 ```
 
 > Remember to include the following code in all `.m` and `.h` files where you want to refer to or use the RudderStack SDK classes, as shown:
@@ -71,7 +71,7 @@ You can also add the RudderStack iOS SDK via Swift Package Mangaer, via one of t
 
 * Enter the package repository (`git@github.com:rudderlabs/rudder-sdk-ios.git`) in the search bar.
 
-* In **Dependency Rule**, select **Up to Next Major Version** and enter `1.26.2` as the value, as shown:
+* In **Dependency Rule**, select **Up to Next Major Version** and enter `1.26.3` as the value, as shown:
 
 ![Setting dependency](https://user-images.githubusercontent.com/59817155/145574696-8c849749-13e0-40d5-aacb-3fccb5c8e67d.png)
 
@@ -99,7 +99,7 @@ let package = Package(
     ],
     dependencies: [
         // Dependencies declare other packages that this package depends on.
-        .package(url: "git@github.com:rudderlabs/rudder-sdk-ios.git", from: "1.26.2")
+        .package(url: "git@github.com:rudderlabs/rudder-sdk-ios.git", from: "1.26.3")
     ],
     targets: [
         // Targets are the basic building blocks of a package. A target can define a module or a test suite.

--- a/Sources/Classes/Headers/RSVersion.h
+++ b/Sources/Classes/Headers/RSVersion.h
@@ -8,6 +8,6 @@
 #ifndef RSVersion_h
 #define RSVersion_h
 
-NSString *const SDK_VERSION = @"1.26.2";
+NSString *const SDK_VERSION = @"1.26.3";
 
 #endif /* RSVersion_h */

--- a/Sources/Resources/PrivacyInfo.xcprivacy
+++ b/Sources/Resources/PrivacyInfo.xcprivacy
@@ -92,9 +92,5 @@
 			</array>
 		</dict>
 	</array>
-	<key>NSPrivacyTrackingDomains</key>
-	<array>
-		<string>rudderstack.com/</string>
-	</array>
 </dict>
 </plist>

--- a/package.json
+++ b/package.json
@@ -1,4 +1,4 @@
 {
-    "version": "1.26.2",
+    "version": "1.26.3",
     "description": "Rudder is a platform for collecting, storing and routing customer event data to dozens of tools"
 }

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -6,7 +6,7 @@ sonar.qualitygate.wait=false
 sonar.projectKey=rudderlabs_rudder-sdk-ios
 sonar.organization=rudderlabs
 sonar.projectName=RudderStack iOS SDK
-sonar.projectVersion=1.26.2
+sonar.projectVersion=1.26.3
 
 # C/C++/Objective-C related details
 # sonar.cfamily.compile-commands=compile_commands.json


### PR DESCRIPTION
:crown: *An automated PR*

   Unreleased (2024-04-22)<br> * fix: remove tracking domain url from Privacy Manifest file ( 509) ([759a9f3](https://github.com/rudderlabs/rudder-sdk-ios/commit/759a9f3)), closes [ 509](https://github.com/rudderlabs/rudder-sdk-ios/issues/509)