### PR TITLE
fix: remove tracking domain url from Privacy Manifest file in v2

### DIFF
--- a/Podfile.lock
+++ b/Podfile.lock
@@ -1,5 +1,5 @@
 PODS:
-  - Rudder (2.4.3)
+  - Rudder (2.5.0-beta)
 
 DEPENDENCIES:
   - Rudder (from `.`)
@@ -9,7 +9,7 @@ EXTERNAL SOURCES:
     :path: "."
 
 SPEC CHECKSUMS:
-  Rudder: 831e9e84722969781103845b287bdbe7b0c9f833
+  Rudder: 2ff2aa3e9d21db4baefa988bd08209f38bd2927a
 
 PODFILE CHECKSUM: ee379229e6a0b60bc98226700ace2de002171547
 

--- a/Sources/Resources/PrivacyInfo.xcprivacy
+++ b/Sources/Resources/PrivacyInfo.xcprivacy
@@ -56,9 +56,5 @@
 			</array>
 		</dict>
 	</array>
-	<key>NSPrivacyTrackingDomains</key>
-	<array>
-		<string>rudderstack.com/</string>
-	</array>
 </dict>
 </plist>


### PR DESCRIPTION
# Description

- We've decided to remove the tracking domain URL from the Privacy Manifest file in iOS-v2. This change aims to resolve the error that occurs when a request to our tracking domain gets blocked after the user denies tracking permission.
