### PR TITLE
chore(release): pulling release/2.5.1-beta into master-v2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+## [2.5.0](https://github.com/rudderlabs/rudder-sdk-ios/compare/v2.5.0-beta...v2.5.0) (2024-04-24)
+
+
+### Bug Fixes
+
+* remove tracking domain url from Privacy Manifest file in v2 ([#514](https://github.com/rudderlabs/rudder-sdk-ios/issues/514)) ([533e8e1](https://github.com/rudderlabs/rudder-sdk-ios/commit/533e8e1114e646df83a1eab100c9bd24088b04d2))
+
 ## [2.5.0-beta](https://github.com/rudderlabs/rudder-sdk-ios/compare/v2.4.4-beta...v2.5.0-beta) (2024-04-08)
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
-## [2.5.0](https://github.com/rudderlabs/rudder-sdk-ios/compare/v2.5.0-beta...v2.5.0) (2024-04-24)
+## [2.5.1-beta](https://github.com/rudderlabs/rudder-sdk-ios/compare/v2.5.0-beta...v2.5.1-beta) (2024-04-24)
 
 
 ### Bug Fixes

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -1,5 +1,5 @@
 PODS:
-  - Rudder (2.4.3)
+  - Rudder (2.5.0-beta)
 
 DEPENDENCIES:
   - Rudder (from `.`)
@@ -9,7 +9,7 @@ EXTERNAL SOURCES:
     :path: "."
 
 SPEC CHECKSUMS:
-  Rudder: 831e9e84722969781103845b287bdbe7b0c9f833
+  Rudder: 2ff2aa3e9d21db4baefa988bd08209f38bd2927a
 
 PODFILE CHECKSUM: ee379229e6a0b60bc98226700ace2de002171547
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 <p align="center">
   <a href="https://cocoapods.org/pods/Rudder">
-    <img src="https://img.shields.io/static/v1?label=pod&message=v2.5.0-beta&color=blue&style=flat">
+    <img src="https://img.shields.io/static/v1?label=pod&message=v2.5.0&color=blue&style=flat">
     </a>
 </p>
 
@@ -47,7 +47,7 @@ The iOS SDK is available through [**CocoaPods**](https://cocoapods.org), [**Cart
 To install the SDK, simply add the following line to your Podfile:
 
 ```xcode
-pod 'Rudder', '2.5.0-beta'
+pod 'Rudder', '2.5.0'
 ```
 
 ### Carthage
@@ -55,7 +55,7 @@ pod 'Rudder', '2.5.0-beta'
 For Carthage support, add the following line to your `Cartfile`:
 
 ```xcode
-github "rudderlabs/rudder-sdk-ios" "v2.5.0-beta"
+github "rudderlabs/rudder-sdk-ios" "v2.5.0"
 ```
 
 > Remember to include the following code where you want to refer to or use the RudderStack SDK classes, as shown:
@@ -86,7 +86,7 @@ You can also add the RudderStack SDK using the Swift Package Mangaer in one of t
 ![Adding a package](https://user-images.githubusercontent.com/59817155/140903027-286a1d64-f5d5-4041-9827-47b6cef76a46.png)
 
 2. Enter the package repository (`git@github.com:rudderlabs/rudder-sdk-ios.git`) in the search bar.
-3. In **Dependency Rule**, select **Up to Next Major Version**, and enter `2.5.0-beta` as the value, as shown:
+3. In **Dependency Rule**, select **Up to Next Major Version**, and enter `2.5.0` as the value, as shown:
 
 ![Setting the dependency](https://user-images.githubusercontent.com/59817155/145574696-8c849749-13e0-40d5-aacb-3fccb5c8e67d.png)
 
@@ -113,7 +113,7 @@ let package = Package(
     ],
     dependencies: [
         // Dependencies declare other packages that this package depends on.
-        .package(url: "git@github.com:rudderlabs/rudder-sdk-ios.git", from: "2.5.0-beta")
+        .package(url: "git@github.com:rudderlabs/rudder-sdk-ios.git", from: "2.5.0")
     ],
     targets: [
         // Targets are the basic building blocks of a package. A target can define a module or a test suite.

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 <p align="center">
   <a href="https://cocoapods.org/pods/Rudder">
-    <img src="https://img.shields.io/static/v1?label=pod&message=v2.5.0&color=blue&style=flat">
+    <img src="https://img.shields.io/static/v1?label=pod&message=v2.5.1-beta&color=blue&style=flat">
     </a>
 </p>
 
@@ -47,7 +47,7 @@ The iOS SDK is available through [**CocoaPods**](https://cocoapods.org), [**Cart
 To install the SDK, simply add the following line to your Podfile:
 
 ```xcode
-pod 'Rudder', '2.5.0'
+pod 'Rudder', '2.5.1-beta'
 ```
 
 ### Carthage
@@ -55,7 +55,7 @@ pod 'Rudder', '2.5.0'
 For Carthage support, add the following line to your `Cartfile`:
 
 ```xcode
-github "rudderlabs/rudder-sdk-ios" "v2.5.0"
+github "rudderlabs/rudder-sdk-ios" "v2.5.1-beta"
 ```
 
 > Remember to include the following code where you want to refer to or use the RudderStack SDK classes, as shown:
@@ -86,7 +86,7 @@ You can also add the RudderStack SDK using the Swift Package Mangaer in one of t
 ![Adding a package](https://user-images.githubusercontent.com/59817155/140903027-286a1d64-f5d5-4041-9827-47b6cef76a46.png)
 
 2. Enter the package repository (`git@github.com:rudderlabs/rudder-sdk-ios.git`) in the search bar.
-3. In **Dependency Rule**, select **Up to Next Major Version**, and enter `2.5.0` as the value, as shown:
+3. In **Dependency Rule**, select **Up to Next Major Version**, and enter `2.5.1-beta` as the value, as shown:
 
 ![Setting the dependency](https://user-images.githubusercontent.com/59817155/145574696-8c849749-13e0-40d5-aacb-3fccb5c8e67d.png)
 
@@ -113,7 +113,7 @@ let package = Package(
     ],
     dependencies: [
         // Dependencies declare other packages that this package depends on.
-        .package(url: "git@github.com:rudderlabs/rudder-sdk-ios.git", from: "2.5.0")
+        .package(url: "git@github.com:rudderlabs/rudder-sdk-ios.git", from: "2.5.1-beta")
     ],
     targets: [
         // Targets are the basic building blocks of a package. A target can define a module or a test suite.

--- a/Sources/Classes/Common/Constants/RSVersion.swift
+++ b/Sources/Classes/Common/Constants/RSVersion.swift
@@ -9,4 +9,4 @@
 import Foundation
 
 // don't edit this line
-let RSVersion = "2.5.0-beta"
+let RSVersion = "2.5.0"

--- a/Sources/Classes/Common/Constants/RSVersion.swift
+++ b/Sources/Classes/Common/Constants/RSVersion.swift
@@ -9,4 +9,4 @@
 import Foundation
 
 // don't edit this line
-let RSVersion = "2.5.0"
+let RSVersion = "2.5.1-beta"

--- a/Sources/Resources/PrivacyInfo.xcprivacy
+++ b/Sources/Resources/PrivacyInfo.xcprivacy
@@ -56,9 +56,5 @@
 			</array>
 		</dict>
 	</array>
-	<key>NSPrivacyTrackingDomains</key>
-	<array>
-		<string>rudderstack.com/</string>
-	</array>
 </dict>
 </plist>

--- a/package.json
+++ b/package.json
@@ -1,4 +1,4 @@
 {
-    "version": "2.5.0",
+    "version": "2.5.1-beta",
     "description": "Rudder is a platform for collecting, storing and routing customer event data to dozens of tools"
 }

--- a/package.json
+++ b/package.json
@@ -1,4 +1,4 @@
 {
-    "version": "2.5.0-beta",
+    "version": "2.5.0",
     "description": "Rudder is a platform for collecting, storing and routing customer event data to dozens of tools"
 }

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -6,7 +6,7 @@ sonar.qualitygate.wait=false
 sonar.projectKey=rudderlabs_rudder-sdk-ios-v2
 sonar.organization=rudderlabs
 sonar.projectName=RudderStack iOS SDK(v2)
-sonar.projectVersion=2.5.0
+sonar.projectVersion=2.5.1-beta
 
 # Meta-data for the project
 sonar.links.scm=https://github.com/rudderlabs/rudder-sdk-ios

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -6,7 +6,7 @@ sonar.qualitygate.wait=false
 sonar.projectKey=rudderlabs_rudder-sdk-ios-v2
 sonar.organization=rudderlabs
 sonar.projectName=RudderStack iOS SDK(v2)
-sonar.projectVersion=2.5.0-beta
+sonar.projectVersion=2.5.0
 
 # Meta-data for the project
 sonar.links.scm=https://github.com/rudderlabs/rudder-sdk-ios


### PR DESCRIPTION
# Description

   Unreleased (2024-04-24)<br> * fix: remove tracking domain url from Privacy Manifest file in v2 ( 514) ([533e8e1](https://github.com/rudderlabs/rudder-sdk-ios/commit/533e8e1)), closes [ 514](https://github.com/rudderlabs/rudder-sdk-ios/issues/514)
