### PR TITLE
docs: update cla link

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -40,4 +40,4 @@ For any questions, concerns, or queries, you can start by asking a question on o
 <!----variables---->
 
 [issue]: https://github.com/rudderlabs/rudder-sdk-ios/issues/new
-[CLA]: https://rudderlabs.wufoo.com/forms/rudderlabs-contributor-license-agreement
+[CLA]: https://forms.gle/845JRGVZaC6kPZy68


### PR DESCRIPTION
We are going to use the new CLA (Google Form link) instead of the old Wufoo link to improve organisation and reduce management/collaboration hassles