### PR TITLE
ci: change the latest platform to macos-latest-large

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,7 +19,7 @@ jobs:
   build:
     name: 'Tests & Coverage'
     needs: cancel_previous
-    runs-on: macOS-latest
+    runs-on: macos-latest-large
     env:
       BUILD_WRAPPER_OUT_DIR: build_wrapper_output_directory # Directory where build-wrapper output will be placed
     steps:


### PR DESCRIPTION
# Description

- Change from `macos-latest` to `macos-latest-large` only for `Tests & Coverage` GitHub Action. This is to fix the sonar cloud installation issue occurring in https://github.com/rudderlabs/rudder-sdk-ios/pull/520 and https://github.com/rudderlabs/rudder-sdk-ios/pull/518.
