### PR TITLE
feat: implement exponential retry mechanism for handling network errors

### DIFF
--- a/Podfile.lock
+++ b/Podfile.lock
@@ -3,7 +3,7 @@ PODS:
     - RSCrashReporter (= 1.0.1)
     - RudderKit (= 1.4.0)
   - RSCrashReporter (1.0.1)
-  - Rudder (1.26.3):
+  - Rudder (1.27.0):
     - MetricsReporter (= 1.2.1)
   - RudderKit (1.4.0)
   - SQLCipher (4.5.4):
@@ -33,7 +33,7 @@ EXTERNAL SOURCES:
 SPEC CHECKSUMS:
   MetricsReporter: 99596ee5003c69949ed2f50acc34aee83c42f843
   RSCrashReporter: 6b8376ac729b0289ebe0908553e5f56d8171f313
-  Rudder: 23456f79749849870e18c45bd250d6e2229a7147
+  Rudder: 3cfcd9e6c5359cd6d49f411101ed9b894e3b64bd
   RudderKit: d9d6997696e1642b753d8bdf94e57af643a68f03
   SQLCipher: 905b145f65f349f26da9e60a19901ad24adcd381
 

--- a/Rudder.xcodeproj/project.pbxproj
+++ b/Rudder.xcodeproj/project.pbxproj
@@ -10,6 +10,12 @@
 		06CABC332630C6B00097BEFF /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 06CABC322630C6B00097BEFF /* Foundation.framework */; };
 		06CABC352630C6D30097BEFF /* UIKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 06CABC2E2630C6660097BEFF /* UIKit.framework */; };
 		2FA4A3E2DF0696E8D68B640A /* Pods_Rudder_watchOS.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 9F631D98DB26309EFE5E0A24 /* Pods_Rudder_watchOS.framework */; };
+		535778972C4F8E0000E8CE9B /* RSExponentialBackOff.m in Sources */ = {isa = PBXBuildFile; fileRef = 535778962C4F8E0000E8CE9B /* RSExponentialBackOff.m */; };
+		535778982C4F8E0000E8CE9B /* RSExponentialBackOff.h in Headers */ = {isa = PBXBuildFile; fileRef = 535778952C4F8E0000E8CE9B /* RSExponentialBackOff.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		535778992C4F8E0000E8CE9B /* RSExponentialBackOff.h in Headers */ = {isa = PBXBuildFile; fileRef = 535778952C4F8E0000E8CE9B /* RSExponentialBackOff.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		5357789A2C4F8E0000E8CE9B /* RSExponentialBackOff.m in Sources */ = {isa = PBXBuildFile; fileRef = 535778962C4F8E0000E8CE9B /* RSExponentialBackOff.m */; };
+		5357789B2C4F8E0000E8CE9B /* RSExponentialBackOff.h in Headers */ = {isa = PBXBuildFile; fileRef = 535778952C4F8E0000E8CE9B /* RSExponentialBackOff.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		5357789C2C4F8E0000E8CE9B /* RSExponentialBackOff.m in Sources */ = {isa = PBXBuildFile; fileRef = 535778962C4F8E0000E8CE9B /* RSExponentialBackOff.m */; };
 		5C11F10C96D80DF73DBED732 /* Pods_Rudder_iOS.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 447958A767B9B6F9BB3AC36A /* Pods_Rudder_iOS.framework */; };
 		60DF93A1FA405B16F4D273AB /* Pods_RudderTests_iOS.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 3F00C6B89DB926A1271D979A /* Pods_RudderTests_iOS.framework */; };
 		7275AF62B3887AFD09CF49CF /* Pods_RudderTests_watchOS.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = E5E0F163A9A54245F87BB53E /* Pods_RudderTests_watchOS.framework */; };
@@ -762,6 +768,8 @@
 		3C44A9E8F4B06BD7D1881CC6 /* Pods-RudderTests-watchOS.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-RudderTests-watchOS.debug.xcconfig"; path = "Target Support Files/Pods-RudderTests-watchOS/Pods-RudderTests-watchOS.debug.xcconfig"; sourceTree = "<group>"; };
 		3F00C6B89DB926A1271D979A /* Pods_RudderTests_iOS.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_RudderTests_iOS.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		447958A767B9B6F9BB3AC36A /* Pods_Rudder_iOS.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_Rudder_iOS.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		535778952C4F8E0000E8CE9B /* RSExponentialBackOff.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = RSExponentialBackOff.h; sourceTree = "<group>"; };
+		535778962C4F8E0000E8CE9B /* RSExponentialBackOff.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = RSExponentialBackOff.m; sourceTree = "<group>"; };
 		767A0EEE9A76F43CF631573B /* Pods-Rudder-watchOS.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Rudder-watchOS.debug.xcconfig"; path = "Target Support Files/Pods-Rudder-watchOS/Pods-Rudder-watchOS.debug.xcconfig"; sourceTree = "<group>"; };
 		83C9949585CD3C274CCE6A27 /* Pods-Rudder-iOS.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Rudder-iOS.release.xcconfig"; path = "Target Support Files/Pods-Rudder-iOS/Pods-Rudder-iOS.release.xcconfig"; sourceTree = "<group>"; };
 		9B4BB7D91351507AD413A9B4 /* Pods-Rudder-tvOS.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Rudder-tvOS.release.xcconfig"; path = "Target Support Files/Pods-Rudder-tvOS/Pods-Rudder-tvOS.release.xcconfig"; sourceTree = "<group>"; };
@@ -1198,6 +1206,7 @@
 				F6B4B53529C8237D00344864 /* RSBackGroundModeManager.m */,
 				ED7DFD8F298C091800ED5A8E /* RSClient.m */,
 				F6B4B53929C8237D00344864 /* RSCloudModeManager.m */,
+				535778962C4F8E0000E8CE9B /* RSExponentialBackOff.m */,
 				ED7DFD89298C091800ED5A8E /* RSConfig.m */,
 				ED7DFDCE298C091800ED5A8E /* RSConfigBuilder.m */,
 				ED8DB01D298E206900907EC4 /* RSConsentFilterHandler.m */,
@@ -1261,6 +1270,7 @@
 				F6B4B51E29C8236100344864 /* RSBackGroundModeManager.h */,
 				ED7DFDB9298C091800ED5A8E /* RSClient.h */,
 				F6B4B51D29C8236100344864 /* RSCloudModeManager.h */,
+				535778952C4F8E0000E8CE9B /* RSExponentialBackOff.h */,
 				ED7DFDB4298C091800ED5A8E /* RSConfig.h */,
 				ED7DFDA5298C091800ED5A8E /* RSConfigBuilder.h */,
 				ED7DFDAD298C091800ED5A8E /* RSConsentFilter.h */,
@@ -1555,6 +1565,7 @@
 				ED7DFE70298C091800ED5A8E /* RSServerDestination.h in Headers */,
 				ED7DFED9298C091800ED5A8E /* RSProductClickedEvent.h in Headers */,
 				ED7DFE82298C091800ED5A8E /* RSECommerceCartBuilder.h in Headers */,
+				535778982C4F8E0000E8CE9B /* RSExponentialBackOff.h in Headers */,
 				ED99908E2A6926E000031B06 /* RSMetricsReporter.h in Headers */,
 				ED7DFE58298C091800ED5A8E /* RSPreferenceManager.h in Headers */,
 				ED7DFEB7298C091800ED5A8E /* RSPaymentInfoEnteredEvent.h in Headers */,
@@ -1673,6 +1684,7 @@
 				ED998E682A69003600031B06 /* RSECommerceCartBuilder.h in Headers */,
 				ED99908F2A6926E000031B06 /* RSMetricsReporter.h in Headers */,
 				ED998E692A69003600031B06 /* RSPreferenceManager.h in Headers */,
+				535778992C4F8E0000E8CE9B /* RSExponentialBackOff.h in Headers */,
 				ED998E6A2A69003600031B06 /* RSPaymentInfoEnteredEvent.h in Headers */,
 				ED998E6B2A69003600031B06 /* RSCartSharedEvent.h in Headers */,
 				ED998E6C2A69003600031B06 /* RSECommerceEvents.h in Headers */,
@@ -1791,6 +1803,7 @@
 				ED998F382A69024E00031B06 /* RSECommerceCartBuilder.h in Headers */,
 				ED9990902A6926E000031B06 /* RSMetricsReporter.h in Headers */,
 				ED998F392A69024E00031B06 /* RSPreferenceManager.h in Headers */,
+				5357789B2C4F8E0000E8CE9B /* RSExponentialBackOff.h in Headers */,
 				ED998F3A2A69024E00031B06 /* RSPaymentInfoEnteredEvent.h in Headers */,
 				ED998F3B2A69024E00031B06 /* RSCartSharedEvent.h in Headers */,
 				ED998F3C2A69024E00031B06 /* RSECommerceEvents.h in Headers */,
@@ -2378,6 +2391,7 @@
 				ED7DFE8F298C091800ED5A8E /* RSECommerceSortBuilder.m in Sources */,
 				ED7DFE3F298C091800ED5A8E /* RSServerDestination.m in Sources */,
 				ED7DFEB6298C091800ED5A8E /* RSOrderRefundedEvent.m in Sources */,
+				535778972C4F8E0000E8CE9B /* RSExponentialBackOff.m in Sources */,
 				F64116022B68EC4B0015CB42 /* RSDefaultsPersistence.m in Sources */,
 				ED7DFEC2298C091800ED5A8E /* RSCouponEnteredEvent.m in Sources */,
 				ED7DFE3E298C091800ED5A8E /* RSApp.m in Sources */,
@@ -2488,6 +2502,7 @@
 				ED998EEF2A69003600031B06 /* WKInterfaceController+RSScreen.m in Sources */,
 				ED998EF02A69003600031B06 /* RSECommerceSortBuilder.m in Sources */,
 				ED998EF12A69003600031B06 /* RSServerDestination.m in Sources */,
+				5357789A2C4F8E0000E8CE9B /* RSExponentialBackOff.m in Sources */,
 				F64116032B68EC4B0015CB42 /* RSDefaultsPersistence.m in Sources */,
 				ED998EF22A69003600031B06 /* RSOrderRefundedEvent.m in Sources */,
 				ED998EF32A69003600031B06 /* RSCouponEnteredEvent.m in Sources */,
@@ -2598,6 +2613,7 @@
 				ED998FBF2A69024E00031B06 /* WKInterfaceController+RSScreen.m in Sources */,
 				ED998FC02A69024E00031B06 /* RSECommerceSortBuilder.m in Sources */,
 				ED998FC12A69024E00031B06 /* RSServerDestination.m in Sources */,
+				5357789C2C4F8E0000E8CE9B /* RSExponentialBackOff.m in Sources */,
 				F64116042B68EC4B0015CB42 /* RSDefaultsPersistence.m in Sources */,
 				ED998FC22A69024E00031B06 /* RSOrderRefundedEvent.m in Sources */,
 				ED998FC32A69024E00031B06 /* RSCouponEnteredEvent.m in Sources */,

--- a/Sources/Classes/Headers/Public/RSConstants.h
+++ b/Sources/Classes/Headers/Public/RSConstants.h
@@ -64,6 +64,9 @@ extern int const RSATTRestricted;
 extern int const RSATTDenied;
 extern int const RSATTAuthorize;
 
+extern int const RSExponentialBackOff_InitialDelay;
+extern int const RSExponentialBackOff_MinimumDelay;
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/Sources/Classes/Headers/Public/RSExponentialBackOff.h
+++ b/Sources/Classes/Headers/Public/RSExponentialBackOff.h
@@ -1,0 +1,40 @@
+//
+//  RSExponentialBackOff.h
+//  Rudder
+//
+//  Created by Satheesh Kannan on 23/07/24.
+//
+
+#import <Foundation/Foundation.h>
+
+NS_ASSUME_NONNULL_BEGIN
+/*!
+ @brief This class implements an exponential backoff strategy with jitter for handling retries.
+ 
+ @discussion It allows for configurable maximum delay and includes methods to calculate the next delay with jitter and reset the backoff attempts. When the calculated delay reaches or exceeds the maximum delay limit, the backoff resets and starts again from beginning.
+ */
+@interface RSExponentialBackOff : NSObject
+
+/**
+ * Init function that accepts the maximum delay value in seconds.
+ *
+ * @param seconds Value for maximum delay property
+ * @return A new instance for this class
+ */
+- (instancetype)initWithMaximumDelay:(int)seconds;
+
+/**
+ * Function will calculate the next delay value in seconds
+ *
+ * @return Next delay value in seconds
+ */
+- (NSInteger)nextDelay;
+
+/**
+ * Function will resets the attempts.
+ */
+- (void)reset;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/Sources/Classes/Headers/Public/RSExponentialBackOff.h
+++ b/Sources/Classes/Headers/Public/RSExponentialBackOff.h
@@ -28,7 +28,7 @@ NS_ASSUME_NONNULL_BEGIN
  *
  * @return Next delay value in seconds
  */
-- (NSInteger)nextDelay;
+- (int)nextDelay;
 
 /**
  * Function will resets the attempts.

--- a/Sources/Classes/Headers/Public/RSUtils.h
+++ b/Sources/Classes/Headers/Public/RSUtils.h
@@ -50,7 +50,7 @@ NS_ASSUME_NONNULL_BEGIN
 + (BOOL) isValidIDFA:(NSString*)idfa;
 + (BOOL) isSpecialFloatingNumber:(NSNumber *)number;
 +(NSArray*) extractParamFromURL: (NSURL*) deepLinkURL;
-+ (NSString *)delayToString:(int) delay;
++ (NSString *)secondsToString:(int) delay;
 extern unsigned int MAX_EVENT_SIZE;
 extern unsigned int MAX_BATCH_SIZE;
 

--- a/Sources/Classes/Headers/Public/RSUtils.h
+++ b/Sources/Classes/Headers/Public/RSUtils.h
@@ -50,6 +50,7 @@ NS_ASSUME_NONNULL_BEGIN
 + (BOOL) isValidIDFA:(NSString*)idfa;
 + (BOOL) isSpecialFloatingNumber:(NSNumber *)number;
 +(NSArray*) extractParamFromURL: (NSURL*) deepLinkURL;
++ (NSString *)delayToString:(int) delay;
 extern unsigned int MAX_EVENT_SIZE;
 extern unsigned int MAX_BATCH_SIZE;
 

--- a/Sources/Classes/RSCloudModeManager.m
+++ b/Sources/Classes/RSCloudModeManager.m
@@ -74,8 +74,9 @@
                 [RSMetricsReporter report:SDKMETRICS_CM_ATTEMPT_ABORT forMetricType:COUNT withProperties:@{SDKMETRICS_TYPE: SDKMETRICS_DATA_PLANE_URL_INVALID} andValue:1];
                 break;
             } else if (response.state == NETWORK_ERROR) {
-                int delay = (int)[self->backOff nextDelay];
-                [RSLogger logDebug:[[NSString alloc] initWithFormat:@"RSCloudModeManager: CloudModeProcessor: Retrying in: %@", [self delayToString:delay]]];
+                int delay = [self->backOff nextDelay];
+                NSString *timeString = [RSUtils delayToString:delay];
+                [RSLogger logDebug:[[NSString alloc] initWithFormat:@"RSCloudModeManager: CloudModeProcessor: Retrying in: %@", timeString]];
                 [RSMetricsReporter report:SDKMETRICS_CM_ATTEMPT_RETRY forMetricType:COUNT withProperties:nil andValue:1];
                 sleep(delay);
             } else { // To handle the status code RESOURCE_NOT_FOUND(404) & BAD_REQUEST(400)

--- a/Sources/Classes/RSCloudModeManager.m
+++ b/Sources/Classes/RSCloudModeManager.m
@@ -75,8 +75,7 @@
                 break;
             } else if (response.state == NETWORK_ERROR) {
                 int delay = [self->backOff nextDelay];
-                NSString *timeString = [RSUtils delayToString:delay];
-                [RSLogger logDebug:[[NSString alloc] initWithFormat:@"RSCloudModeManager: CloudModeProcessor: Retrying in: %@", timeString]];
+                [RSLogger logDebug:[[NSString alloc] initWithFormat:@"RSCloudModeManager: CloudModeProcessor: Retrying in: %@", [RSUtils secondsToString:delay]]];
                 [RSMetricsReporter report:SDKMETRICS_CM_ATTEMPT_RETRY forMetricType:COUNT withProperties:nil andValue:1];
                 sleep(delay);
             } else { // To handle the status code RESOURCE_NOT_FOUND(404) & BAD_REQUEST(400)

--- a/Sources/Classes/RSCloudModeManager.m
+++ b/Sources/Classes/RSCloudModeManager.m
@@ -13,6 +13,7 @@
 #import "RSNetworkResponse.h"
 #import "RSMetricsReporter.h"
 #import "RSExponentialBackOff.h"
+#import "RSConstants.h"
 
 @implementation RSCloudModeManager {
     RSExponentialBackOff *backOff;
@@ -26,7 +27,7 @@
         self->config = config;
         self->lock = lock;
         self->cloud_mode_processor_queue = dispatch_queue_create("com.rudder.RSCloudModeManager", NULL);
-        self->backOff = [[RSExponentialBackOff alloc] initWithMaximumDelay:5 * 60];
+        self->backOff = [[RSExponentialBackOff alloc] initWithMaximumDelay:RSExponentialBackOff_MinimumDelay];
     }
     return self;
 }
@@ -57,6 +58,7 @@
                         [strongSelf->dbPersistentManager updateEventsWithIds:dbMessage.messageIds withStatus:CLOUD_MODE_PROCESSING_DONE];
                         [strongSelf->dbPersistentManager clearProcessedEventsFromDB];
                         sleepCount = 0;
+                        [self->backOff reset];
                     }
                 }
             }

--- a/Sources/Classes/RSCloudModeManager.m
+++ b/Sources/Classes/RSCloudModeManager.m
@@ -12,9 +12,11 @@
 #import "RSNetworkManager.h"
 #import "RSNetworkResponse.h"
 #import "RSMetricsReporter.h"
+#import "RSExponentialBackOff.h"
 
-@implementation RSCloudModeManager
-
+@implementation RSCloudModeManager {
+    RSExponentialBackOff *backOff;
+}
 
 - (instancetype)initWithConfig:(RSConfig *) config andDBPersistentManager:(RSDBPersistentManager *) dbPersistentManager andNetworkManager:(RSNetworkManager *) networkManager andLock: (NSLock *) lock {
     self = [super init];
@@ -24,6 +26,7 @@
         self->config = config;
         self->lock = lock;
         self->cloud_mode_processor_queue = dispatch_queue_create("com.rudder.RSCloudModeManager", NULL);
+        self->backOff = [[RSExponentialBackOff alloc] initWithMaximumDelay:5 * 60];
     }
     return self;
 }
@@ -60,8 +63,9 @@
             [strongSelf->lock unlock];
             [RSLogger logDebug:[[NSString alloc] initWithFormat:@"RSCloudModeManager: CloudModeProcessor: cloudModeSleepCount: %d", sleepCount]];
             sleepCount += 1;
+            
             if(response == nil) {
-                usleep(1000000);
+                sleep(1);
             } else if (response.state == WRONG_WRITE_KEY) {
                 [RSLogger logError:@"RSCloudModeManager: CloudModeProcessor: Wrong WriteKey. Aborting the Cloud Mode Processor"];
                 break;
@@ -69,11 +73,14 @@
                 [RSLogger logError:@"RSCloudModeManager: CloudModeProcessor: Invalid Data Plane URL. Aborting the Cloud Mode Processor"];
                 [RSMetricsReporter report:SDKMETRICS_CM_ATTEMPT_ABORT forMetricType:COUNT withProperties:@{SDKMETRICS_TYPE: SDKMETRICS_DATA_PLANE_URL_INVALID} andValue:1];
                 break;
-            }
-            else if (response.state == NETWORK_ERROR) {
-                [RSLogger logDebug:[[NSString alloc] initWithFormat:@"RSCloudModeManager: CloudModeProcessor: Retrying in: %d s", abs(sleepCount - strongSelf->config.sleepTimeout)]];
+            } else if (response.state == NETWORK_ERROR) {
+                int delay = (int)[self->backOff nextDelay];
+                [RSLogger logDebug:[[NSString alloc] initWithFormat:@"RSCloudModeManager: CloudModeProcessor: Retrying in: %@", [self delayToString:delay]]];
                 [RSMetricsReporter report:SDKMETRICS_CM_ATTEMPT_RETRY forMetricType:COUNT withProperties:nil andValue:1];
-                usleep(abs(sleepCount - strongSelf->config.sleepTimeout) * 1000000);
+                sleep(delay);
+            } else { // To handle the status code RESOURCE_NOT_FOUND(404) & BAD_REQUEST(400)
+                [RSLogger logDebug:[[NSString alloc] initWithFormat:@"RSCloudModeManager: CloudModeProcessor: Retrying in: 1s"]];
+                sleep(1);
             }
         }
     });

--- a/Sources/Classes/RSConstants.m
+++ b/Sources/Classes/RSConstants.m
@@ -39,4 +39,7 @@ int const RSATTRestricted = 1;
 int const RSATTDenied = 2;
 int const RSATTAuthorize = 3;
 
+int const RSExponentialBackOff_MinimumDelay = 5 * 60; //in seconds..
+int const RSExponentialBackOff_InitialDelay = 3; //in seconds..
+
 @end

--- a/Sources/Classes/RSExponentialBackOff.m
+++ b/Sources/Classes/RSExponentialBackOff.m
@@ -6,7 +6,7 @@
 //
 
 #import "RSExponentialBackOff.h"
-
+#import "RSConstants.h"
 #pragma mark - RSExponentialBackOff
 
 @interface RSExponentialBackOff()
@@ -25,7 +25,7 @@
     if (self) {
         _maximumDelay = seconds;
         _attempt = 0;
-        _initialDelay = 3;
+        _initialDelay = RSExponentialBackOff_InitialDelay;
     }
     
     return self;
@@ -35,16 +35,16 @@
  * Function will calculate the next delay value in seconds
  */
 - (int)nextDelay {
-    int delay = (int)pow(2, _attempt);
+    int delay = _initialDelay * (int)pow(2, _attempt);
     _attempt = _attempt + 1;
     
     int jitter = arc4random_uniform((delay + 1));
     
-    int exponentialDelay = _initialDelay + delay + jitter;
+    int exponentialDelay = delay + jitter;
     exponentialDelay = MIN(exponentialDelay, _maximumDelay);
     
-    if (exponentialDelay >= _maximumDelay) {
-        _attempt = 0;
+    if (exponentialDelay == _maximumDelay) {
+        [self reset];
     }
     
     return exponentialDelay;

--- a/Sources/Classes/RSExponentialBackOff.m
+++ b/Sources/Classes/RSExponentialBackOff.m
@@ -10,9 +10,9 @@
 #pragma mark - RSExponentialBackOff
 
 @interface RSExponentialBackOff()
-@property (nonatomic, assign) NSInteger attempt;
-@property (nonatomic, assign) NSInteger maximumDelay;
-@property (nonatomic, assign) NSInteger initialDelay;
+@property (nonatomic, assign) int attempt;
+@property (nonatomic, assign) int maximumDelay;
+@property (nonatomic, assign) int initialDelay;
 @end
 
 @implementation RSExponentialBackOff
@@ -35,7 +35,7 @@
  * Function will calculate the next delay value in seconds
  */
 - (int)nextDelay {
-    int delay = pow(2, _attempt++);
+    int delay = (int)pow(2, _attempt++);
     int jitter = arc4random_uniform((delay + 1));
     
     int exponentialDelay = _initialDelay + delay + jitter;

--- a/Sources/Classes/RSExponentialBackOff.m
+++ b/Sources/Classes/RSExponentialBackOff.m
@@ -1,0 +1,60 @@
+//
+//  RSExponentialBackOff.m
+//  Rudder
+//
+//  Created by Satheesh Kannan on 23/07/24.
+//
+
+#import "RSExponentialBackOff.h"
+
+#pragma mark - RSExponentialBackOff
+
+@interface RSExponentialBackOff()
+@property (nonatomic, assign) NSInteger attempt;
+@property (nonatomic, assign) NSInteger maximumDelay;
+@property (nonatomic, assign) NSInteger initialDelay;
+@end
+
+@implementation RSExponentialBackOff
+
+/**
+ * Init function that accepts the maximum delay value in seconds.
+ */
+- (instancetype)initWithMaximumDelay:(int) seconds {
+    self = [super init];
+    if (self) {
+        _maximumDelay = seconds;
+        _attempt = 0;
+        _initialDelay = 3;
+    }
+    
+    return self;
+}
+
+/**
+ * Function will calculate the next delay value in seconds
+ */
+- (NSInteger)nextDelay {
+    NSInteger delay = (NSInteger)pow(2, _attempt++);
+    NSInteger jitter = arc4random_uniform((uint32_t)(delay + 1));
+    
+    NSInteger exponentialDelay = _initialDelay + delay + jitter;
+    exponentialDelay = MIN(exponentialDelay, _maximumDelay);
+    
+    if (exponentialDelay >= _maximumDelay) {
+        _attempt = 0;
+    }
+    
+    return exponentialDelay;
+}
+
+/**
+ * Function will resets the attempts.
+ */
+- (void)reset {
+    _attempt = 0;
+}
+
+@end
+
+

--- a/Sources/Classes/RSExponentialBackOff.m
+++ b/Sources/Classes/RSExponentialBackOff.m
@@ -34,11 +34,11 @@
 /**
  * Function will calculate the next delay value in seconds
  */
-- (NSInteger)nextDelay {
-    NSInteger delay = (NSInteger)pow(2, _attempt++);
-    NSInteger jitter = arc4random_uniform((uint32_t)(delay + 1));
+- (int)nextDelay {
+    int delay = pow(2, _attempt++);
+    int jitter = arc4random_uniform((delay + 1));
     
-    NSInteger exponentialDelay = _initialDelay + delay + jitter;
+    int exponentialDelay = _initialDelay + delay + jitter;
     exponentialDelay = MIN(exponentialDelay, _maximumDelay);
     
     if (exponentialDelay >= _maximumDelay) {

--- a/Sources/Classes/RSExponentialBackOff.m
+++ b/Sources/Classes/RSExponentialBackOff.m
@@ -35,7 +35,9 @@
  * Function will calculate the next delay value in seconds
  */
 - (int)nextDelay {
-    int delay = (int)pow(2, _attempt++);
+    int delay = (int)pow(2, _attempt);
+    _attempt = _attempt + 1;
+    
     int jitter = arc4random_uniform((delay + 1));
     
     int exponentialDelay = _initialDelay + delay + jitter;

--- a/Sources/Classes/RSUtils.m
+++ b/Sources/Classes/RSUtils.m
@@ -283,7 +283,9 @@
         NSURLComponents *components = [NSURLComponents componentsWithURL:deepLinkURL resolvingAgainstBaseURL:NO];
         
         // Get the query items
-        queryItems = components.queryItems;
+        if (components.queryItems) {
+            queryItems = components.queryItems;
+        }
       
     }
     return queryItems;

--- a/Sources/Classes/RSUtils.m
+++ b/Sources/Classes/RSUtils.m
@@ -283,10 +283,9 @@
         NSURLComponents *components = [NSURLComponents componentsWithURL:deepLinkURL resolvingAgainstBaseURL:NO];
         
         // Get the query items
-        if (components.queryItems) {
+        if (components.queryItems != nil) {
             queryItems = components.queryItems;
         }
-      
     }
     return queryItems;
 }

--- a/Sources/Classes/RSUtils.m
+++ b/Sources/Classes/RSUtils.m
@@ -277,7 +277,7 @@
 }
 
 +(NSArray*) extractParamFromURL: (NSURL*) deepLinkURL{
-    NSMutableArray<NSURLQueryItem *> *queryItems;
+    NSArray<NSURLQueryItem *> *queryItems;
     if (deepLinkURL) {
         // Create NSURLComponents object
         NSURLComponents *components = [NSURLComponents componentsWithURL:deepLinkURL resolvingAgainstBaseURL:NO];
@@ -290,7 +290,7 @@
 unsigned int MAX_EVENT_SIZE = 32 * 1024; // 32 KB
 unsigned int MAX_BATCH_SIZE = 500 * 1024; // 500 KB
 
-+ (NSString *)delayToString:(int) delay {
++ (NSString *)secondsToString:(int) delay {
     int min = delay / 60;
     int sec = min > 0 ? (delay - (min * 60)) : delay;
     NSString *finalString = min > 0 ? [NSString stringWithFormat:@"%dm, %ds", min, sec] : [NSString stringWithFormat:@"%ds", sec];

--- a/Sources/Classes/RSUtils.m
+++ b/Sources/Classes/RSUtils.m
@@ -277,7 +277,7 @@
 }
 
 +(NSArray*) extractParamFromURL: (NSURL*) deepLinkURL{
-    NSArray<NSURLQueryItem *> *queryItems;
+    NSMutableArray<NSURLQueryItem *> *queryItems = [NSMutableArray array];
     if (deepLinkURL) {
         // Create NSURLComponents object
         NSURLComponents *components = [NSURLComponents componentsWithURL:deepLinkURL resolvingAgainstBaseURL:NO];
@@ -286,7 +286,7 @@
         queryItems = components.queryItems;
       
     }
-    return  queryItems;
+    return queryItems;
 }
 unsigned int MAX_EVENT_SIZE = 32 * 1024; // 32 KB
 unsigned int MAX_BATCH_SIZE = 500 * 1024; // 500 KB

--- a/Sources/Classes/RSUtils.m
+++ b/Sources/Classes/RSUtils.m
@@ -291,4 +291,12 @@
 unsigned int MAX_EVENT_SIZE = 32 * 1024; // 32 KB
 unsigned int MAX_BATCH_SIZE = 500 * 1024; // 500 KB
 
++ (NSString *)delayToString:(int) delay {
+    int min = delay / 60;
+    int sec = min > 0 ? (delay - (min * 60)) : delay;
+    NSString *finalString = min > 0 ? [NSString stringWithFormat:@"%d min, %d sec", min, sec] : [NSString stringWithFormat:@"%d sec", sec];
+    NSLog(@"SK--->>%@", finalString);
+    return finalString;
+}
+
 @end

--- a/Sources/Classes/RSUtils.m
+++ b/Sources/Classes/RSUtils.m
@@ -294,8 +294,7 @@ unsigned int MAX_BATCH_SIZE = 500 * 1024; // 500 KB
 + (NSString *)delayToString:(int) delay {
     int min = delay / 60;
     int sec = min > 0 ? (delay - (min * 60)) : delay;
-    NSString *finalString = min > 0 ? [NSString stringWithFormat:@"%d min, %d sec", min, sec] : [NSString stringWithFormat:@"%d sec", sec];
-    NSLog(@"SK--->>%@", finalString);
+    NSString *finalString = min > 0 ? [NSString stringWithFormat:@"%dm, %ds", min, sec] : [NSString stringWithFormat:@"%ds", sec];
     return finalString;
 }
 

--- a/Sources/Classes/RSUtils.m
+++ b/Sources/Classes/RSUtils.m
@@ -292,7 +292,7 @@ unsigned int MAX_BATCH_SIZE = 500 * 1024; // 500 KB
 
 + (NSString *)secondsToString:(int) delay {
     int min = delay / 60;
-    int sec = min > 0 ? (delay - (min * 60)) : delay;
+    int sec = delay % 60;
     NSString *finalString = min > 0 ? [NSString stringWithFormat:@"%dm, %ds", min, sec] : [NSString stringWithFormat:@"%ds", sec];
     return finalString;
 }

--- a/Sources/Classes/RSUtils.m
+++ b/Sources/Classes/RSUtils.m
@@ -277,17 +277,15 @@
 }
 
 +(NSArray*) extractParamFromURL: (NSURL*) deepLinkURL{
-    NSMutableArray<NSURLQueryItem *> *queryItems = [NSMutableArray array];
+    NSMutableArray<NSURLQueryItem *> *queryItems;
     if (deepLinkURL) {
         // Create NSURLComponents object
         NSURLComponents *components = [NSURLComponents componentsWithURL:deepLinkURL resolvingAgainstBaseURL:NO];
         
         // Get the query items
-        if (components.queryItems != nil) {
-            queryItems = components.queryItems;
-        }
+        queryItems = components.queryItems;
     }
-    return queryItems;
+    return queryItems != nil ? queryItems : [NSArray array];
 }
 unsigned int MAX_EVENT_SIZE = 32 * 1024; // 32 KB
 unsigned int MAX_BATCH_SIZE = 500 * 1024; // 500 KB


### PR DESCRIPTION
## Description

- This PR removes the existing retry mechanism for network errors and replaces it with an **exponential retry mechanism with jitter**. Now, retries will occur exponentially for every **4xx** and **5xx** status code (except 400 and 404). If the network is unavailable, retries will continue with a one-second delay.
- The maximum limit is 5 minutes; once this limit is reached, the retry process will start over from the beginning.
- Example sequence:
```
6s, 8s, 15s, 28s, 1m 35s, 2m 48s, 3m 49s, 5m 0s,
4s, 6s, 24s, 31s..
```

**NOTE**: No event is deleted in this process.