### PR TITLE
fix: set anonymousId in traits when second Identify event is made

### DIFF
--- a/Sources/Classes/RSContext.m
+++ b/Sources/Classes/RSContext.m
@@ -128,6 +128,7 @@ static dispatch_queue_t queue;
         if(existingId!=nil && userId!=nil && ![existingId isEqual:userId])
         {
             self->_traits = [[traits dict] mutableCopy];
+            self->_traits[@"anonymousId"] = [self->preferenceManager getAnonymousId];
             [self resetExternalIds];
             return;
         }


### PR DESCRIPTION
## Description

- This PR has the fix for missing `anonymousId` under `context.traits` section on second identify event with different `userId`.
