### PR TITLE
Update Package.swift

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -14,7 +14,7 @@ let package = Package(
         )
     ],
     dependencies: [
-        .package(name: "MetricsReporter", url: "https://github.com/rudderlabs/metrics-reporter-ios", from: "1.2.1"),
+        .package(name: "MetricsReporter", url: "https://github.com/rudderlabs/metrics-reporter-ios", exact: "1.2.1"),
     ],
     targets: [
         .target(


### PR DESCRIPTION
Point to a specific version of MetricsReporter to avoid issues with other breaking changes

Possible fix for https://github.com/rudderlabs/rudder-sdk-ios/issues/529
