### PR TITLE
fix: lock the metrics reporter dependency version in package.swift

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -14,7 +14,7 @@ let package = Package(
         )
     ],
     dependencies: [
-        .package(name: "MetricsReporter", url: "https://github.com/rudderlabs/metrics-reporter-ios", from: "1.2.1"),
+        .package(name: "MetricsReporter", url: "https://github.com/rudderlabs/metrics-reporter-ios", .exact("1.2.1")),
     ],
     targets: [
         .target(


### PR DESCRIPTION
# Description

< Replace with adequate description for this PR>
