### PR TITLE
ci: update beta github release action script

### DIFF
--- a/.github/workflows/deploy-beta-cocoapods.yml
+++ b/.github/workflows/deploy-beta-cocoapods.yml
@@ -7,7 +7,6 @@ jobs:
   deploy-cocoapods-beta:
     name: Beta deploy to Cocoapods
     runs-on: macOS-latest
-    if: startsWith(github.ref, 'refs/heads/beta-release/')
     steps:
       - name: Checkout source branch
         uses: actions/checkout@v4


### PR DESCRIPTION
# Description

In this PR, we removed the beta release prefix check in order to release the beta SDK.
We will revert this change after the beta release.
