### PR TITLE
chore: import exponential back off header in rudder.h

### DIFF
--- a/Sources/Classes/Headers/Public/Rudder.h
+++ b/Sources/Classes/Headers/Public/Rudder.h
@@ -55,6 +55,7 @@
 #import "RSEnums.h"
 #import "RSEventFilteringPlugin.h"
 #import "RSEventRepository.h"
+#import "RSExponentialBackOff.h"
 #import "RSFlushManager.h"
 #import "RSIntegration.h"
 #import "RSIntegrationFactory.h"


### PR DESCRIPTION
This file appears to be missing from the umbrella header, and is now giving warnings in my CI pipeline.

It looks to me like it was introduced in this pull request.
https://github.com/rudderlabs/rudder-sdk-ios/pull/525
