### PR TITLE
fix: set anonymousId as previousId in alias API if userId is not present

### DIFF
--- a/Podfile.lock
+++ b/Podfile.lock
@@ -3,7 +3,7 @@ PODS:
     - RSCrashReporter (= 1.0.1)
     - RudderKit (= 1.4.0)
   - RSCrashReporter (1.0.1)
-  - Rudder (1.29.1):
+  - Rudder (1.30.0):
     - MetricsReporter (= 2.0.0)
   - RudderKit (1.4.0)
   - SQLCipher (4.5.4):
@@ -33,10 +33,10 @@ EXTERNAL SOURCES:
 SPEC CHECKSUMS:
   MetricsReporter: 364b98791e868b10e9d512eb50af28d8c11e5cdb
   RSCrashReporter: 6b8376ac729b0289ebe0908553e5f56d8171f313
-  Rudder: 731095848aee39d27ff5d0e78233aa5ad8febb0b
+  Rudder: 408085701df64dd8258f47c4af0b6f8cff5ac581
   RudderKit: d9d6997696e1642b753d8bdf94e57af643a68f03
   SQLCipher: 905b145f65f349f26da9e60a19901ad24adcd381
 
 PODFILE CHECKSUM: b6937cee06e0633464427ff0d975d40e17419e9f
 
-COCOAPODS: 1.15.2
+COCOAPODS: 1.16.2

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -3,7 +3,7 @@ PODS:
     - RSCrashReporter (= 1.0.1)
     - RudderKit (= 1.4.0)
   - RSCrashReporter (1.0.1)
-  - Rudder (1.30.0):
+  - Rudder (1.29.1):
     - MetricsReporter (= 2.0.0)
   - RudderKit (1.4.0)
   - SQLCipher (4.5.4):
@@ -33,10 +33,10 @@ EXTERNAL SOURCES:
 SPEC CHECKSUMS:
   MetricsReporter: 364b98791e868b10e9d512eb50af28d8c11e5cdb
   RSCrashReporter: 6b8376ac729b0289ebe0908553e5f56d8171f313
-  Rudder: 408085701df64dd8258f47c4af0b6f8cff5ac581
+  Rudder: 731095848aee39d27ff5d0e78233aa5ad8febb0b
   RudderKit: d9d6997696e1642b753d8bdf94e57af643a68f03
   SQLCipher: 905b145f65f349f26da9e60a19901ad24adcd381
 
 PODFILE CHECKSUM: b6937cee06e0633464427ff0d975d40e17419e9f
 
-COCOAPODS: 1.16.2
+COCOAPODS: 1.15.2

--- a/Sources/Classes/RSClient.m
+++ b/Sources/Classes/RSClient.m
@@ -236,13 +236,7 @@ static NSString* _advertisingId = nil;
     RSContext *rc = [RSElementCache getContext];
     NSMutableDictionary<NSString*,NSObject*>* traits = [rc.traits mutableCopy];
     
-    NSObject *prevId = [traits objectForKey:@"userId"];
-    if(prevId == nil) {
-        prevId =[traits objectForKey:@"id"];
-    }
-    if (prevId == nil) {
-        prevId = self.anonymousId;
-    }
+    NSObject *prevId = [traits objectForKey:@"userId"] ?: [traits objectForKey:@"id"] ?: self.anonymousId;
     
     traits[@"id"] = newId;
     traits[@"userId"] = newId;

--- a/Sources/Classes/RSClient.m
+++ b/Sources/Classes/RSClient.m
@@ -240,6 +240,9 @@ static NSString* _advertisingId = nil;
     if(prevId == nil) {
         prevId =[traits objectForKey:@"id"];
     }
+    if (prevId == nil) {
+        prevId = self.anonymousId;
+    }
     
     traits[@"id"] = newId;
     traits[@"userId"] = newId;


### PR DESCRIPTION
# Description

- In the existing `alias` API, set `anonymousId` as `previousId`, if `userId` is not present. 
- This case will happen when an `alias` event is made before any `identify` event is made. In this case, `previousId` needs to be set as `anonymousId` but currently this field is not present. So we've added a fix to add the correct value.