### PR TITLE
feat: add alias api with previousId support

### DIFF
--- a/Podfile.lock
+++ b/Podfile.lock
@@ -3,7 +3,7 @@ PODS:
     - RSCrashReporter (= 1.0.1)
     - RudderKit (= 1.4.0)
   - RSCrashReporter (1.0.1)
-  - Rudder (1.29.1):
+  - Rudder (1.30.0):
     - MetricsReporter (= 2.0.0)
   - RudderKit (1.4.0)
   - SQLCipher (4.5.4):
@@ -33,10 +33,10 @@ EXTERNAL SOURCES:
 SPEC CHECKSUMS:
   MetricsReporter: 364b98791e868b10e9d512eb50af28d8c11e5cdb
   RSCrashReporter: 6b8376ac729b0289ebe0908553e5f56d8171f313
-  Rudder: 731095848aee39d27ff5d0e78233aa5ad8febb0b
+  Rudder: 408085701df64dd8258f47c4af0b6f8cff5ac581
   RudderKit: d9d6997696e1642b753d8bdf94e57af643a68f03
   SQLCipher: 905b145f65f349f26da9e60a19901ad24adcd381
 
 PODFILE CHECKSUM: b6937cee06e0633464427ff0d975d40e17419e9f
 
-COCOAPODS: 1.15.2
+COCOAPODS: 1.16.2

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -3,7 +3,7 @@ PODS:
     - RSCrashReporter (= 1.0.1)
     - RudderKit (= 1.4.0)
   - RSCrashReporter (1.0.1)
-  - Rudder (1.30.0):
+  - Rudder (1.29.1):
     - MetricsReporter (= 2.0.0)
   - RudderKit (1.4.0)
   - SQLCipher (4.5.4):
@@ -33,10 +33,10 @@ EXTERNAL SOURCES:
 SPEC CHECKSUMS:
   MetricsReporter: 364b98791e868b10e9d512eb50af28d8c11e5cdb
   RSCrashReporter: 6b8376ac729b0289ebe0908553e5f56d8171f313
-  Rudder: 408085701df64dd8258f47c4af0b6f8cff5ac581
+  Rudder: 731095848aee39d27ff5d0e78233aa5ad8febb0b
   RudderKit: d9d6997696e1642b753d8bdf94e57af643a68f03
   SQLCipher: 905b145f65f349f26da9e60a19901ad24adcd381
 
 PODFILE CHECKSUM: b6937cee06e0633464427ff0d975d40e17419e9f
 
-COCOAPODS: 1.16.2
+COCOAPODS: 1.15.2

--- a/Sources/Classes/Headers/Public/RSClient.h
+++ b/Sources/Classes/Headers/Public/RSClient.h
@@ -51,7 +51,7 @@ typedef void (^Callback)(NSObject *_Nullable);
 - (void) group:(NSString *)groupId traits:(NSDictionary<NSString*, id>*)traits;
 - (void) group:(NSString *)groupId;
 
-- (void) alias:(NSString *)newId options:(RSOption * _Nullable) options previousId:(NSString * _Nullable)previousId;
+- (void) alias:(NSString *)newId options previousId:(NSString * _Nullable)previousId options:(RSOption * _Nullable);
 - (void) alias:(NSString *)newId options:(RSOption * _Nullable) options;
 - (void) alias:(NSString *)newId;
 

--- a/Sources/Classes/Headers/Public/RSClient.h
+++ b/Sources/Classes/Headers/Public/RSClient.h
@@ -51,6 +51,7 @@ typedef void (^Callback)(NSObject *_Nullable);
 - (void) group:(NSString *)groupId traits:(NSDictionary<NSString*, id>*)traits;
 - (void) group:(NSString *)groupId;
 
+- (void) alias:(NSString *)newId options:(RSOption * _Nullable) options previousId:(NSString * _Nullable)previousId;
 - (void) alias:(NSString *)newId options:(RSOption * _Nullable) options;
 - (void) alias:(NSString *)newId;
 

--- a/Sources/Classes/Headers/Public/RSClient.h
+++ b/Sources/Classes/Headers/Public/RSClient.h
@@ -51,7 +51,7 @@ typedef void (^Callback)(NSObject *_Nullable);
 - (void) group:(NSString *)groupId traits:(NSDictionary<NSString*, id>*)traits;
 - (void) group:(NSString *)groupId;
 
-- (void) alias:(NSString *)newId options previousId:(NSString * _Nullable)previousId options:(RSOption * _Nullable);
+- (void) alias:(NSString *)newId previousId:(NSString * _Nullable)previousId options:(RSOption * _Nullable) options;
 - (void) alias:(NSString *)newId options:(RSOption * _Nullable) options;
 - (void) alias:(NSString *)newId;
 

--- a/Sources/Classes/RSClient.m
+++ b/Sources/Classes/RSClient.m
@@ -225,10 +225,14 @@ static NSString* _advertisingId = nil;
         [self reportDiscardedEvent];
         return;
     }
-    [self alias:newId options:nil];
+    [self alias:newId options:nil previousId:nil];
 }
 
 - (void) alias:(NSString *)newId options:(RSOption *) options {
+    [self alias:newId options:options previousId:nil];
+}
+
+- (void) alias:(NSString *)newId options:(RSOption *) options previousId:(NSString *)previousId {
     if ([RSClient getOptStatus]) {
         [self reportDiscardedEvent];
         return;
@@ -236,12 +240,17 @@ static NSString* _advertisingId = nil;
     RSContext *rc = [RSElementCache getContext];
     NSMutableDictionary<NSString*,NSObject*>* traits = [rc.traits mutableCopy];
     
-    NSObject *prevId = [traits objectForKey:@"userId"];
-    if(prevId == nil) {
-        prevId =[traits objectForKey:@"id"];
-    }
-    if (prevId == nil) {
-        prevId = self.anonymousId;
+    NSObject *prevId = nil;
+    if (previousId != nil) {
+        prevId = previousId;
+    } else {
+        prevId = [traits objectForKey:@"userId"];
+        if(prevId == nil) {
+            prevId =[traits objectForKey:@"id"];
+        }
+        if (prevId == nil) {
+            prevId = self.anonymousId;
+        }
     }
     
     traits[@"id"] = newId;

--- a/Sources/Classes/RSClient.m
+++ b/Sources/Classes/RSClient.m
@@ -240,6 +240,9 @@ static NSString* _advertisingId = nil;
     if(prevId == nil) {
         prevId =[traits objectForKey:@"id"];
     }
+    if (prevId == nil) {
+        prevId = self.anonymousId;
+    }
     
     traits[@"id"] = newId;
     traits[@"userId"] = newId;

--- a/Sources/Classes/RSClient.m
+++ b/Sources/Classes/RSClient.m
@@ -225,14 +225,14 @@ static NSString* _advertisingId = nil;
         [self reportDiscardedEvent];
         return;
     }
-    [self alias:newId options:nil previousId:nil];
+    [self alias:newId previousId:nil options:nil];
 }
 
 - (void) alias:(NSString *)newId options:(RSOption *) options {
-    [self alias:newId options:options previousId:nil];
+    [self alias:newId previousId:nil options:options];
 }
 
-- (void) alias:(NSString *)newId options:(RSOption *) options previousId:(NSString *)previousId {
+- (void) alias:(NSString *)newId previousId:(NSString *)previousId options:(RSOption *) options {
     if ([RSClient getOptStatus]) {
         [self reportDiscardedEvent];
         return;


### PR DESCRIPTION
# Description

- Added an `Alias` API with `previousId` support. Now, `previousId` can be passed and will be preferred over the existing `userId` or `anonymousId`.
- New Alias API:
```
- (void) alias:(NSString *)newId previousId:(NSString * _Nullable)previousId options:(RSOption * _Nullable) options;
```
- This is to bring it in parity with the JS SDK so that `previousId` can be explicitly passed if needed.

NOTE: The change is backwards compatible, as we are introducing a new Alias API which adds a new behaviour to the existing payload schema.

## How to test

Objective: We need to test, if `previousId` is passed then it should be used, else the existing behaviour should continue i.e., userId or anonymousId should be used.

- Make an `alias` event and explicitly pass `previousId` field -> It should be set as the `previousId`.
- Existing API: Make an Identify event, then `RESET` call and then an `alias` event (with previousId) -> `previousId` should be set as passed previousId.
- Existing API: Make an `alias` event with only `newId` -> `previousId` should be set as `anonymousId`.
- Existing API: Make an `alias` event with only `newId` and `options` -> `previousId` should be set as `anonymousId`.
- Existing API: Make an `identify` event and then an `alias` event (without previousId) -> `previousId` should be set as previous userId.
- Existing API: Make an Identify event, then `RESET` call and then an `alias` event (without previousId) -> `previousId` should be set as `anonymousId`.
