### PR TITLE
chore(release): pulling release/1.31.0 into master

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+## [1.31.0](https://github.com/rudderlabs/rudder-sdk-ios/compare/v1.30.0...v1.31.0) (2024-12-09)
+
+
+### Features
+
+* add alias api with previousId support ([#554](https://github.com/rudderlabs/rudder-sdk-ios/issues/554)) ([6c68a3d](https://github.com/rudderlabs/rudder-sdk-ios/commit/6c68a3da2760be92573d493216a7cbcc23493dc0))
+
+
+### Bug Fixes
+
+* set anonymousId as previousId in alias API if userId is not present ([#553](https://github.com/rudderlabs/rudder-sdk-ios/issues/553)) ([67c6715](https://github.com/rudderlabs/rudder-sdk-ios/commit/67c671561a57d8ee16253af51cbb3958e02b1fcc))
+
 ## [1.30.0](https://github.com/rudderlabs/rudder-sdk-ios/compare/v1.29.1...v1.30.0) (2024-11-11)
 
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 <p align="center">
   <a href="https://cocoapods.org/pods/Rudder">
-    <img src="https://img.shields.io/static/v1?label=pod&message=v1.30.0&color=blue&style=flat">
+    <img src="https://img.shields.io/static/v1?label=pod&message=v1.31.0&color=blue&style=flat">
     </a>
 </p>
 
@@ -39,7 +39,7 @@ The iOS SDK is available through [**CocoaPods**](https://cocoapods.org), [**Cart
 To install the SDK, simply add the following line to your Podfile:
 
 ```xcode
-pod 'Rudder', '1.30.0'
+pod 'Rudder', '1.31.0'
 ```
 
 ### Carthage
@@ -47,7 +47,7 @@ pod 'Rudder', '1.30.0'
 For Carthage support, add the following line to your `Cartfile`:
 
 ```xcode
-github "rudderlabs/rudder-sdk-ios" "v1.30.0"
+github "rudderlabs/rudder-sdk-ios" "v1.31.0"
 ```
 
 > Remember to include the following code in all `.m` and `.h` files where you want to refer to or use the RudderStack SDK classes, as shown:
@@ -71,7 +71,7 @@ You can also add the RudderStack iOS SDK via Swift Package Mangaer, via one of t
 
 * Enter the package repository (`git@github.com:rudderlabs/rudder-sdk-ios.git`) in the search bar.
 
-* In **Dependency Rule**, select **Up to Next Major Version** and enter `1.30.0` as the value, as shown:
+* In **Dependency Rule**, select **Up to Next Major Version** and enter `1.31.0` as the value, as shown:
 
 ![Setting dependency](https://user-images.githubusercontent.com/59817155/145574696-8c849749-13e0-40d5-aacb-3fccb5c8e67d.png)
 
@@ -99,7 +99,7 @@ let package = Package(
     ],
     dependencies: [
         // Dependencies declare other packages that this package depends on.
-        .package(url: "git@github.com:rudderlabs/rudder-sdk-ios.git", from: "1.30.0")
+        .package(url: "git@github.com:rudderlabs/rudder-sdk-ios.git", from: "1.31.0")
     ],
     targets: [
         // Targets are the basic building blocks of a package. A target can define a module or a test suite.

--- a/Sources/Classes/Headers/Public/RSClient.h
+++ b/Sources/Classes/Headers/Public/RSClient.h
@@ -51,6 +51,7 @@ typedef void (^Callback)(NSObject *_Nullable);
 - (void) group:(NSString *)groupId traits:(NSDictionary<NSString*, id>*)traits;
 - (void) group:(NSString *)groupId;
 
+- (void) alias:(NSString *)newId previousId:(NSString * _Nullable)previousId options:(RSOption * _Nullable) options;
 - (void) alias:(NSString *)newId options:(RSOption * _Nullable) options;
 - (void) alias:(NSString *)newId;
 

--- a/Sources/Classes/Headers/Public/Rudder.h
+++ b/Sources/Classes/Headers/Public/Rudder.h
@@ -55,6 +55,7 @@
 #import "RSEnums.h"
 #import "RSEventFilteringPlugin.h"
 #import "RSEventRepository.h"
+#import "RSExponentialBackOff.h"
 #import "RSFlushManager.h"
 #import "RSIntegration.h"
 #import "RSIntegrationFactory.h"

--- a/Sources/Classes/Headers/RSVersion.h
+++ b/Sources/Classes/Headers/RSVersion.h
@@ -8,6 +8,6 @@
 #ifndef RSVersion_h
 #define RSVersion_h
 
-NSString *const SDK_VERSION = @"1.30.0";
+NSString *const SDK_VERSION = @"1.31.0";
 
 #endif /* RSVersion_h */

--- a/Sources/Classes/RSClient.m
+++ b/Sources/Classes/RSClient.m
@@ -236,10 +236,7 @@ static NSString* _advertisingId = nil;
     RSContext *rc = [RSElementCache getContext];
     NSMutableDictionary<NSString*,NSObject*>* traits = [rc.traits mutableCopy];
     
-    NSObject *prevId = [traits objectForKey:@"userId"];
-    if(prevId == nil) {
-        prevId =[traits objectForKey:@"id"];
-    }
+    NSObject *prevId = [traits objectForKey:@"userId"] ?: [traits objectForKey:@"id"] ?: self.anonymousId;
     
     traits[@"id"] = newId;
     traits[@"userId"] = newId;

--- a/Sources/Classes/RSClient.m
+++ b/Sources/Classes/RSClient.m
@@ -225,10 +225,14 @@ static NSString* _advertisingId = nil;
         [self reportDiscardedEvent];
         return;
     }
-    [self alias:newId options:nil];
+    [self alias:newId previousId:nil options:nil];
 }
 
 - (void) alias:(NSString *)newId options:(RSOption *) options {
+    [self alias:newId previousId:nil options:options];
+}
+
+- (void) alias:(NSString *)newId previousId:(NSString *)previousId options:(RSOption *) options {
     if ([RSClient getOptStatus]) {
         [self reportDiscardedEvent];
         return;
@@ -236,7 +240,7 @@ static NSString* _advertisingId = nil;
     RSContext *rc = [RSElementCache getContext];
     NSMutableDictionary<NSString*,NSObject*>* traits = [rc.traits mutableCopy];
     
-    NSObject *prevId = [traits objectForKey:@"userId"] ?: [traits objectForKey:@"id"] ?: self.anonymousId;
+    NSObject *prevId = previousId ?: [traits objectForKey:@"userId"] ?: [traits objectForKey:@"id"] ?: self.anonymousId;
     
     traits[@"id"] = newId;
     traits[@"userId"] = newId;

--- a/package.json
+++ b/package.json
@@ -1,4 +1,4 @@
 {
-    "version": "1.30.0",
+    "version": "1.31.0",
     "description": "Rudder is a platform for collecting, storing and routing customer event data to dozens of tools"
 }

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -6,7 +6,7 @@ sonar.qualitygate.wait=false
 sonar.projectKey=rudderlabs_rudder-sdk-ios
 sonar.organization=rudderlabs
 sonar.projectName=RudderStack iOS SDK
-sonar.projectVersion=1.30.0
+sonar.projectVersion=1.31.0
 
 # C/C++/Objective-C related details
 # sonar.cfamily.compile-commands=compile_commands.json


### PR DESCRIPTION
:crown: *An automated PR*

   Unreleased (2024-12-09)<br> * feat: add alias api with previousId support ( 554) ([6c68a3d](https://github.com/rudderlabs/rudder-sdk-ios/commit/6c68a3d)), closes [ 554](https://github.com/rudderlabs/rudder-sdk-ios/issues/554)<br> *  chore: import exponential back off header in rudder.h ([b3b4a01](https://github.com/rudderlabs/rudder-sdk-ios/commit/b3b4a01))<br> * fix: set anonymousId as previousId in alias API if userId is not present ( 553) ([67c6715](https://github.com/rudderlabs/rudder-sdk-ios/commit/67c6715)), closes [ 553](https://github.com/rudderlabs/rudder-sdk-ios/issues/553)