### PR TITLE
Fix potential crash in screen name handling

### DIFF
--- a/Sources/Classes/Helpers/Platforms/iOS/RSiOSScreenViewEvents.swift
+++ b/Sources/Classes/Helpers/Platforms/iOS/RSiOSScreenViewEvents.swift
@@ -43,8 +43,8 @@ extension UIViewController {
     @objc
     func rsViewDidAppear(_ animated: Bool) {
         var name = String(describing: type(of: self))
-        if name.starts(with: "UIHostingController") {
-            name.removeFirst("UIHostingController".count + 1) // Remove `UIHostingController<`
+        if name.starts(with: "UIHostingController<") {
+            name.removeFirst("UIHostingController<".count) // Remove `UIHostingController<`
             if name.hasSuffix(">") { name.removeLast(1) } // Remove last `>`
         }
 


### PR DESCRIPTION
# Description

If `name` happens to be "UIHostingController", current implementation will crash with an:
Swift/RangeReplaceableCollection.swift:599: Fatal error: Can't remove more items from a collection than it has.
The `starts(with:...)` check should be done with the exact string we're going to remove.
