### PR TITLE
ci: use shas for external github actions

### DIFF
--- a/.github/workflows/build-and-quality-checks.yml
+++ b/.github/workflows/build-and-quality-checks.yml
@@ -9,7 +9,7 @@ jobs:
     name: 'Cancel previous Code Quality Checks'
     runs-on: ubuntu-latest
     steps:
-      - uses: styfle/cancel-workflow-action@0.12.1
+      - uses: styfle/cancel-workflow-action@85880fa0301c86cca9da44039ee3bb12d3bedbfa #v0.12.1
         with:
           workflow_id: ${{ github.event.workflow.id }}
           

--- a/.github/workflows/draft-new-release-v2.yml
+++ b/.github/workflows/draft-new-release-v2.yml
@@ -80,7 +80,7 @@ jobs:
           git push
 
       - name: Create pull request into master
-        uses: repo-sync/pull-request@v2
+        uses: repo-sync/pull-request@7e79a9f5dc3ad0ce53138f01df2fad14a04831c5 #v2
         with:
           source_branch: ${{ steps.create-release.outputs.branch_name }}
           destination_branch: "master-v2"

--- a/.github/workflows/draft-new-release.yml
+++ b/.github/workflows/draft-new-release.yml
@@ -80,7 +80,7 @@ jobs:
           git push --follow-tags
 
       - name: Create pull request into master
-        uses: repo-sync/pull-request@v2
+        uses: repo-sync/pull-request@7e79a9f5dc3ad0ce53138f01df2fad14a04831c5 #v2
         with:
           source_branch: ${{ steps.create-release.outputs.branch_name }}
           destination_branch: "master"

--- a/.github/workflows/notion-pr-sync.yml
+++ b/.github/workflows/notion-pr-sync.yml
@@ -48,7 +48,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Sync Github PRs to Notion
-        uses: sivashanmukh/github-notion-pr-sync@1.0.0
+        uses: sivashanmukh/github-notion-pr-sync@3967330238449a8550b06f6e1d6b83e1af569876 #v1.0.0
         with:
           notionKey: ${{ secrets.NOTION_BOT_KEY }}
           notionDatabaseId: ${{ secrets.NOTION_PR_DB_ID }}

--- a/.github/workflows/publish-new-release-v2.yml
+++ b/.github/workflows/publish-new-release-v2.yml
@@ -53,7 +53,7 @@ jobs:
           DEBUG=conventional-github-releaser npx conventional-github-releaser -p angular --config github-release.config.js
 
       - name: Create pull request into develop
-        uses: repo-sync/pull-request@v2
+        uses: repo-sync/pull-request@7e79a9f5dc3ad0ce53138f01df2fad14a04831c5 #v2
         with:
           source_branch: 'master-v2'
           destination_branch: 'develop-v2'

--- a/.github/workflows/publish-new-release.yml
+++ b/.github/workflows/publish-new-release.yml
@@ -48,7 +48,7 @@ jobs:
           DEBUG=conventional-github-releaser npx conventional-github-releaser -p angular --config github-release.config.js
 
       - name: Create pull request into develop
-        uses: repo-sync/pull-request@v2
+        uses: repo-sync/pull-request@7e79a9f5dc3ad0ce53138f01df2fad14a04831c5 #v2
         with:
           source_branch: "master"
           destination_branch: "develop"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,7 +12,7 @@ jobs:
     name: 'Cancel previous Tests & Coverage'
     runs-on: ubuntu-latest
     steps:
-      - uses: styfle/cancel-workflow-action@0.12.1
+      - uses: repo-sync/pull-request@7e79a9f5dc3ad0ce53138f01df2fad14a04831c5 # v2
         with:
           workflow_id: ${{ github.event.workflow.id }}
           


### PR DESCRIPTION
# Description

- Updated `styfle/cancel-workflow-action@0.12.1` with `styfle/cancel-workflow-action@85880fa0301c86cca9da44039ee3bb12d3bedbfa #v0.12.1`.
- Updated `repo-sync/pull-request@v2` with `repo-sync/pull-request@7e79a9f5dc3ad0ce53138f01df2fad14a04831c5 # v2`.
- Updated `sivashanmukh/github-notion-pr-sync@1.0.0` with `sivashanmukh/github-notion-pr-sync@3967330238449a8550b06f6e1d6b83e1af569876 #v1.0.0`.