### PR TITLE
fix: custom factory issue

### DIFF
--- a/Sources/Classes/Headers/Public/RSDeviceModeManager.h
+++ b/Sources/Classes/Headers/Public/RSDeviceModeManager.h
@@ -40,5 +40,6 @@
 - (void) reset;
 - (void) flush;
 - (void) handleCaseWhenNoDeviceModeFactoryIsPresent;
+- (void) handleCaseWhenOnlyCustomFactoryIsPresent;
 - (void) addCallBackForIntegration:(NSString*)integrationName withCallback:(Callback)callback;
 @end

--- a/Sources/Classes/RSDeviceModeManager.m
+++ b/Sources/Classes/RSDeviceModeManager.m
@@ -40,7 +40,7 @@
     // this might fail if serverConfig is nil, need to handle
     [RSLogger logDebug:@"RSDeviceModeManager: DeviceModeProcessor: Initializing the Custom Factories"];
     [self initiateCustomFactories];
-    [self isDeviceModeFactoriesNotPresent];
+    [self checkAndSetDeviceModeFactoriesNotPresent];
     [self replayMessageQueue];
     self->areFactoriesInitialized = YES;
     // initaiting the transformation processor only if there are any factories passed have a device mode transformation connected to them on control plane
@@ -84,7 +84,7 @@
 }
 
 - (void) handleCaseWhenNoDeviceModeFactoryIsPresent {
-    [self isDeviceModeFactoriesNotPresent];
+    [self checkAndSetDeviceModeFactoriesNotPresent];
     [self replayMessageQueue];
 }
 
@@ -156,7 +156,7 @@
     }
 }
 
-- (void) isDeviceModeFactoriesNotPresent {
+- (void) checkAndSetDeviceModeFactoriesNotPresent {
     if ([self->integrationOperationMap count] == 0) {
         self->isDeviceModeFactoriesNotPresent = YES;
     }

--- a/Sources/Classes/RSDeviceModeManager.m
+++ b/Sources/Classes/RSDeviceModeManager.m
@@ -40,6 +40,7 @@
     // this might fail if serverConfig is nil, need to handle
     [RSLogger logDebug:@"RSDeviceModeManager: DeviceModeProcessor: Initializing the Custom Factories"];
     [self initiateCustomFactories];
+    [self isDeviceModeFactoriesNotPresent];
     [self replayMessageQueue];
     self->areFactoriesInitialized = YES;
     // initaiting the transformation processor only if there are any factories passed have a device mode transformation connected to them on control plane
@@ -76,20 +77,24 @@
     }
 }
 
+- (void) handleCaseWhenOnlyCustomFactoryIsPresent {
+    [self initiateCustomFactories];
+    self->areFactoriesInitialized = YES;
+    [self replayMessageQueue];
+}
+
 - (void) handleCaseWhenNoDeviceModeFactoryIsPresent {
-    self->isDeviceModeFactoriesNotPresent = YES;
+    [self isDeviceModeFactoriesNotPresent];
     [self replayMessageQueue];
 }
 
 - (void) initiateFactories : (NSArray*) destinations {
     if (![self areFactoriesPassedInConfig]) {
         [RSLogger logInfo:@"RSDeviceModeManager: initiateFactories: No native SDK is found in the config"];
-        self->isDeviceModeFactoriesNotPresent = YES;
         return;
     }
     if (destinations.count == 0) {
         [RSLogger logInfo:@"RSDeviceModeManager: initiateFactories: No native SDK factory is found in the server config"];
-        self->isDeviceModeFactoriesNotPresent = YES;
         return;
     }
     RSClient* client = [RSClient sharedInstance];
@@ -148,6 +153,12 @@
         @catch(NSException* e){
             [RSLogger logError:[[NSString alloc] initWithFormat:@"RSDeviceModeManager: initiateCustomFactories: Exception while initiating custom Factory %@ due to %@", factory.key,e.reason]];
         }
+    }
+}
+
+- (void) isDeviceModeFactoriesNotPresent {
+    if ([self->integrationOperationMap count] == 0) {
+        self->isDeviceModeFactoriesNotPresent = YES;
     }
 }
 
@@ -345,6 +356,9 @@
 
 - (BOOL) isEvent:(RSMessage *) message allowedForDestination: (NSString *) destinationName {
     BOOL isDestinationEnabledInMessage = [self isDestination:destinationName enabledInMessage:message];
+    if (self->eventFilteringPlugin == nil) {
+        return isDestinationEnabledInMessage;
+    }
     BOOL isEventAllowedByDestination = [self->eventFilteringPlugin isEventAllowed:message byDestination:destinationName];
     return isDestinationEnabledInMessage && isEventAllowedByDestination;
 }

--- a/Sources/Classes/RSEventRepository.m
+++ b/Sources/Classes/RSEventRepository.m
@@ -199,7 +199,7 @@ static RSEventRepository* _instance;
                         if(consentedDestinations != nil && consentedDestinations.count > 0 ) {
                             [self->deviceModeManager startDeviceModeProcessor:consentedDestinations withConfigManager:strongSelf->configManager];
                         }
-                    } else if((self->config != nil && self->config.customFactories != nil && self->config.customFactories.count != 0)) {
+                    } else if(self->config != nil && self->config.customFactories != nil && self->config.customFactories.count != 0) {
                         [self->deviceModeManager handleCaseWhenOnlyCustomFactoryIsPresent];
                         [RSLogger logDebug:@"EventRepository: Only Custom Factory is present"];
                     } else {

--- a/Sources/Classes/RSEventRepository.m
+++ b/Sources/Classes/RSEventRepository.m
@@ -199,6 +199,9 @@ static RSEventRepository* _instance;
                         if(consentedDestinations != nil && consentedDestinations.count > 0 ) {
                             [self->deviceModeManager startDeviceModeProcessor:consentedDestinations withConfigManager:strongSelf->configManager];
                         }
+                    } else if((self->config != nil && self->config.customFactories != nil && self->config.customFactories.count != 0)) {
+                        [self->deviceModeManager handleCaseWhenOnlyCustomFactoryIsPresent];
+                        [RSLogger logDebug:@"EventRepository: Only Custom Factory is present"];
                     } else {
                         [self->deviceModeManager handleCaseWhenNoDeviceModeFactoryIsPresent];
                         [RSLogger logDebug:@"EventRepository: no device mode present"];


### PR DESCRIPTION
# Description

- Fixed the issue where events were not being sent to the custom factory. This issue happens in all the scenarios except when device mode factory and custom factory both are added, and also, some destinations are configured at the dashboard.
- Let me explain the issue in simple words: Our SDK was sending events to the Custom Factory only when it's used along with any one standard integrations we support, e.g., Amplitude integration. For all other scenarios, events were not being forwarded to the custom factory.

## Implementation details

- Although there are multiple ways to fix this issue, I've chosen the one that seems to be an efficient fix and requires minimal code change and testing effort.
- I've added a new method in `DeviceModeManager`: `handleCaseWhenOnlyCustomFactoryIsPresent()`. This method only handles the case where only custom factories are added, and also, no integration is configured at the dashboard.
- Also, I've fixed one edge case scenario where if custom factory is added and integration is configured at the dashboard, but still, due to event filtering logic, events were not being sent to the custom factory. This same issue was present in Android-v1, as well. Over there, it causes a crash, but in iOS, it just drops the event silently.

## Test cases

- To test this fix, there are multiple scenarios: 
    - Attach custom factory and source shouldn't have any integration connected to it.
    - Attach custom factory and source should have any integration connected to it.
    - Attach custom factory and device mode integration and try with different combinations of source config.
- Please refer to the internal QA page for full scenarios.
