### PR TITLE
chore(docs): remove V2 SDK documentation and add deprecation warning

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@
 > - **Repository**: https://github.com/rudderlabs/rudder-sdk-swift
 > - **Documentation**: https://www.rudderstack.com/docs/sources/event-streams/sdks/swift-sdk/
 >
-> This v2 SDK remains available for legacy support only. No new features will be added. 
+> This version of the SDK will be sunset soon. So, migrate to the newer SDK as soon as possible.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@
   <b>
     <a href="https://rudderstack.com">Website</a>
     ·
-    <a href="https://www.rudderstack.com/docs/stream-sources/rudderstack-sdk-integration-guides/rudderstack-ios-sdk/ios-v2/">Documentation</a>
+    <a href="https://www.rudderstack.com/docs/sources/event-streams/sdks/">Documentation</a>
     ·
     <a href="https://rudderstack.com/join-rudderstack-slack-community">Community Slack</a>
   </b>
@@ -24,11 +24,23 @@
 
 ---
 
+> ⚠️ **DEPRECATION WARNING**
+>
+> **This SDK is deprecated and no longer actively maintained.**
+>
+> Please use the newer **Swift-based iOS SDK** instead:
+> - **Repository**: https://github.com/rudderlabs/rudder-sdk-swift
+> - **Documentation**: https://www.rudderstack.com/docs/sources/event-streams/sdks/swift-sdk/
+>
+> This v2 SDK remains available for legacy support only. No new features will be added. 
+
+---
+
 # RudderStack iOS SDK
 
 The RudderStack iOS SDK lets you track event data from your **iOS**, **tvOS**, **watchOS** and **macOS** applications. After integrating the SDK, you will also be able to send these events to your to your specified destinations via RudderStack.
 
-| For more information on the RudderStack iOS SDK, refer to the [**SDK documentation**](https://www.rudderstack.com/docs/stream-sources/rudderstack-sdk-integration-guides/rudderstack-ios-sdk/ios-v2/). |
+| For more information on the RudderStack iOS SDK, refer to the [**SDK documentation**](https://www.rudderstack.com/docs/sources/event-streams/sdks/). |
 | :--|
 
 ## What's new in v2

--- a/README.md
+++ b/README.md
@@ -16,8 +16,6 @@
   <b>
     <a href="https://rudderstack.com">Website</a>
     ·
-    <a href="https://www.rudderstack.com/docs/sources/event-streams/sdks/">Documentation</a>
-    ·
     <a href="https://rudderstack.com/join-rudderstack-slack-community">Community Slack</a>
   </b>
 </p>
@@ -29,8 +27,8 @@
 > **This SDK is deprecated and no longer actively maintained.**
 >
 > Please use the newer **Swift-based iOS SDK** instead:
-> - **Repository**: https://github.com/rudderlabs/rudder-sdk-swift
-> - **Documentation**: https://www.rudderstack.com/docs/sources/event-streams/sdks/swift-sdk/
+> - **Repository**: <https://github.com/rudderlabs/rudder-sdk-swift>
+> - **Documentation**: <https://www.rudderstack.com/docs/sources/event-streams/sdks/swift-sdk/>
 >
 > This version of the SDK will be sunset soon. So, migrate to the newer SDK as soon as possible.
 
@@ -39,9 +37,6 @@
 # RudderStack iOS SDK
 
 The RudderStack iOS SDK lets you track event data from your **iOS**, **tvOS**, **watchOS** and **macOS** applications. After integrating the SDK, you will also be able to send these events to your to your specified destinations via RudderStack.
-
-| For more information on the RudderStack iOS SDK, refer to the [**SDK documentation**](https://www.rudderstack.com/docs/sources/event-streams/sdks/). |
-| :--|
 
 ## What's new in v2
 


### PR DESCRIPTION
# Description

This PR removes the V2 SDK documentation from the README and adds a deprecation warning message.
