### PR TITLE
chore(release): pulling release/1.31.2 into master

### DIFF
--- a/.github/workflows/build-and-quality-checks-v2.yml
+++ b/.github/workflows/build-and-quality-checks-v2.yml
@@ -14,7 +14,7 @@ jobs:
     
     steps:
       - name: Harden the runner (Audit all outbound calls)
-        uses: step-security/harden-runner@f4a75cfd619ee5ce8d5b864b0d183aff3c69b55a # v2.13.1
+        uses: step-security/harden-runner@95d9a5deda9de15063e7595e9719c11c38c90ae2 # v2.13.2
         with:
           egress-policy: audit
 

--- a/.github/workflows/build-and-quality-checks-v2.yml
+++ b/.github/workflows/build-and-quality-checks-v2.yml
@@ -4,6 +4,9 @@ on:
     branches: ['master-v2', 'develop-v2']
     types: ['opened', 'reopened', 'synchronize']
 
+permissions:
+  contents: read
+
 jobs:
   build:
     name: Code Quality Checks(v2)
@@ -16,7 +19,7 @@ jobs:
           egress-policy: audit
 
       - name: Checkout source branch
-        uses: actions/checkout@v4
+        uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4.3.0
       
       - name: Install xcpretty
         run: gem install xcpretty

--- a/.github/workflows/build-and-quality-checks-v2.yml
+++ b/.github/workflows/build-and-quality-checks-v2.yml
@@ -10,6 +10,11 @@ jobs:
     runs-on: macOS-latest
     
     steps:
+      - name: Harden the runner (Audit all outbound calls)
+        uses: step-security/harden-runner@f4a75cfd619ee5ce8d5b864b0d183aff3c69b55a # v2.13.1
+        with:
+          egress-policy: audit
+
       - name: Checkout source branch
         uses: actions/checkout@v4
       

--- a/.github/workflows/build-and-quality-checks.yml
+++ b/.github/workflows/build-and-quality-checks.yml
@@ -4,8 +4,13 @@ on:
     branches: ['master', 'develop']
     types: ['opened', 'reopened', 'synchronize']
 
+permissions:
+  contents: read
+
 jobs:
   cancel_previous:
+    permissions:
+      actions: write  # for styfle/cancel-workflow-action to cancel/stop running workflows
     name: 'Cancel previous Code Quality Checks'
     runs-on: ubuntu-latest
     steps:
@@ -30,7 +35,7 @@ jobs:
           egress-policy: audit
 
       - name: Checkout source branch
-        uses: actions/checkout@v4
+        uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4.3.0
       
       - name: Install xcpretty
         run: gem install xcpretty

--- a/.github/workflows/build-and-quality-checks.yml
+++ b/.github/workflows/build-and-quality-checks.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Harden the runner (Audit all outbound calls)
-        uses: step-security/harden-runner@f4a75cfd619ee5ce8d5b864b0d183aff3c69b55a # v2.13.1
+        uses: step-security/harden-runner@95d9a5deda9de15063e7595e9719c11c38c90ae2 # v2.13.2
         with:
           egress-policy: audit
 
@@ -30,7 +30,7 @@ jobs:
     
     steps:
       - name: Harden the runner (Audit all outbound calls)
-        uses: step-security/harden-runner@f4a75cfd619ee5ce8d5b864b0d183aff3c69b55a # v2.13.1
+        uses: step-security/harden-runner@95d9a5deda9de15063e7595e9719c11c38c90ae2 # v2.13.2
         with:
           egress-policy: audit
 

--- a/.github/workflows/build-and-quality-checks.yml
+++ b/.github/workflows/build-and-quality-checks.yml
@@ -9,6 +9,11 @@ jobs:
     name: 'Cancel previous Code Quality Checks'
     runs-on: ubuntu-latest
     steps:
+      - name: Harden the runner (Audit all outbound calls)
+        uses: step-security/harden-runner@f4a75cfd619ee5ce8d5b864b0d183aff3c69b55a # v2.13.1
+        with:
+          egress-policy: audit
+
       - uses: styfle/cancel-workflow-action@85880fa0301c86cca9da44039ee3bb12d3bedbfa #v0.12.1
         with:
           workflow_id: ${{ github.event.workflow.id }}
@@ -19,6 +24,11 @@ jobs:
     runs-on: macOS-latest
     
     steps:
+      - name: Harden the runner (Audit all outbound calls)
+        uses: step-security/harden-runner@f4a75cfd619ee5ce8d5b864b0d183aff3c69b55a # v2.13.1
+        with:
+          egress-policy: audit
+
       - name: Checkout source branch
         uses: actions/checkout@v4
       

--- a/.github/workflows/check-pr-title.yml
+++ b/.github/workflows/check-pr-title.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Harden the runner (Audit all outbound calls)
-        uses: step-security/harden-runner@f4a75cfd619ee5ce8d5b864b0d183aff3c69b55a # v2.13.1
+        uses: step-security/harden-runner@95d9a5deda9de15063e7595e9719c11c38c90ae2 # v2.13.2
         with:
           egress-policy: audit
 

--- a/.github/workflows/check-pr-title.yml
+++ b/.github/workflows/check-pr-title.yml
@@ -15,7 +15,7 @@ jobs:
           egress-policy: audit
 
       - name: Checkout source branch
-        uses: actions/checkout@v4
+        uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4.3.0
 
       - name: Check PR title
-        uses: rudderlabs/github-action-check-pr-title@v1.0.11
+        uses: rudderlabs/github-action-check-pr-title@0a83071336f7d6417249629f67a64530fcecda2e # v1.0.11

--- a/.github/workflows/check-pr-title.yml
+++ b/.github/workflows/check-pr-title.yml
@@ -9,6 +9,11 @@ jobs:
     name: Check PR title
     runs-on: ubuntu-latest
     steps:
+      - name: Harden the runner (Audit all outbound calls)
+        uses: step-security/harden-runner@f4a75cfd619ee5ce8d5b864b0d183aff3c69b55a # v2.13.1
+        with:
+          egress-policy: audit
+
       - name: Checkout source branch
         uses: actions/checkout@v4
 

--- a/.github/workflows/create-hotfix-branch-v2.yml
+++ b/.github/workflows/create-hotfix-branch-v2.yml
@@ -19,7 +19,7 @@ jobs:
           egress-policy: audit
 
       - name: Create branch
-        uses: peterjgrainger/action-create-branch@v3.0.0
+        uses: peterjgrainger/action-create-branch@10c7d268152480ae859347db45dc69086cef1d9c # v3.0.0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:

--- a/.github/workflows/create-hotfix-branch-v2.yml
+++ b/.github/workflows/create-hotfix-branch-v2.yml
@@ -13,6 +13,11 @@ jobs:
     runs-on: ubuntu-latest
     if: github.ref == 'refs/heads/master-v2'
     steps:
+      - name: Harden the runner (Audit all outbound calls)
+        uses: step-security/harden-runner@f4a75cfd619ee5ce8d5b864b0d183aff3c69b55a # v2.13.1
+        with:
+          egress-policy: audit
+
       - name: Create branch
         uses: peterjgrainger/action-create-branch@v3.0.0
         env:

--- a/.github/workflows/create-hotfix-branch-v2.yml
+++ b/.github/workflows/create-hotfix-branch-v2.yml
@@ -14,7 +14,7 @@ jobs:
     if: github.ref == 'refs/heads/master-v2'
     steps:
       - name: Harden the runner (Audit all outbound calls)
-        uses: step-security/harden-runner@f4a75cfd619ee5ce8d5b864b0d183aff3c69b55a # v2.13.1
+        uses: step-security/harden-runner@95d9a5deda9de15063e7595e9719c11c38c90ae2 # v2.13.2
         with:
           egress-policy: audit
 

--- a/.github/workflows/create-hotfix-branch.yml
+++ b/.github/workflows/create-hotfix-branch.yml
@@ -13,6 +13,11 @@ jobs:
     runs-on: ubuntu-latest
     if: github.ref == 'refs/heads/master'
     steps:
+      - name: Harden the runner (Audit all outbound calls)
+        uses: step-security/harden-runner@f4a75cfd619ee5ce8d5b864b0d183aff3c69b55a # v2.13.1
+        with:
+          egress-policy: audit
+
       - name: Create branch
         uses: peterjgrainger/action-create-branch@v3.0.0
         env:

--- a/.github/workflows/create-hotfix-branch.yml
+++ b/.github/workflows/create-hotfix-branch.yml
@@ -19,7 +19,7 @@ jobs:
           egress-policy: audit
 
       - name: Create branch
-        uses: peterjgrainger/action-create-branch@v3.0.0
+        uses: peterjgrainger/action-create-branch@10c7d268152480ae859347db45dc69086cef1d9c # v3.0.0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:

--- a/.github/workflows/create-hotfix-branch.yml
+++ b/.github/workflows/create-hotfix-branch.yml
@@ -14,7 +14,7 @@ jobs:
     if: github.ref == 'refs/heads/master'
     steps:
       - name: Harden the runner (Audit all outbound calls)
-        uses: step-security/harden-runner@f4a75cfd619ee5ce8d5b864b0d183aff3c69b55a # v2.13.1
+        uses: step-security/harden-runner@95d9a5deda9de15063e7595e9719c11c38c90ae2 # v2.13.2
         with:
           egress-policy: audit
 

--- a/.github/workflows/deploy-beta-cocoapods.yml
+++ b/.github/workflows/deploy-beta-cocoapods.yml
@@ -9,6 +9,11 @@ jobs:
     runs-on: macOS-latest
     if: startsWith(github.ref, 'refs/heads/beta-release/')
     steps:
+      - name: Harden the runner (Audit all outbound calls)
+        uses: step-security/harden-runner@f4a75cfd619ee5ce8d5b864b0d183aff3c69b55a # v2.13.1
+        with:
+          egress-policy: audit
+
       - name: Checkout source branch
         uses: actions/checkout@v4
 

--- a/.github/workflows/deploy-beta-cocoapods.yml
+++ b/.github/workflows/deploy-beta-cocoapods.yml
@@ -13,7 +13,7 @@ jobs:
     if: startsWith(github.ref, 'refs/heads/beta-release/')
     steps:
       - name: Harden the runner (Audit all outbound calls)
-        uses: step-security/harden-runner@f4a75cfd619ee5ce8d5b864b0d183aff3c69b55a # v2.13.1
+        uses: step-security/harden-runner@95d9a5deda9de15063e7595e9719c11c38c90ae2 # v2.13.2
         with:
           egress-policy: audit
 

--- a/.github/workflows/deploy-beta-cocoapods.yml
+++ b/.github/workflows/deploy-beta-cocoapods.yml
@@ -3,6 +3,9 @@ name: Beta deploy to Cocoapods
 on:
   workflow_dispatch
 
+permissions:
+  contents: read
+
 jobs:
   deploy-cocoapods-beta:
     name: Beta deploy to Cocoapods
@@ -15,7 +18,7 @@ jobs:
           egress-policy: audit
 
       - name: Checkout source branch
-        uses: actions/checkout@v4
+        uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4.3.0
 
       - name: Install Cocoapods
         run: gem install cocoapods

--- a/.github/workflows/deploy-cocoapods-manual-v2.yml
+++ b/.github/workflows/deploy-cocoapods-manual-v2.yml
@@ -3,6 +3,9 @@ name: Manually deploy to Cocoapods(v2)
 on:
   workflow_dispatch
 
+permissions:
+  contents: read
+
 jobs:
   deploy-cocoapods-manual:
     name: Manually deploy to Cocoapods(v2)
@@ -15,7 +18,7 @@ jobs:
           egress-policy: audit
 
       - name: Checkout source branch
-        uses: actions/checkout@v4
+        uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4.3.0
 
       - name: Install Cocoapods
         run: gem install cocoapods

--- a/.github/workflows/deploy-cocoapods-manual-v2.yml
+++ b/.github/workflows/deploy-cocoapods-manual-v2.yml
@@ -13,7 +13,7 @@ jobs:
     if: startsWith(github.ref, 'refs/heads/master-v2')
     steps:
       - name: Harden the runner (Audit all outbound calls)
-        uses: step-security/harden-runner@f4a75cfd619ee5ce8d5b864b0d183aff3c69b55a # v2.13.1
+        uses: step-security/harden-runner@95d9a5deda9de15063e7595e9719c11c38c90ae2 # v2.13.2
         with:
           egress-policy: audit
 

--- a/.github/workflows/deploy-cocoapods-manual-v2.yml
+++ b/.github/workflows/deploy-cocoapods-manual-v2.yml
@@ -9,6 +9,11 @@ jobs:
     runs-on: macOS-latest
     if: startsWith(github.ref, 'refs/heads/master-v2')
     steps:
+      - name: Harden the runner (Audit all outbound calls)
+        uses: step-security/harden-runner@f4a75cfd619ee5ce8d5b864b0d183aff3c69b55a # v2.13.1
+        with:
+          egress-policy: audit
+
       - name: Checkout source branch
         uses: actions/checkout@v4
 

--- a/.github/workflows/deploy-cocoapods-manual.yml
+++ b/.github/workflows/deploy-cocoapods-manual.yml
@@ -9,6 +9,11 @@ jobs:
     runs-on: macOS-latest
     if: startsWith(github.ref, 'refs/heads/master')
     steps:
+      - name: Harden the runner (Audit all outbound calls)
+        uses: step-security/harden-runner@f4a75cfd619ee5ce8d5b864b0d183aff3c69b55a # v2.13.1
+        with:
+          egress-policy: audit
+
       - name: Checkout source branch
         uses: actions/checkout@v4
 

--- a/.github/workflows/deploy-cocoapods-manual.yml
+++ b/.github/workflows/deploy-cocoapods-manual.yml
@@ -3,6 +3,9 @@ name: Manually deploy to Cocoapods
 on:
   workflow_dispatch
 
+permissions:
+  contents: read
+
 jobs:
   deploy-cocoapods-manual:
     name: Manually deploy to Cocoapods
@@ -15,7 +18,7 @@ jobs:
           egress-policy: audit
 
       - name: Checkout source branch
-        uses: actions/checkout@v4
+        uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4.3.0
 
       - name: Install Cocoapods
         run: gem install cocoapods

--- a/.github/workflows/deploy-cocoapods-manual.yml
+++ b/.github/workflows/deploy-cocoapods-manual.yml
@@ -13,7 +13,7 @@ jobs:
     if: startsWith(github.ref, 'refs/heads/master')
     steps:
       - name: Harden the runner (Audit all outbound calls)
-        uses: step-security/harden-runner@f4a75cfd619ee5ce8d5b864b0d183aff3c69b55a # v2.13.1
+        uses: step-security/harden-runner@95d9a5deda9de15063e7595e9719c11c38c90ae2 # v2.13.2
         with:
           egress-policy: audit
 

--- a/.github/workflows/deploy-cocoapods.yml
+++ b/.github/workflows/deploy-cocoapods.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: macOS-latest
     steps:
     - name: Harden the runner (Audit all outbound calls)
-      uses: step-security/harden-runner@f4a75cfd619ee5ce8d5b864b0d183aff3c69b55a # v2.13.1
+      uses: step-security/harden-runner@95d9a5deda9de15063e7595e9719c11c38c90ae2 # v2.13.2
       with:
         egress-policy: audit
 

--- a/.github/workflows/deploy-cocoapods.yml
+++ b/.github/workflows/deploy-cocoapods.yml
@@ -4,6 +4,9 @@ on:
   release:
     types: [created]
     
+permissions:
+  contents: read
+
 jobs:
   build:
     name: Deploy to Cocoapods
@@ -15,7 +18,7 @@ jobs:
         egress-policy: audit
 
     - name: Checkout source branch
-      uses: actions/checkout@v4
+      uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4.3.0
       
     - name: Install Cocoapods
       run: gem install cocoapods

--- a/.github/workflows/deploy-cocoapods.yml
+++ b/.github/workflows/deploy-cocoapods.yml
@@ -9,6 +9,11 @@ jobs:
     name: Deploy to Cocoapods
     runs-on: macOS-latest
     steps:
+    - name: Harden the runner (Audit all outbound calls)
+      uses: step-security/harden-runner@f4a75cfd619ee5ce8d5b864b0d183aff3c69b55a # v2.13.1
+      with:
+        egress-policy: audit
+
     - name: Checkout source branch
       uses: actions/checkout@v4
       

--- a/.github/workflows/deploy-private-pod.yml
+++ b/.github/workflows/deploy-private-pod.yml
@@ -17,7 +17,7 @@ jobs:
     if: (startsWith(github.event.pull_request.head.ref, 'release/') || startsWith(github.event.pull_request.head.ref, 'hotfix-release/'))
     steps:
       - name: Harden the runner (Audit all outbound calls)
-        uses: step-security/harden-runner@f4a75cfd619ee5ce8d5b864b0d183aff3c69b55a # v2.13.1
+        uses: step-security/harden-runner@95d9a5deda9de15063e7595e9719c11c38c90ae2 # v2.13.2
         with:
           egress-policy: audit
 

--- a/.github/workflows/deploy-private-pod.yml
+++ b/.github/workflows/deploy-private-pod.yml
@@ -13,6 +13,11 @@ jobs:
     runs-on: macOS-latest
     if: (startsWith(github.event.pull_request.head.ref, 'release/') || startsWith(github.event.pull_request.head.ref, 'hotfix-release/'))
     steps:
+      - name: Harden the runner (Audit all outbound calls)
+        uses: step-security/harden-runner@f4a75cfd619ee5ce8d5b864b0d183aff3c69b55a # v2.13.1
+        with:
+          egress-policy: audit
+
       - name: 'Checkout'
         uses: actions/checkout@v4
         with:

--- a/.github/workflows/deploy-private-pod.yml
+++ b/.github/workflows/deploy-private-pod.yml
@@ -7,6 +7,9 @@ on:
     types:
       - opened
   
+permissions:
+  contents: read
+
 jobs:
   deploy_private_pod:
     name: Deploy to Private Pod
@@ -19,7 +22,7 @@ jobs:
           egress-policy: audit
 
       - name: 'Checkout'
-        uses: actions/checkout@v4
+        uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4.3.0
         with:
           ref: '${{ github.event.pull_request.head.ref }}'
     

--- a/.github/workflows/draft-new-beta-release.yml
+++ b/.github/workflows/draft-new-beta-release.yml
@@ -19,7 +19,7 @@ jobs:
     if: startsWith(github.ref, 'refs/heads/fix/') || startsWith(github.ref, 'refs/heads/feat/') || startsWith(github.ref, 'refs/heads/feature/')
     steps:
       - name: Harden the runner (Audit all outbound calls)
-        uses: step-security/harden-runner@f4a75cfd619ee5ce8d5b864b0d183aff3c69b55a # v2.13.1
+        uses: step-security/harden-runner@95d9a5deda9de15063e7595e9719c11c38c90ae2 # v2.13.2
         with:
           egress-policy: audit
 

--- a/.github/workflows/draft-new-beta-release.yml
+++ b/.github/workflows/draft-new-beta-release.yml
@@ -7,8 +7,13 @@ on:
         description: "Beta version(Only single digit, example: 1)"
         required: true
 
+permissions:
+  contents: read
+
 jobs:
   draft-new-beta-release:
+    permissions:
+      contents: write  # for Git to git push
     name: Draft a new Beta release
     runs-on: macOS-latest
     if: startsWith(github.ref, 'refs/heads/fix/') || startsWith(github.ref, 'refs/heads/feat/') || startsWith(github.ref, 'refs/heads/feature/')
@@ -19,12 +24,12 @@ jobs:
           egress-policy: audit
 
       - name: Checkout source branch
-        uses: actions/checkout@v4
+        uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4.3.0
         with:
           fetch-depth: 0
 
       - name: Set Node 16
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: 16
           
@@ -88,7 +93,7 @@ jobs:
           git push
 
       - name: 'Checkout'
-        uses: actions/checkout@v4
+        uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4.3.0
         with:
           ref: '${{ steps.create-release.outputs.branch_name }}'
 

--- a/.github/workflows/draft-new-beta-release.yml
+++ b/.github/workflows/draft-new-beta-release.yml
@@ -13,6 +13,11 @@ jobs:
     runs-on: macOS-latest
     if: startsWith(github.ref, 'refs/heads/fix/') || startsWith(github.ref, 'refs/heads/feat/') || startsWith(github.ref, 'refs/heads/feature/')
     steps:
+      - name: Harden the runner (Audit all outbound calls)
+        uses: step-security/harden-runner@f4a75cfd619ee5ce8d5b864b0d183aff3c69b55a # v2.13.1
+        with:
+          egress-policy: audit
+
       - name: Checkout source branch
         uses: actions/checkout@v4
         with:

--- a/.github/workflows/draft-new-release-v2.yml
+++ b/.github/workflows/draft-new-release-v2.yml
@@ -8,6 +8,11 @@ jobs:
     runs-on: ubuntu-latest
     if: startsWith(github.ref, 'refs/heads/develop-v2') || startsWith(github.ref, 'refs/heads/hotfix-v2/')
     steps:
+      - name: Harden the runner (Audit all outbound calls)
+        uses: step-security/harden-runner@f4a75cfd619ee5ce8d5b864b0d183aff3c69b55a # v2.13.1
+        with:
+          egress-policy: audit
+
       - name: Checkout source branch
         uses: actions/checkout@v4
         with:

--- a/.github/workflows/draft-new-release-v2.yml
+++ b/.github/workflows/draft-new-release-v2.yml
@@ -2,8 +2,13 @@ name: Draft new release(v2)
 
 on: workflow_dispatch
 
+permissions:
+  contents: read
+
 jobs:
   draft-new-release:
+    permissions:
+      contents: write  # for Git to git push
     name: Draft a new release(v2)
     runs-on: ubuntu-latest
     if: startsWith(github.ref, 'refs/heads/develop-v2') || startsWith(github.ref, 'refs/heads/hotfix-v2/')
@@ -14,12 +19,12 @@ jobs:
           egress-policy: audit
 
       - name: Checkout source branch
-        uses: actions/checkout@v4
+        uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4.3.0
         with:
           fetch-depth: 0
 
       - name: Set Node 16
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: 16
 

--- a/.github/workflows/draft-new-release-v2.yml
+++ b/.github/workflows/draft-new-release-v2.yml
@@ -14,7 +14,7 @@ jobs:
     if: startsWith(github.ref, 'refs/heads/develop-v2') || startsWith(github.ref, 'refs/heads/hotfix-v2/')
     steps:
       - name: Harden the runner (Audit all outbound calls)
-        uses: step-security/harden-runner@f4a75cfd619ee5ce8d5b864b0d183aff3c69b55a # v2.13.1
+        uses: step-security/harden-runner@95d9a5deda9de15063e7595e9719c11c38c90ae2 # v2.13.2
         with:
           egress-policy: audit
 

--- a/.github/workflows/draft-new-release.yml
+++ b/.github/workflows/draft-new-release.yml
@@ -8,6 +8,11 @@ jobs:
     runs-on: ubuntu-latest
     if: startsWith(github.ref, 'refs/heads/develop') || startsWith(github.ref, 'refs/heads/hotfix/')
     steps:
+      - name: Harden the runner (Audit all outbound calls)
+        uses: step-security/harden-runner@f4a75cfd619ee5ce8d5b864b0d183aff3c69b55a # v2.13.1
+        with:
+          egress-policy: audit
+
       - name: Checkout source branch
         uses: actions/checkout@v4
         with:

--- a/.github/workflows/draft-new-release.yml
+++ b/.github/workflows/draft-new-release.yml
@@ -2,8 +2,13 @@ name: Draft new release
 
 on: workflow_dispatch
 
+permissions:
+  contents: read
+
 jobs:
   draft-new-release:
+    permissions:
+      contents: write  # for Git to git push
     name: Draft a new release
     runs-on: ubuntu-latest
     if: startsWith(github.ref, 'refs/heads/develop') || startsWith(github.ref, 'refs/heads/hotfix/')
@@ -14,12 +19,12 @@ jobs:
           egress-policy: audit
 
       - name: Checkout source branch
-        uses: actions/checkout@v4
+        uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4.3.0
         with:
           fetch-depth: 0
 
       - name: Set Node 16
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: 16
 

--- a/.github/workflows/draft-new-release.yml
+++ b/.github/workflows/draft-new-release.yml
@@ -14,7 +14,7 @@ jobs:
     if: startsWith(github.ref, 'refs/heads/develop') || startsWith(github.ref, 'refs/heads/hotfix/')
     steps:
       - name: Harden the runner (Audit all outbound calls)
-        uses: step-security/harden-runner@f4a75cfd619ee5ce8d5b864b0d183aff3c69b55a # v2.13.1
+        uses: step-security/harden-runner@95d9a5deda9de15063e7595e9719c11c38c90ae2 # v2.13.2
         with:
           egress-policy: audit
 

--- a/.github/workflows/notion-pr-sync.yml
+++ b/.github/workflows/notion-pr-sync.yml
@@ -48,7 +48,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Harden the runner (Audit all outbound calls)
-        uses: step-security/harden-runner@f4a75cfd619ee5ce8d5b864b0d183aff3c69b55a # v2.13.1
+        uses: step-security/harden-runner@95d9a5deda9de15063e7595e9719c11c38c90ae2 # v2.13.2
         with:
           egress-policy: audit
 

--- a/.github/workflows/notion-pr-sync.yml
+++ b/.github/workflows/notion-pr-sync.yml
@@ -47,6 +47,11 @@ jobs:
   request:
     runs-on: ubuntu-latest
     steps:
+      - name: Harden the runner (Audit all outbound calls)
+        uses: step-security/harden-runner@f4a75cfd619ee5ce8d5b864b0d183aff3c69b55a # v2.13.1
+        with:
+          egress-policy: audit
+
       - name: Sync Github PRs to Notion
         uses: sivashanmukh/github-notion-pr-sync@3967330238449a8550b06f6e1d6b83e1af569876 #v1.0.0
         with:

--- a/.github/workflows/publish-new-release-v2.yml
+++ b/.github/workflows/publish-new-release-v2.yml
@@ -13,6 +13,11 @@ jobs:
     runs-on: ubuntu-latest
     if: (startsWith(github.event.pull_request.head.ref, 'release/') || startsWith(github.event.pull_request.head.ref, 'hotfix-v2-release/')) && github.event.pull_request.merged == true # only merged pull requests must trigger this job
     steps:
+      - name: Harden the runner (Audit all outbound calls)
+        uses: step-security/harden-runner@f4a75cfd619ee5ce8d5b864b0d183aff3c69b55a # v2.13.1
+        with:
+          egress-policy: audit
+
       - name: Extract version from branch name (for release branches)
         id: extract-version
         run: |

--- a/.github/workflows/publish-new-release-v2.yml
+++ b/.github/workflows/publish-new-release-v2.yml
@@ -27,12 +27,12 @@ jobs:
           echo "release_version=$VERSION" >> $GITHUB_OUTPUT
 
       - name: Checkout source branch
-        uses: actions/checkout@v4
+        uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4.3.0
         with:
           fetch-depth: 0
 
       - name: Set Node 16
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: 16
 
@@ -67,7 +67,7 @@ jobs:
           pr_body: ':crown: *An automated PR*'
 
       - name: Delete hotfix release branch
-        uses: koj-co/delete-merged-action@master
+        uses: koj-co/delete-merged-action@63a03c35810a8a7d4840d18793c0f68ff8b59450 # master
         if: startsWith(github.event.pull_request.head.ref, 'hotfix-v2-release/')
         with:
           branches: 'hotfix-v2-release/*'
@@ -75,7 +75,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Delete release branch
-        uses: koj-co/delete-merged-action@master
+        uses: koj-co/delete-merged-action@63a03c35810a8a7d4840d18793c0f68ff8b59450 # master
         if: startsWith(github.event.pull_request.head.ref, 'release/')
         with:
           branches: 'release/*'

--- a/.github/workflows/publish-new-release-v2.yml
+++ b/.github/workflows/publish-new-release-v2.yml
@@ -14,7 +14,7 @@ jobs:
     if: (startsWith(github.event.pull_request.head.ref, 'release/') || startsWith(github.event.pull_request.head.ref, 'hotfix-v2-release/')) && github.event.pull_request.merged == true # only merged pull requests must trigger this job
     steps:
       - name: Harden the runner (Audit all outbound calls)
-        uses: step-security/harden-runner@f4a75cfd619ee5ce8d5b864b0d183aff3c69b55a # v2.13.1
+        uses: step-security/harden-runner@95d9a5deda9de15063e7595e9719c11c38c90ae2 # v2.13.2
         with:
           egress-policy: audit
 

--- a/.github/workflows/publish-new-release.yml
+++ b/.github/workflows/publish-new-release.yml
@@ -27,12 +27,12 @@ jobs:
           echo "release_version=$VERSION" >> $GITHUB_OUTPUT
 
       - name: Checkout source branch
-        uses: actions/checkout@v4
+        uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4.3.0
         with:
           fetch-depth: 0
 
       - name: Set Node 16
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: 16
 
@@ -63,7 +63,7 @@ jobs:
           pr_reviewer: "@rudderlabs/sdk-ios"
 
       - name: Delete hotfix release branch
-        uses: koj-co/delete-merged-action@master
+        uses: koj-co/delete-merged-action@63a03c35810a8a7d4840d18793c0f68ff8b59450 # master
         if: startsWith(github.event.pull_request.head.ref, 'hotfix-release/')
         with:
           branches: "hotfix-release/*"
@@ -71,7 +71,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Delete release branch
-        uses: koj-co/delete-merged-action@master
+        uses: koj-co/delete-merged-action@63a03c35810a8a7d4840d18793c0f68ff8b59450 # master
         if: startsWith(github.event.pull_request.head.ref, 'release/')
         with:
           branches: "release/*"
@@ -97,7 +97,7 @@ jobs:
           echo "release_version=$VERSION" >> $GITHUB_OUTPUT
 
       - name: Checkout source branch
-        uses: actions/checkout@v4
+        uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4.3.0
         with:
           fetch-depth: 0
 

--- a/.github/workflows/publish-new-release.yml
+++ b/.github/workflows/publish-new-release.yml
@@ -14,7 +14,7 @@ jobs:
     if: (startsWith(github.event.pull_request.head.ref, 'release/') || startsWith(github.event.pull_request.head.ref, 'hotfix-release/')) && github.event.pull_request.merged == true # only merged pull requests must trigger this job
     steps:
       - name: Harden the runner (Audit all outbound calls)
-        uses: step-security/harden-runner@f4a75cfd619ee5ce8d5b864b0d183aff3c69b55a # v2.13.1
+        uses: step-security/harden-runner@95d9a5deda9de15063e7595e9719c11c38c90ae2 # v2.13.2
         with:
           egress-policy: audit
 
@@ -84,7 +84,7 @@ jobs:
     needs: release
     steps:
       - name: Harden the runner (Audit all outbound calls)
-        uses: step-security/harden-runner@f4a75cfd619ee5ce8d5b864b0d183aff3c69b55a # v2.13.1
+        uses: step-security/harden-runner@95d9a5deda9de15063e7595e9719c11c38c90ae2 # v2.13.2
         with:
           egress-policy: audit
 

--- a/.github/workflows/publish-new-release.yml
+++ b/.github/workflows/publish-new-release.yml
@@ -13,6 +13,11 @@ jobs:
     runs-on: ubuntu-latest
     if: (startsWith(github.event.pull_request.head.ref, 'release/') || startsWith(github.event.pull_request.head.ref, 'hotfix-release/')) && github.event.pull_request.merged == true # only merged pull requests must trigger this job
     steps:
+      - name: Harden the runner (Audit all outbound calls)
+        uses: step-security/harden-runner@f4a75cfd619ee5ce8d5b864b0d183aff3c69b55a # v2.13.1
+        with:
+          egress-policy: audit
+
       - name: Extract version from branch name (for release branches)
         id: extract-version
         run: |
@@ -78,6 +83,11 @@ jobs:
     runs-on: macos-latest
     needs: release
     steps:
+      - name: Harden the runner (Audit all outbound calls)
+        uses: step-security/harden-runner@f4a75cfd619ee5ce8d5b864b0d183aff3c69b55a # v2.13.1
+        with:
+          egress-policy: audit
+
       - name: Extract version from branch name (for release branches)
         id: extract-version
         run: |

--- a/.github/workflows/slack-notify.yml
+++ b/.github/workflows/slack-notify.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Harden the runner (Audit all outbound calls)
-        uses: step-security/harden-runner@f4a75cfd619ee5ce8d5b864b0d183aff3c69b55a # v2.13.1
+        uses: step-security/harden-runner@95d9a5deda9de15063e7595e9719c11c38c90ae2 # v2.13.2
         with:
           egress-policy: audit
 

--- a/.github/workflows/slack-notify.yml
+++ b/.github/workflows/slack-notify.yml
@@ -9,6 +9,11 @@ jobs:
     name: Notify Slack
     runs-on: ubuntu-latest
     steps:
+      - name: Harden the runner (Audit all outbound calls)
+        uses: step-security/harden-runner@f4a75cfd619ee5ce8d5b864b0d183aff3c69b55a # v2.13.1
+        with:
+          egress-policy: audit
+
       - name: Send message to Slack channel
         id: slack
         uses: slackapi/slack-github-action@v2.0.0

--- a/.github/workflows/slack-notify.yml
+++ b/.github/workflows/slack-notify.yml
@@ -4,6 +4,9 @@ on:
   release:
     types: [created]
 
+permissions:
+  contents: read
+
 jobs:
   deploy-tag:
     name: Notify Slack
@@ -16,7 +19,7 @@ jobs:
 
       - name: Send message to Slack channel
         id: slack
-        uses: slackapi/slack-github-action@v2.0.0
+        uses: slackapi/slack-github-action@485a9d42d3a73031f12ec201c457e2162c45d02d # v2.0.0
         env:
           SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
           PROJECT_NAME: 'iOS SDK'

--- a/.github/workflows/test-v2.yml
+++ b/.github/workflows/test-v2.yml
@@ -17,7 +17,7 @@ jobs:
 
     steps:
       - name: Harden the runner (Audit all outbound calls)
-        uses: step-security/harden-runner@f4a75cfd619ee5ce8d5b864b0d183aff3c69b55a # v2.13.1
+        uses: step-security/harden-runner@95d9a5deda9de15063e7595e9719c11c38c90ae2 # v2.13.2
         with:
           egress-policy: audit
 

--- a/.github/workflows/test-v2.yml
+++ b/.github/workflows/test-v2.yml
@@ -13,6 +13,11 @@ jobs:
     runs-on: macOS-latest
 
     steps:
+      - name: Harden the runner (Audit all outbound calls)
+        uses: step-security/harden-runner@f4a75cfd619ee5ce8d5b864b0d183aff3c69b55a # v2.13.1
+        with:
+          egress-policy: audit
+
       - name: Checkout
         uses: actions/checkout@v4
       

--- a/.github/workflows/test-v2.yml
+++ b/.github/workflows/test-v2.yml
@@ -7,6 +7,9 @@ on:
     branches: ['master-v2', 'develop-v2']
     types: ['opened', 'reopened', 'synchronize']
 
+permissions:
+  contents: read
+
 jobs:
   build:
     name: 'Tests & Coverage(v2)'
@@ -19,7 +22,7 @@ jobs:
           egress-policy: audit
 
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4.3.0
       
       - name: Install xcpretty
         run: gem install xcpretty

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,6 +15,11 @@ jobs:
     env:
       BUILD_WRAPPER_OUT_DIR: build_wrapper_output_directory # Directory where build-wrapper output will be placed
     steps:
+      - name: Harden the runner (Audit all outbound calls)
+        uses: step-security/harden-runner@f4a75cfd619ee5ce8d5b864b0d183aff3c69b55a # v2.13.1
+        with:
+          egress-policy: audit
+
       - name: Checkout
         uses: actions/checkout@v4
       

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,7 +19,7 @@ jobs:
       BUILD_WRAPPER_OUT_DIR: build_wrapper_output_directory # Directory where build-wrapper output will be placed
     steps:
       - name: Harden the runner (Audit all outbound calls)
-        uses: step-security/harden-runner@f4a75cfd619ee5ce8d5b864b0d183aff3c69b55a # v2.13.1
+        uses: step-security/harden-runner@95d9a5deda9de15063e7595e9719c11c38c90ae2 # v2.13.2
         with:
           egress-policy: audit
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,6 +7,9 @@ on:
     branches: ['master', 'develop']
     types: ['opened', 'reopened', 'synchronize']
 
+permissions:
+  contents: read
+
 jobs:
           
   build:
@@ -21,7 +24,7 @@ jobs:
           egress-policy: audit
 
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4.3.0
       
       # - name: Install sonar-scanner and build-wrapper
       #   uses: SonarSource/sonarcloud-github-c-cpp@e4882e1621ad2fb48dddfa48287411bed34789b1 #v2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+### [1.31.2](https://github.com/rudderlabs/rudder-sdk-ios/compare/v1.31.1...v1.31.2) (2026-01-20)
+
+
+### Bug Fixes
+
+* address license warning on pod install ([#577](https://github.com/rudderlabs/rudder-sdk-ios/issues/577)) ([42f7a92](https://github.com/rudderlabs/rudder-sdk-ios/commit/42f7a9276c52fcb8be17fbd9566a147a3d320720))
+
 ### [1.31.1](https://github.com/rudderlabs/rudder-sdk-ios/compare/v1.31.0...v1.31.1) (2025-04-02)
 
 

--- a/Package.resolved
+++ b/Package.resolved
@@ -15,8 +15,8 @@
         "repositoryURL": "https://github.com/rudderlabs/metrics-reporter-ios",
         "state": {
           "branch": null,
-          "revision": "c5fe7cc861a83ec75978a516c02398c2a2cb1f20",
-          "version": "1.2.1"
+          "revision": "49b0d7b8f5fefd95da210f6c92fc8a6a9daf0dfd",
+          "version": "2.0.1"
         }
       },
       {

--- a/Package.swift
+++ b/Package.swift
@@ -14,7 +14,7 @@ let package = Package(
         )
     ],
     dependencies: [
-        .package(name: "MetricsReporter", url: "https://github.com/rudderlabs/metrics-reporter-ios", .exact("2.0.0")),
+        .package(name: "MetricsReporter", url: "https://github.com/rudderlabs/metrics-reporter-ios", .exact("2.0.1")),
     ],
     targets: [
         .target(

--- a/Podfile
+++ b/Podfile
@@ -1,4 +1,4 @@
-source 'https://github.com/rudderlabs/Specs.git'
+# source 'https://github.com/rudderlabs/Specs.git'
 workspace 'Rudder.xcworkspace'
 use_frameworks!
 inhibit_all_warnings!

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -1,10 +1,10 @@
 PODS:
-  - MetricsReporter (2.0.0):
+  - MetricsReporter (2.0.1):
     - RSCrashReporter (= 1.0.1)
     - RudderKit (= 1.4.0)
   - RSCrashReporter (1.0.1)
-  - Rudder (1.29.1):
-    - MetricsReporter (= 2.0.0)
+  - Rudder (1.31.1):
+    - MetricsReporter (= 2.0.1)
   - RudderKit (1.4.0)
   - SQLCipher (4.5.4):
     - SQLCipher/standard (= 4.5.4)
@@ -31,12 +31,12 @@ EXTERNAL SOURCES:
     :path: "."
 
 SPEC CHECKSUMS:
-  MetricsReporter: 364b98791e868b10e9d512eb50af28d8c11e5cdb
+  MetricsReporter: b76937c31c06e81316ec1f9049ee069ca69faea0
   RSCrashReporter: 6b8376ac729b0289ebe0908553e5f56d8171f313
-  Rudder: 731095848aee39d27ff5d0e78233aa5ad8febb0b
+  Rudder: a0d683367a8e9ae2f4fb36061ae6fce1ab6c2067
   RudderKit: d9d6997696e1642b753d8bdf94e57af643a68f03
   SQLCipher: 905b145f65f349f26da9e60a19901ad24adcd381
 
-PODFILE CHECKSUM: b6937cee06e0633464427ff0d975d40e17419e9f
+PODFILE CHECKSUM: e8d5b9335fcb12b7b27d70287e45e81067909b07
 
-COCOAPODS: 1.15.2
+COCOAPODS: 1.16.2

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 <p align="center">
   <a href="https://cocoapods.org/pods/Rudder">
-    <img src="https://img.shields.io/static/v1?label=pod&message=v1.31.1&color=blue&style=flat">
+    <img src="https://img.shields.io/static/v1?label=pod&message=v1.31.2&color=blue&style=flat">
     </a>
 </p>
 
@@ -39,7 +39,7 @@ The iOS SDK is available through [**CocoaPods**](https://cocoapods.org), [**Cart
 To install the SDK, simply add the following line to your Podfile:
 
 ```xcode
-pod 'Rudder', '1.31.1'
+pod 'Rudder', '1.31.2'
 ```
 
 ### Carthage
@@ -47,7 +47,7 @@ pod 'Rudder', '1.31.1'
 For Carthage support, add the following line to your `Cartfile`:
 
 ```xcode
-github "rudderlabs/rudder-sdk-ios" "v1.31.1"
+github "rudderlabs/rudder-sdk-ios" "v1.31.2"
 ```
 
 > Remember to include the following code in all `.m` and `.h` files where you want to refer to or use the RudderStack SDK classes, as shown:
@@ -71,7 +71,7 @@ You can also add the RudderStack iOS SDK via Swift Package Mangaer, via one of t
 
 * Enter the package repository (`git@github.com:rudderlabs/rudder-sdk-ios.git`) in the search bar.
 
-* In **Dependency Rule**, select **Up to Next Major Version** and enter `1.31.1` as the value, as shown:
+* In **Dependency Rule**, select **Up to Next Major Version** and enter `1.31.2` as the value, as shown:
 
 ![Setting dependency](https://user-images.githubusercontent.com/59817155/145574696-8c849749-13e0-40d5-aacb-3fccb5c8e67d.png)
 
@@ -99,7 +99,7 @@ let package = Package(
     ],
     dependencies: [
         // Dependencies declare other packages that this package depends on.
-        .package(url: "git@github.com:rudderlabs/rudder-sdk-ios.git", from: "1.31.1")
+        .package(url: "git@github.com:rudderlabs/rudder-sdk-ios.git", from: "1.31.2")
     ],
     targets: [
         // Targets are the basic building blocks of a package. A target can define a module or a test suite.

--- a/Rudder.podspec
+++ b/Rudder.podspec
@@ -28,5 +28,5 @@ Pod::Spec.new do |s|
   
   s.source_files = 'Sources/**/*.{h,m}'
   
-  s.dependency 'MetricsReporter', '2.0.0'
+  s.dependency 'MetricsReporter', '2.0.1'
 end

--- a/Sources/Classes/Headers/RSVersion.h
+++ b/Sources/Classes/Headers/RSVersion.h
@@ -8,6 +8,6 @@
 #ifndef RSVersion_h
 #define RSVersion_h
 
-NSString *const SDK_VERSION = @"1.31.1";
+NSString *const SDK_VERSION = @"1.31.2";
 
 #endif /* RSVersion_h */

--- a/package.json
+++ b/package.json
@@ -1,4 +1,4 @@
 {
-    "version": "1.31.1",
+    "version": "1.31.2",
     "description": "Rudder is a platform for collecting, storing and routing customer event data to dozens of tools"
 }

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -6,7 +6,7 @@ sonar.qualitygate.wait=false
 sonar.projectKey=rudderlabs_rudder-sdk-ios
 sonar.organization=rudderlabs
 sonar.projectName=RudderStack iOS SDK
-sonar.projectVersion=1.31.1
+sonar.projectVersion=1.31.2
 
 # C/C++/Objective-C related details
 # sonar.cfamily.compile-commands=compile_commands.json


### PR DESCRIPTION
:crown: *An automated PR*

   Unreleased (2026-01-20)<br> * chore: apply security best practices from step security ( 571) ([2ff4a3a](https://github.com/rudderlabs/rudder-sdk-ios/commit/2ff4a3a)), closes [ 571](https://github.com/rudderlabs/rudder-sdk-ios/issues/571)<br> * chore(deps): bump step-security/harden-runner from 2.13.1 to 2.13.2 ( 572) ([6fb0b5d](https://github.com/rudderlabs/rudder-sdk-ios/commit/6fb0b5d)), closes [ 572](https://github.com/rudderlabs/rudder-sdk-ios/issues/572) [ 606](https://github.com/rudderlabs/rudder-sdk-ios/issues/606) [ 593](https://github.com/rudderlabs/rudder-sdk-ios/issues/593) [ 591](https://github.com/rudderlabs/rudder-sdk-ios/issues/591)<br> * fix: address license warning on pod install ( 577) ([42f7a92](https://github.com/rudderlabs/rudder-sdk-ios/commit/42f7a92)), closes [ 577](https://github.com/rudderlabs/rudder-sdk-ios/issues/577)<br> * Merge pull request  569 from rudderlabs/chore/GHA-110917-stepsecurity-remediation ([55f3d85](https://github.com/rudderlabs/rudder-sdk-ios/commit/55f3d85)), closes [ 569](https://github.com/rudderlabs/rudder-sdk-ios/issues/569)