### PR TITLE
feat: add comprehensive deprecation notices for iOS SDK v2.x

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,5 +1,31 @@
 // swift-tools-version:5.3
 
+/*
+┌────────────────────────────────────────────────────────────────────┐
+│                     ⚠️ DEPRECATION WARNING                         │
+├────────────────────────────────────────────────────────────────────┤
+│ This version of the RudderStack iOS SDK is deprecated and is       │
+│ no longer actively maintained.                                     │
+│ Please migrate to the newer Swift-based iOS SDK for continued      │
+│                                                                    │
+│ support, bug fixes, and new features.                              │
+│                                                                    │
+│ Swift SDK Repository:                                              │
+│ https://github.com/rudderlabs/rudder-sdk-swift                     │
+│                                                                    │
+│ Documentation:                                                     │
+│ https://www.rudderstack.com/docs/sources/event-streams/sdks/       │
+│ swift-sdk/                                                         │
+│                                                                    │
+│ Migration Documentation:                                           │
+│ https://www.rudderstack.com/docs/sources/event-streams             │
+│ /sdks/swift-sdk/breaking-changes/ios-v2/migration-guide/           │
+│                                                                    │
+│ This SDK will be sunset in the near future. We strongly            │
+│ recommend migrating as soon as possible.                           │
+└────────────────────────────────────────────────────────────────────┘
+*/
+
 import PackageDescription
 
 let package = Package(

--- a/Rudder.podspec
+++ b/Rudder.podspec
@@ -35,8 +35,7 @@ Pod::Spec.new do |s|
   s.resource_bundles = { s.name => 'Sources/Resources/PrivacyInfo.xcprivacy' }
 
   s.deprecated = true
-  s.deprecated_in_favor_of = "rudder-sdk-swift"
-  
+
   s.swift_version = '5.3'
   s.ios.deployment_target = '12.0'
   s.tvos.deployment_target = '11.0'

--- a/Rudder.podspec
+++ b/Rudder.podspec
@@ -6,9 +6,27 @@ Pod::Spec.new do |s|
   s.name             = 'Rudder'
   s.version          = package['version']
   s.summary          = "Privacy and Security focused Segment-alternative. iOS, tvOS, watchOS & macOS SDK"
-  s.description      = <<-DESC
-  Rudder is a platform for collecting, storing and routing customer event data to dozens of tools. Rudder is open-source, can run in your cloud environment (AWS, GCP, Azure or even your data-centre) and provides a powerful transformation framework to process your event data on the fly.
-                       DESC
+  
+  s.description = <<-DESC
+  ⚠️ DEPRECATION NOTICE
+
+  Version 2.x of the RudderStack iOS SDK is deprecated and is no longer actively maintained.
+
+  Please migrate to the newer Swift-based iOS SDK for continued support, bug fixes, and new features.
+
+  Swift SDK Repository:
+  https://github.com/rudderlabs/rudder-sdk-swift
+
+  Documentation:
+  https://www.rudderstack.com/docs/sources/event-streams/sdks/swift-sdk/
+
+  This SDK will be sunset in the near future. We strongly recommend migrating as soon as possible.
+
+
+  ABOUT RUDDERSTACK
+
+  Rudder is a platform for collecting, storing, and routing customer event data to dozens of tools. It is open-source, can run in your cloud environment (AWS, GCP, Azure, or your data center), and provides a powerful transformation framework to process event data on the fly.
+  DESC
 
   s.homepage         = "https://github.com/rudderlabs/rudder-sdk-ios"
   s.license          = { :type => "Apache", :file => "LICENSE" }
@@ -16,6 +34,9 @@ Pod::Spec.new do |s|
   s.source           = { :git => "https://github.com/rudderlabs/rudder-sdk-ios.git", :tag => "v#{s.version}" }
   s.resource_bundles = { s.name => 'Sources/Resources/PrivacyInfo.xcprivacy' }
 
+  s.deprecated = true
+  s.deprecated_in_favor_of = "rudder-sdk-swift"
+  
   s.swift_version = '5.3'
   s.ios.deployment_target = '12.0'
   s.tvos.deployment_target = '11.0'

--- a/Sources/Classes/Client/RSClient.swift
+++ b/Sources/Classes/Client/RSClient.swift
@@ -403,11 +403,11 @@ extension RSClient {
         │ Documentation:                                                     │
         │ https://www.rudderstack.com/docs/sources/event-streams/sdks/       │
         │ swift-sdk/                                                         │
-        │                                                                    |
-        | Migration Documentation:                                           |
-        | https://www.rudderstack.com/docs/sources/event-streams             |
-        | /sdks/swift-sdk/breaking-changes/ios-v2/migration-guide/           |
-        |                                                                    |
+        │                                                                    │
+        │ Migration Documentation:                                           │
+        │ https://www.rudderstack.com/docs/sources/event-streams             │
+        │ /sdks/swift-sdk/breaking-changes/ios-v2/migration-guide/           │
+        │                                                                    │
         │ This SDK will be sunset in the near future. We strongly            │
         │ recommend migrating as soon as possible.                           │
         └────────────────────────────────────────────────────────────────────┘

--- a/Sources/Classes/Client/RSClient.swift
+++ b/Sources/Classes/Client/RSClient.swift
@@ -44,6 +44,7 @@ open class RSClient: NSObject {
     @objc
     public func configure(with config: RSConfig) {
         self.config = config
+        self.printDeprecationWarning()
         addPlugins()
     }
     
@@ -380,5 +381,32 @@ extension RSClient {
         default:
             break
         }
+    }
+}
+
+extension RSClient {
+    private func printDeprecationWarning() {
+        let warning = """
+        ┌────────────────────────────────────────────────────────────────────┐
+        │                     ⚠️ DEPRECATION WARNING                         │
+        ├────────────────────────────────────────────────────────────────────┤
+        │ This version of the RudderStack iOS SDK is deprecated and is       │
+        │ no longer actively maintained.                                     │
+        │                                                                    │
+        │ Please migrate to the newer Swift-based iOS SDK for continued      │
+        │ support, bug fixes, and new features.                              │
+        │                                                                    │
+        │ Swift SDK Repository:                                              │
+        │ https://github.com/rudderlabs/rudder-sdk-swift                     │
+        │                                                                    │
+        │ Documentation:                                                     │
+        │ https://www.rudderstack.com/docs/sources/event-streams/sdks/       │
+        │ swift-sdk/                                                         │
+        │                                                                    │
+        │ This SDK will be sunset in the near future. We strongly            │
+        │ recommend migrating as soon as possible.                           │
+        └────────────────────────────────────────────────────────────────────┘
+        """
+        print(warning)
     }
 }

--- a/Sources/Classes/Client/RSClient.swift
+++ b/Sources/Classes/Client/RSClient.swift
@@ -402,7 +402,11 @@ extension RSClient {
         │ Documentation:                                                     │
         │ https://www.rudderstack.com/docs/sources/event-streams/sdks/       │
         │ swift-sdk/                                                         │
-        │                                                                    │
+        │                                                                    |
+        | Migration Documentation:                                           |
+        | https://www.rudderstack.com/docs/sources/event-streams             |
+        | /sdks/swift-sdk/breaking-changes/ios-v2/migration-guide/           |
+        |                                                                    |
         │ This SDK will be sunset in the near future. We strongly            │
         │ recommend migrating as soon as possible.                           │
         └────────────────────────────────────────────────────────────────────┘

--- a/Sources/Classes/Client/RSClient.swift
+++ b/Sources/Classes/Client/RSClient.swift
@@ -8,6 +8,7 @@
 
 import Foundation
 
+@available(*, deprecated, message: "This version of the RudderStack iOS SDK is deprecated and is no longer actively maintained. We strongly recommend migrating to our new Swift SDK as soon as possible.")
 @objc
 open class RSClient: NSObject {
     var config: RSConfig?

--- a/Sources/Classes/Domain/Models/RSConfig.swift
+++ b/Sources/Classes/Domain/Models/RSConfig.swift
@@ -8,6 +8,7 @@
 
 import Foundation
 
+@available(*, deprecated, message: "This version of the RudderStack iOS SDK is deprecated and is no longer actively maintained. We strongly recommend migrating to our new Swift SDK as soon as possible.")
 @objc
 open class RSConfig: NSObject {
     let _writeKey: String

--- a/Sources/Classes/Domain/Models/RSOption.swift
+++ b/Sources/Classes/Domain/Models/RSOption.swift
@@ -8,6 +8,7 @@
 
 import Foundation
 
+@available(*, deprecated, message: "This version of the RudderStack iOS SDK is deprecated and is no longer actively maintained. We strongly recommend migrating to our new Swift SDK as soon as possible.")
 @objc
 open class RSOption: NSObject {
     var externalIds: [[String: String]]?

--- a/Sources/Classes/Domain/Protocols/RSMessage.swift
+++ b/Sources/Classes/Domain/Protocols/RSMessage.swift
@@ -8,6 +8,7 @@
 
 import Foundation
 
+@available(*, deprecated, message: "This version of the RudderStack iOS SDK is deprecated and is no longer actively maintained. We strongly recommend migrating to our new Swift SDK as soon as possible.")
 public protocol RSMessage {
     var type: RSMessageType { get set }
     var anonymousId: String? { get set }
@@ -21,6 +22,7 @@ public protocol RSMessage {
     var dictionaryValue: [String: Any] { get }
 }
 
+@available(*, deprecated, message: "This version of the RudderStack iOS SDK is deprecated and is no longer actively maintained. We strongly recommend migrating to our new Swift SDK as soon as possible.")
 public struct TrackMessage: RSMessage {
     public var type: RSMessageType = .track
     public var anonymousId: String?
@@ -53,6 +55,7 @@ public struct TrackMessage: RSMessage {
     }
 }
 
+@available(*, deprecated, message: "This version of the RudderStack iOS SDK is deprecated and is no longer actively maintained. We strongly recommend migrating to our new Swift SDK as soon as possible.")
 public struct IdentifyMessage: RSMessage {
     public var type: RSMessageType = .identify
     public var anonymousId: String?
@@ -83,6 +86,7 @@ public struct IdentifyMessage: RSMessage {
     }
 }
 
+@available(*, deprecated, message: "This version of the RudderStack iOS SDK is deprecated and is no longer actively maintained. We strongly recommend migrating to our new Swift SDK as soon as possible.")
 public struct ScreenMessage: RSMessage {
     public var type: RSMessageType = .screen
     public var anonymousId: String?
@@ -118,6 +122,7 @@ public struct ScreenMessage: RSMessage {
     }
 }
 
+@available(*, deprecated, message: "This version of the RudderStack iOS SDK is deprecated and is no longer actively maintained. We strongly recommend migrating to our new Swift SDK as soon as possible.")
 public struct GroupMessage: RSMessage {
     public var type: RSMessageType = .group
     public var anonymousId: String?
@@ -150,6 +155,7 @@ public struct GroupMessage: RSMessage {
     }
 }
 
+@available(*, deprecated, message: "This version of the RudderStack iOS SDK is deprecated and is no longer actively maintained. We strongly recommend migrating to our new Swift SDK as soon as possible.")
 public struct AliasMessage: RSMessage {
     public var type: RSMessageType = .alias
     public var anonymousId: String?

--- a/Sources/Classes/Domain/Protocols/RSPlugins.swift
+++ b/Sources/Classes/Domain/Protocols/RSPlugins.swift
@@ -29,6 +29,7 @@ public enum UpdateType {
     case refresh
 }
 
+@available(*, deprecated, message: "This version of the RudderStack iOS SDK is deprecated and is no longer actively maintained. We strongly recommend migrating to our new Swift SDK as soon as possible.")
 public protocol RSPlugin: AnyObject {
     var type: PluginType { get }
     var client: RSClient? { get set }


### PR DESCRIPTION
## Description

This PR implements comprehensive deprecation notices for the RudderStack iOS SDK v2.x, formally announcing the end-of-life of this version and guiding users to migrate to the newer Swift-based SDK.

## Changes Made

### 1. Package.swift
- Added a prominent deprecation warning banner at the top of the Swift Package Manager configuration
- Warning includes migration guidance and links to the new Swift SDK

### 2. Rudder.podspec
- Updated the description to include a detailed deprecation notice
- Added the `s.deprecated = true` flag to mark the CocoaPods spec as deprecated
- Maintained backward compatibility while clearly communicating the deprecation status

### 3. Core SDK Classes
Added `@available(*, deprecated, message: "...")` annotations to the following public classes and protocols:

#### Client Layer
- **RSClient.swift**: Added deprecation warning to the main client class and implemented a `printDeprecationWarning()` method that displays a formatted console warning on SDK initialization

#### Domain Models  
- **RSConfig.swift**: Deprecated the configuration class
- **RSOption.swift**: Deprecated the options class

#### Message Protocols and Types
- **RSMessage.swift**: Deprecated all message protocols and structs including:
  - `RSMessage` protocol
  - `TrackMessage` struct
  - `IdentifyMessage` struct  
  - `ScreenMessage` struct
  - `GroupMessage` struct
  - `AliasMessage` struct

#### Plugin System
- **RSPlugins.swift**: Deprecated the `RSPlugin` protocol

### 4. Runtime Warning Implementation
- Added a new private method `printDeprecationWarning()` to `RSClient` that displays a formatted deprecation warning when the SDK is configured
- The warning includes:
  - Clear deprecation notice
  - Migration guidance
  - Links to the new Swift SDK repository
  - Documentation links
  - Migration guide reference

## Migration Information

Users of this SDK should migrate to the new Swift SDK:

- **Repository**: https://github.com/rudderlabs/rudder-sdk-swift
- **Documentation**: https://www.rudderstack.com/docs/sources/event-streams/sdks/swift-sdk/
- **Migration Guide**: https://www.rudderstack.com/docs/sources/event-streams/sdks/swift-sdk/breaking-changes/ios-v2/migration-guide/

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)  
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [x] Deprecation notice

### Testing

- [x] Verified deprecation warnings appear in Xcode
- [x] Confirmed runtime warning displays correctly when SDK is configured
- [x] Tested that CocoaPods recognizes the deprecated flag
- [x] All existing functionality remains unaffected

### Additional Context

This change is part of the strategic migration plan to sunset the Objective-C based iOS SDK v2.x in favor of the modern Swift SDK. The deprecation notices will help users understand the timeline and provide clear guidance for migration.

**Related Links:**
- Swift SDK Repository: https://github.com/rudderlabs/rudder-sdk-swift
- Swift SDK Documentation: https://www.rudderstack.com/docs/sources/event-streams/sdks/swift-sdk/
- Migration Guide: https://www.rudderstack.com/docs/sources/event-streams/sdks/swift-sdk/breaking-changes/ios-v2/migration-guide/