### PR TITLE
fix: resolve SwiftLint empty_count violation in AppleUtils

### DIFF
--- a/Sources/Classes/Helpers/Platforms/Vendors/AppleUtils.swift
+++ b/Sources/Classes/Helpers/Platforms/Vendors/AppleUtils.swift
@@ -87,7 +87,7 @@ internal class PhoneVendor: Vendor {
     func retrieveCarrierNames() -> String? {
         let systemVersion = UIDevice.current.systemVersion
         let versionComponents = systemVersion.split(separator: ".").compactMap { Int($0) }
-        if versionComponents.count > 0 {
+        if !versionComponents.isEmpty {
             let majorVersion = versionComponents[0]
             
             if majorVersion >= 16 {


### PR DESCRIPTION
# Description

  - Replace versionComponents.count > 0 with !versionComponents.isEmpty in AppleUtils.swift to resolve the SwiftLint empty_count rule violation.

## Details

  - SwiftLint's https://realm.github.io/SwiftLint/empty_count.html rule prefers using .isEmpty over comparing .count to zero, as .isEmpty is more expressive and can be more performant.

  File changed: Sources/Classes/Helpers/Platforms/Vendors/AppleUtils.swift

``` Swift
  - if versionComponents.count > 0 {
  + if !versionComponents.isEmpty {
```

## Test plan
  - Confirm SwiftLint no longer reports empty_count violation for this file.