### PR TITLE
chore(release): pulling release/2.6.0 into master

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+## [2.6.0](https://github.com/rudderlabs/rudder-sdk-ios/compare/v2.5.1-beta...v2.6.0) (2026-02-11)
+
+
+### Features
+
+* add comprehensive deprecation notices for iOS SDK v2.x ([#584](https://github.com/rudderlabs/rudder-sdk-ios/issues/584)) ([d7956cc](https://github.com/rudderlabs/rudder-sdk-ios/commit/d7956ccf175a7a91491f3c41d5fab66c381480c9))
+
+
+### Bug Fixes
+
+* resolve SwiftLint empty_count violation in AppleUtils ([#585](https://github.com/rudderlabs/rudder-sdk-ios/issues/585)) ([4df73b1](https://github.com/rudderlabs/rudder-sdk-ios/commit/4df73b16887139fc7a70d8ba586d9d4f3c88f021))
+
 ## [2.5.1-beta](https://github.com/rudderlabs/rudder-sdk-ios/compare/v2.5.0-beta...v2.5.1-beta) (2024-04-24)
 
 

--- a/Package.swift
+++ b/Package.swift
@@ -1,5 +1,31 @@
 // swift-tools-version:5.3
 
+/*
+┌────────────────────────────────────────────────────────────────────┐
+│                     ⚠️ DEPRECATION WARNING                         │
+├────────────────────────────────────────────────────────────────────┤
+│ This version of the RudderStack iOS SDK is deprecated and is       │
+│ no longer actively maintained.                                     │
+│ Please migrate to the newer Swift-based iOS SDK for continued      │
+│                                                                    │
+│ support, bug fixes, and new features.                              │
+│                                                                    │
+│ Swift SDK Repository:                                              │
+│ https://github.com/rudderlabs/rudder-sdk-swift                     │
+│                                                                    │
+│ Documentation:                                                     │
+│ https://www.rudderstack.com/docs/sources/event-streams/sdks/       │
+│ swift-sdk/                                                         │
+│                                                                    │
+│ Migration Documentation:                                           │
+│ https://www.rudderstack.com/docs/sources/event-streams             │
+│ /sdks/swift-sdk/breaking-changes/ios-v2/migration-guide/           │
+│                                                                    │
+│ This SDK will be sunset in the near future. We strongly            │
+│ recommend migrating as soon as possible.                           │
+└────────────────────────────────────────────────────────────────────┘
+*/
+
 import PackageDescription
 
 let package = Package(

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 <p align="center">
   <a href="https://cocoapods.org/pods/Rudder">
-    <img src="https://img.shields.io/static/v1?label=pod&message=v2.5.1-beta&color=blue&style=flat">
+    <img src="https://img.shields.io/static/v1?label=pod&message=v2.6.0&color=blue&style=flat">
     </a>
 </p>
 
@@ -54,7 +54,7 @@ The iOS SDK is available through [**CocoaPods**](https://cocoapods.org), [**Cart
 To install the SDK, simply add the following line to your Podfile:
 
 ```xcode
-pod 'Rudder', '2.5.1-beta'
+pod 'Rudder', '2.6.0'
 ```
 
 ### Carthage
@@ -62,7 +62,7 @@ pod 'Rudder', '2.5.1-beta'
 For Carthage support, add the following line to your `Cartfile`:
 
 ```xcode
-github "rudderlabs/rudder-sdk-ios" "v2.5.1-beta"
+github "rudderlabs/rudder-sdk-ios" "v2.6.0"
 ```
 
 > Remember to include the following code where you want to refer to or use the RudderStack SDK classes, as shown:
@@ -93,7 +93,7 @@ You can also add the RudderStack SDK using the Swift Package Mangaer in one of t
 ![Adding a package](https://user-images.githubusercontent.com/59817155/140903027-286a1d64-f5d5-4041-9827-47b6cef76a46.png)
 
 2. Enter the package repository (`git@github.com:rudderlabs/rudder-sdk-ios.git`) in the search bar.
-3. In **Dependency Rule**, select **Up to Next Major Version**, and enter `2.5.1-beta` as the value, as shown:
+3. In **Dependency Rule**, select **Up to Next Major Version**, and enter `2.6.0` as the value, as shown:
 
 ![Setting the dependency](https://user-images.githubusercontent.com/59817155/145574696-8c849749-13e0-40d5-aacb-3fccb5c8e67d.png)
 
@@ -120,7 +120,7 @@ let package = Package(
     ],
     dependencies: [
         // Dependencies declare other packages that this package depends on.
-        .package(url: "git@github.com:rudderlabs/rudder-sdk-ios.git", from: "2.5.1-beta")
+        .package(url: "git@github.com:rudderlabs/rudder-sdk-ios.git", from: "2.6.0")
     ],
     targets: [
         // Targets are the basic building blocks of a package. A target can define a module or a test suite.

--- a/Rudder.podspec
+++ b/Rudder.podspec
@@ -6,15 +6,35 @@ Pod::Spec.new do |s|
   s.name             = 'Rudder'
   s.version          = package['version']
   s.summary          = "Privacy and Security focused Segment-alternative. iOS, tvOS, watchOS & macOS SDK"
-  s.description      = <<-DESC
-  Rudder is a platform for collecting, storing and routing customer event data to dozens of tools. Rudder is open-source, can run in your cloud environment (AWS, GCP, Azure or even your data-centre) and provides a powerful transformation framework to process your event data on the fly.
-                       DESC
+  
+  s.description = <<-DESC
+  ⚠️ DEPRECATION NOTICE
+
+  Version 2.x of the RudderStack iOS SDK is deprecated and is no longer actively maintained.
+
+  Please migrate to the newer Swift-based iOS SDK for continued support, bug fixes, and new features.
+
+  Swift SDK Repository:
+  https://github.com/rudderlabs/rudder-sdk-swift
+
+  Documentation:
+  https://www.rudderstack.com/docs/sources/event-streams/sdks/swift-sdk/
+
+  This SDK will be sunset in the near future. We strongly recommend migrating as soon as possible.
+
+
+  ABOUT RUDDERSTACK
+
+  Rudder is a platform for collecting, storing, and routing customer event data to dozens of tools. It is open-source, can run in your cloud environment (AWS, GCP, Azure, or your data center), and provides a powerful transformation framework to process event data on the fly.
+  DESC
 
   s.homepage         = "https://github.com/rudderlabs/rudder-sdk-ios"
   s.license          = { :type => "Apache", :file => "LICENSE" }
   s.author           = { "RudderStack" => "sdk@rudderstack.com" }
   s.source           = { :git => "https://github.com/rudderlabs/rudder-sdk-ios.git", :tag => "v#{s.version}" }
   s.resource_bundles = { s.name => 'Sources/Resources/PrivacyInfo.xcprivacy' }
+
+  s.deprecated = true
 
   s.swift_version = '5.3'
   s.ios.deployment_target = '12.0'

--- a/Sources/Classes/Client/RSClient.swift
+++ b/Sources/Classes/Client/RSClient.swift
@@ -8,6 +8,7 @@
 
 import Foundation
 
+@available(*, deprecated, message: "This version of the RudderStack iOS SDK is deprecated and is no longer actively maintained. We strongly recommend migrating to our new Swift SDK as soon as possible.")
 @objc
 open class RSClient: NSObject {
     var config: RSConfig?
@@ -44,6 +45,7 @@ open class RSClient: NSObject {
     @objc
     public func configure(with config: RSConfig) {
         self.config = config
+        self.printDeprecationWarning()
         addPlugins()
     }
     
@@ -380,5 +382,36 @@ extension RSClient {
         default:
             break
         }
+    }
+}
+
+extension RSClient {
+    private func printDeprecationWarning() {
+        let warning = """
+        ┌────────────────────────────────────────────────────────────────────┐
+        │                     ⚠️ DEPRECATION WARNING                         │
+        ├────────────────────────────────────────────────────────────────────┤
+        │ This version of the RudderStack iOS SDK is deprecated and is       │
+        │ no longer actively maintained.                                     │
+        │                                                                    │
+        │ Please migrate to the newer Swift-based iOS SDK for continued      │
+        │ support, bug fixes, and new features.                              │
+        │                                                                    │
+        │ Swift SDK Repository:                                              │
+        │ https://github.com/rudderlabs/rudder-sdk-swift                     │
+        │                                                                    │
+        │ Documentation:                                                     │
+        │ https://www.rudderstack.com/docs/sources/event-streams/sdks/       │
+        │ swift-sdk/                                                         │
+        │                                                                    │
+        │ Migration Documentation:                                           │
+        │ https://www.rudderstack.com/docs/sources/event-streams             │
+        │ /sdks/swift-sdk/breaking-changes/ios-v2/migration-guide/           │
+        │                                                                    │
+        │ This SDK will be sunset in the near future. We strongly            │
+        │ recommend migrating as soon as possible.                           │
+        └────────────────────────────────────────────────────────────────────┘
+        """
+        print(warning)
     }
 }

--- a/Sources/Classes/Common/Constants/RSVersion.swift
+++ b/Sources/Classes/Common/Constants/RSVersion.swift
@@ -9,4 +9,4 @@
 import Foundation
 
 // don't edit this line
-let RSVersion = "2.5.1-beta"
+let RSVersion = "2.6.0"

--- a/Sources/Classes/Domain/Models/RSConfig.swift
+++ b/Sources/Classes/Domain/Models/RSConfig.swift
@@ -8,6 +8,7 @@
 
 import Foundation
 
+@available(*, deprecated, message: "This version of the RudderStack iOS SDK is deprecated and is no longer actively maintained. We strongly recommend migrating to our new Swift SDK as soon as possible.")
 @objc
 open class RSConfig: NSObject {
     let _writeKey: String

--- a/Sources/Classes/Domain/Models/RSOption.swift
+++ b/Sources/Classes/Domain/Models/RSOption.swift
@@ -8,6 +8,7 @@
 
 import Foundation
 
+@available(*, deprecated, message: "This version of the RudderStack iOS SDK is deprecated and is no longer actively maintained. We strongly recommend migrating to our new Swift SDK as soon as possible.")
 @objc
 open class RSOption: NSObject {
     var externalIds: [[String: String]]?

--- a/Sources/Classes/Domain/Protocols/RSMessage.swift
+++ b/Sources/Classes/Domain/Protocols/RSMessage.swift
@@ -8,6 +8,7 @@
 
 import Foundation
 
+@available(*, deprecated, message: "This version of the RudderStack iOS SDK is deprecated and is no longer actively maintained. We strongly recommend migrating to our new Swift SDK as soon as possible.")
 public protocol RSMessage {
     var type: RSMessageType { get set }
     var anonymousId: String? { get set }
@@ -21,6 +22,7 @@ public protocol RSMessage {
     var dictionaryValue: [String: Any] { get }
 }
 
+@available(*, deprecated, message: "This version of the RudderStack iOS SDK is deprecated and is no longer actively maintained. We strongly recommend migrating to our new Swift SDK as soon as possible.")
 public struct TrackMessage: RSMessage {
     public var type: RSMessageType = .track
     public var anonymousId: String?
@@ -53,6 +55,7 @@ public struct TrackMessage: RSMessage {
     }
 }
 
+@available(*, deprecated, message: "This version of the RudderStack iOS SDK is deprecated and is no longer actively maintained. We strongly recommend migrating to our new Swift SDK as soon as possible.")
 public struct IdentifyMessage: RSMessage {
     public var type: RSMessageType = .identify
     public var anonymousId: String?
@@ -83,6 +86,7 @@ public struct IdentifyMessage: RSMessage {
     }
 }
 
+@available(*, deprecated, message: "This version of the RudderStack iOS SDK is deprecated and is no longer actively maintained. We strongly recommend migrating to our new Swift SDK as soon as possible.")
 public struct ScreenMessage: RSMessage {
     public var type: RSMessageType = .screen
     public var anonymousId: String?
@@ -118,6 +122,7 @@ public struct ScreenMessage: RSMessage {
     }
 }
 
+@available(*, deprecated, message: "This version of the RudderStack iOS SDK is deprecated and is no longer actively maintained. We strongly recommend migrating to our new Swift SDK as soon as possible.")
 public struct GroupMessage: RSMessage {
     public var type: RSMessageType = .group
     public var anonymousId: String?
@@ -150,6 +155,7 @@ public struct GroupMessage: RSMessage {
     }
 }
 
+@available(*, deprecated, message: "This version of the RudderStack iOS SDK is deprecated and is no longer actively maintained. We strongly recommend migrating to our new Swift SDK as soon as possible.")
 public struct AliasMessage: RSMessage {
     public var type: RSMessageType = .alias
     public var anonymousId: String?

--- a/Sources/Classes/Domain/Protocols/RSPlugins.swift
+++ b/Sources/Classes/Domain/Protocols/RSPlugins.swift
@@ -29,6 +29,7 @@ public enum UpdateType {
     case refresh
 }
 
+@available(*, deprecated, message: "This version of the RudderStack iOS SDK is deprecated and is no longer actively maintained. We strongly recommend migrating to our new Swift SDK as soon as possible.")
 public protocol RSPlugin: AnyObject {
     var type: PluginType { get }
     var client: RSClient? { get set }

--- a/Sources/Classes/Helpers/Platforms/Vendors/AppleUtils.swift
+++ b/Sources/Classes/Helpers/Platforms/Vendors/AppleUtils.swift
@@ -87,7 +87,7 @@ internal class PhoneVendor: Vendor {
     func retrieveCarrierNames() -> String? {
         let systemVersion = UIDevice.current.systemVersion
         let versionComponents = systemVersion.split(separator: ".").compactMap { Int($0) }
-        if versionComponents.count > 0 {
+        if !versionComponents.isEmpty {
             let majorVersion = versionComponents[0]
             
             if majorVersion >= 16 {

--- a/package.json
+++ b/package.json
@@ -1,4 +1,4 @@
 {
-    "version": "2.5.1-beta",
+    "version": "2.6.0",
     "description": "Rudder is a platform for collecting, storing and routing customer event data to dozens of tools"
 }

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -6,7 +6,7 @@ sonar.qualitygate.wait=false
 sonar.projectKey=rudderlabs_rudder-sdk-ios-v2
 sonar.organization=rudderlabs
 sonar.projectName=RudderStack iOS SDK(v2)
-sonar.projectVersion=2.5.1-beta
+sonar.projectVersion=2.6.0
 
 # Meta-data for the project
 sonar.links.scm=https://github.com/rudderlabs/rudder-sdk-ios


### PR DESCRIPTION
:crown: *An automated PR*

   Unreleased (2026-02-11)<br> * fix: resolve SwiftLint empty_count violation in AppleUtils ( 585) ([4df73b1](https://github.com/rudderlabs/rudder-sdk-ios/commit/4df73b1)), closes [ 585](https://github.com/rudderlabs/rudder-sdk-ios/issues/585)<br> * feat: add comprehensive deprecation notices for iOS SDK v2.x ( 584) ([d7956cc](https://github.com/rudderlabs/rudder-sdk-ios/commit/d7956cc)), closes [ 584](https://github.com/rudderlabs/rudder-sdk-ios/issues/584)<br> * chore(docs): remove V2 SDK documentation and add deprecation warning ( 575) ([7cc5204](https://github.com/rudderlabs/rudder-sdk-ios/commit/7cc5204)), closes [ 575](https://github.com/rudderlabs/rudder-sdk-ios/issues/575)