### PR TITLE
ci: add members:read permission to fix team reviewer assignment

### DIFF
--- a/.github/workflows/draft-new-release-v2.yml
+++ b/.github/workflows/draft-new-release-v2.yml
@@ -27,6 +27,7 @@ jobs:
           repositories: rudder-sdk-ios
           permission-contents: write # to create commits, tags, and push branches
           permission-pull-requests: write # to create and update PRs
+          permission-members: read # to request team reviewers on PRs
 
       - name: Checkout source branch
         uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4.3.0

--- a/.github/workflows/draft-new-release.yml
+++ b/.github/workflows/draft-new-release.yml
@@ -27,6 +27,7 @@ jobs:
           repositories: rudder-sdk-ios
           permission-contents: write # to create commits, tags, and push branches
           permission-pull-requests: write # to create and update PRs
+          permission-members: read # to request team reviewers on PRs
 
       - name: Checkout source branch
         uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4.3.0

--- a/.github/workflows/publish-new-release.yml
+++ b/.github/workflows/publish-new-release.yml
@@ -29,6 +29,7 @@ jobs:
           repositories: rudder-sdk-ios
           permission-contents: write # to create releases and tags
           permission-pull-requests: write # to create and update PRs
+          permission-members: read # to request team reviewers on PRs
 
       - name: Extract version from branch name (for release branches)
         id: extract-version


### PR DESCRIPTION
# Description

- After migrating from PAT to GitHub App token in #583, the `draft-new-release` workflow started failing with Could not resolve to a node with the global id when trying to assign `@rudderlabs/sdk-ios` as a PR reviewer. 
- The PAT had implicit org-level permissions, but the GitHub App token requires members: read to be explicitly requested.
- Added permission-members: read to the token generation step in all three affected workflows.
- The same change applied on below workflows also.
   - `draft-new-release-v2`
   - `publish-new-release`

