### PR TITLE
chore: add DeepWiki badge to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,10 +9,11 @@
 <p align="center">
   <a href="https://cocoapods.org/pods/Rudder">
     <img src="https://img.shields.io/static/v1?label=pod&message=v1.32.0&color=blue&style=flat">
-    </a>
+  </a>
+  <a href="https://deepwiki.com/rudderlabs/rudder-sdk-ios">
+    <img src="https://deepwiki.com/badge.svg" alt="Ask DeepWiki">
+  </a>
 </p>
-
-[![Ask DeepWiki](https://deepwiki.com/badge.svg)](https://deepwiki.com/rudderlabs/rudder-sdk-ios)
 
 <p align="center">
   <b>

--- a/README.md
+++ b/README.md
@@ -12,6 +12,8 @@
     </a>
 </p>
 
+[![Ask DeepWiki](https://deepwiki.com/badge.svg)](https://deepwiki.com/rudderlabs/rudder-sdk-ios)
+
 <p align="center">
   <b>
     <a href="https://rudderstack.com">Website</a>


### PR DESCRIPTION
# Description

Add a DeepWiki badge to the README.md file. The badge links to the DeepWiki page for this repository (https://deepwiki.com/rudderlabs/rudder-sdk-ios), providing an easy entry point for AI-powered documentation and codebase exploration.

This is a documentation-only change with no impact on SDK functionality.
