### PR TITLE
fix(podspec): enable DEFINES_MODULE on Rudder.podspec

### DIFF
--- a/Podfile.lock
+++ b/Podfile.lock
@@ -1,5 +1,5 @@
 PODS:
-  - Rudder (1.31.2)
+  - Rudder (1.32.0)
   - SQLCipher (4.10.0):
     - SQLCipher/standard (= 4.10.0)
   - SQLCipher/common (4.10.0)
@@ -19,7 +19,7 @@ EXTERNAL SOURCES:
     :path: "."
 
 SPEC CHECKSUMS:
-  Rudder: 444f89f881ab16f2225e563dc64bf45f3849ba60
+  Rudder: 5befe9893f52e7c387f929037bd4a96ba026e25a
   SQLCipher: eb79c64049cb002b4e9fcb30edb7979bf4706dfc
 
 PODFILE CHECKSUM: c942a175e75dbaae30985c65a6a158144db54d47

--- a/Rudder.podspec
+++ b/Rudder.podspec
@@ -27,5 +27,7 @@ Pod::Spec.new do |s|
   s.frameworks = 'Foundation'
   
   s.source_files = 'Sources/**/*.{h,m}'
-  
+
+  s.pod_target_xcconfig = { 'DEFINES_MODULE' => 'YES' }
+
 end


### PR DESCRIPTION
## Description

Adds `s.pod_target_xcconfig = { 'DEFINES_MODULE' => 'YES' }` to `Rudder.podspec` so that CocoaPods synthesises a clang module map for `Rudder` when it is integrated as a static library (i.e. no `use_frameworks!`).

This unblocks Swift downstream pods (e.g. `Rudder-Sprig`) that need to `import Rudder` without forcing every customer Podfile to add `:modular_headers => true` on `Rudder`. The responsibility now lives in the SDK itself, which is the correct place for it.

Linear: [SDK-4916](https://linear.app/rudderstack/issue/SDK-4916/ios-v1-enable-defines-module-on-rudderpodspec)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactor/optimization

## Implementation Details

- `Rudder.podspec`: added `s.pod_target_xcconfig = { 'DEFINES_MODULE' => 'YES' }` so CocoaPods generates a module map for the static-library variant of the pod
- No source-code changes (`Sources/**/*.{h,m}` untouched)
- No-op for `use_frameworks!` consumers — CocoaPods already generates a module map there; this flag only affects the static-library integration path

## Checklist

- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] I have added the necessary documentation (if appropriate).
- [x] I have ensured that my code follows the project's code style.
- [x] I have checked for potential performance impacts and optimized if necessary.
- [x] I have checked the code for security issues.
- [x] I have updated the changelog (if required).

## How to test?

**Side-effect verification (existing `use_frameworks!` consumers should be unaffected):**

1. Point a sample Obj-C app with a Rudder device-mode integration (e.g. Adjust) at this branch via `:path =>` in its Podfile.
2. `pod install` and inspect `Pods/Target Support Files/Rudder/`:
   - File list, `Rudder.modulemap`, and `Rudder-umbrella.h` should be identical to a `develop` install
   - `Rudder.{debug,release}.xcconfig` should differ by exactly one line: `DEFINES_MODULE = YES`
3. Build, launch on simulator, fire `identify` + `track` events.
4. Expected: clean build, app launches, factory is initialised, `/v1/batch` POST returns 200, device-mode dump to the integration succeeds.

**Forward verification (Swift consumers in static-libraries mode):**

5. Point a sample app at `Rudder-Sprig` (Swift) with `pod 'Rudder', :path =>` pinned to this branch.
6. Run `pod install` with no `use_frameworks!` declaration in the Podfile.
7. Expected: `pod install` succeeds where previously it failed with `Could not build module 'Rudder'` from `Rudder-Sprig`'s Swift sources.

## Breaking Changes

None.

`DEFINES_MODULE` is a static-library directive. With `use_frameworks!` enabled, CocoaPods generates a module map regardless, so the flag is a no-op for existing framework-mode consumers. Verified empirically on an Obj-C consumer with `use_frameworks!` + Adjust device-mode — build, launch, event flow, and dataplane delivery all behave identically to `develop`.

## Maintainers Checklist

- [ ] The code has been reviewed.
- [ ] CI tests have passed.
- [ ] All necessary documentation has been updated.

## Screenshots (if applicable)

N/A

## Additional Context

`DEFINES_MODULE` controls whether CocoaPods synthesises a clang module map for a pod's static-library product. Frameworks always carry a module map; static libraries don't, unless this flag is set or the customer adds `:modular_headers => true` in their Podfile.

The motivation is downstream Swift integrations. `Rudder-Sprig` (Swift) does `import Rudder`; without a module map on `Rudder` it cannot resolve in `mode=none` (no `use_frameworks!`) or `use_frameworks! :linkage => :static`. Putting the flag on `Rudder.podspec` moves that requirement off every customer's Podfile and into the SDK, which is the right surface for a packaging concern. Any future Swift-based integration that depends on `Rudder` will benefit from the same fix without further work.
