### PR TITLE
fix(ci): publish private podspecs via Specs PR

### DIFF
--- a/.github/workflows/deploy-private-pod.yml
+++ b/.github/workflows/deploy-private-pod.yml
@@ -30,7 +30,8 @@ jobs:
           app-id: ${{ vars.RELEASE_APP_ID }}
           private-key: ${{ secrets.RELEASE_PRIVATE_KEY }}
           repositories: rudder-sdk-ios,Specs
-          permission-contents: write # to push to private Specs repo
+          permission-contents: write # to push branches in private Specs repo
+          permission-pull-requests: write # to create PRs in private Specs repo
 
       - name: 'Checkout'
         uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4.3.0
@@ -51,6 +52,41 @@ jobs:
         run: |
           pod repo add rudderlabs https://x-access-token:${GH_TOKEN}@github.com/rudderlabs/Specs.git
         
-      - name: 'Add Podspec to repo'
+      - name: 'Add Podspec to local private Spec repo'
         run: |
-          pod repo push rudderlabs Rudder.podspec.json --allow-warnings
+          pod repo push rudderlabs Rudder.podspec.json --allow-warnings --local-only
+
+      - name: 'Create private Specs PR'
+        env:
+          GH_TOKEN: ${{ steps.generate-token.outputs.token }}
+        run: |
+          set -euo pipefail
+
+          pod_version="$(jq -r .version package.json)"
+          pr_title="deploy: Rudder ${pod_version}"
+          specs_repo="${HOME}/.cocoapods/repos/rudderlabs"
+
+          cd "$specs_repo"
+
+          if ! git diff --quiet origin/master...HEAD; then
+            existing_pr="$(gh pr list --repo rudderlabs/Specs --state open --json title,url | jq -r --arg title "$pr_title" '.[] | select(.title == $title) | .url' | head -n 1)"
+            if [ -n "$existing_pr" ]; then
+              echo "A Specs PR already exists for Rudder ${pod_version}: $existing_pr"
+              exit 0
+            fi
+
+            branch_name="deploy/rudder-${pod_version}-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
+            git checkout -B "$branch_name"
+            git push origin "HEAD:refs/heads/${branch_name}"
+
+            gh pr create \
+              --repo rudderlabs/Specs \
+              --base master \
+              --head "$branch_name" \
+              --title "$pr_title" \
+              --body "Adds Rudder ${pod_version} to the private CocoaPods Specs repo.
+
+          Created by ${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}. A human review is required by the Specs repository ruleset before merge."
+          else
+            echo "No private Specs changes detected for Rudder ${pod_version}."
+          fi

--- a/.github/workflows/draft-new-beta-release.yml
+++ b/.github/workflows/draft-new-beta-release.yml
@@ -126,6 +126,41 @@ jobs:
         run: |
           pod repo add rudderlabs https://x-access-token:${GH_TOKEN}@github.com/rudderlabs/Specs.git
 
-      - name: 'Add Podspec to repo'
+      - name: 'Add Podspec to local private Spec repo'
         run: |
-          pod repo push rudderlabs Rudder.podspec.json
+          pod repo push rudderlabs Rudder.podspec.json --allow-warnings --local-only
+
+      - name: 'Create private Specs PR'
+        env:
+          GH_TOKEN: ${{ steps.generate-token.outputs.token }}
+        run: |
+          set -euo pipefail
+
+          pod_version="$(jq -r .version package.json)"
+          pr_title="deploy: Rudder ${pod_version}"
+          specs_repo="${HOME}/.cocoapods/repos/rudderlabs"
+
+          cd "$specs_repo"
+
+          if ! git diff --quiet origin/master...HEAD; then
+            existing_pr="$(gh pr list --repo rudderlabs/Specs --state open --json title,url | jq -r --arg title "$pr_title" '.[] | select(.title == $title) | .url' | head -n 1)"
+            if [ -n "$existing_pr" ]; then
+              echo "A Specs PR already exists for Rudder ${pod_version}: $existing_pr"
+              exit 0
+            fi
+
+            branch_name="deploy/rudder-${pod_version}-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
+            git checkout -B "$branch_name"
+            git push origin "HEAD:refs/heads/${branch_name}"
+
+            gh pr create \
+              --repo rudderlabs/Specs \
+              --base master \
+              --head "$branch_name" \
+              --title "$pr_title" \
+              --body "Adds Rudder ${pod_version} to the private CocoaPods Specs repo.
+
+          Created by ${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}. A human review is required by the Specs repository ruleset before merge."
+          else
+            echo "No private Specs changes detected for Rudder ${pod_version}."
+          fi


### PR DESCRIPTION
Closed in favor of https://github.com/rudderlabs/rudder-sdk-ios/pull/608, which uses a clean branch name and conventional PR title.