### PR TITLE
fix(ci): publish private podspecs via Specs PR

### DIFF
--- a/.github/workflows/deploy-private-pod.yml
+++ b/.github/workflows/deploy-private-pod.yml
@@ -60,33 +60,4 @@ jobs:
         env:
           GH_TOKEN: ${{ steps.generate-token.outputs.token }}
         run: |
-          set -euo pipefail
-
-          pod_version="$(jq -r .version package.json)"
-          pr_title="deploy: Rudder ${pod_version}"
-          specs_repo="${HOME}/.cocoapods/repos/rudderlabs"
-
-          cd "$specs_repo"
-
-          if ! git diff --quiet origin/master...HEAD; then
-            existing_pr="$(gh pr list --repo rudderlabs/Specs --state open --json title,url | jq -r --arg title "$pr_title" '.[] | select(.title == $title) | .url' | head -n 1)"
-            if [ -n "$existing_pr" ]; then
-              echo "A Specs PR already exists for Rudder ${pod_version}: $existing_pr"
-              exit 0
-            fi
-
-            branch_name="deploy/rudder-${pod_version}-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
-            git checkout -B "$branch_name"
-            git push origin "HEAD:refs/heads/${branch_name}"
-
-            gh pr create \
-              --repo rudderlabs/Specs \
-              --base master \
-              --head "$branch_name" \
-              --title "$pr_title" \
-              --body "Adds Rudder ${pod_version} to the private CocoaPods Specs repo.
-
-          Created by ${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}. A human review is required by the Specs repository ruleset before merge."
-          else
-            echo "No private Specs changes detected for Rudder ${pod_version}."
-          fi
+          bash Scripts/create-private-specs-pr.sh

--- a/.github/workflows/deploy-private-pod.yml
+++ b/.github/workflows/deploy-private-pod.yml
@@ -30,7 +30,8 @@ jobs:
           app-id: ${{ vars.RELEASE_APP_ID }}
           private-key: ${{ secrets.RELEASE_PRIVATE_KEY }}
           repositories: rudder-sdk-ios,Specs
-          permission-contents: write # to push to private Specs repo
+          permission-contents: write # to push branches in private Specs repo
+          permission-pull-requests: write # to create PRs in private Specs repo
 
       - name: 'Checkout'
         uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4.3.0
@@ -51,6 +52,41 @@ jobs:
         run: |
           pod repo add rudderlabs https://x-access-token:${GH_TOKEN}@github.com/rudderlabs/Specs.git
         
-      - name: 'Add Podspec to repo'
+      - name: 'Add Podspec to local private Spec repo'
         run: |
-          pod repo push rudderlabs Rudder.podspec.json --allow-warnings
+          pod repo push rudderlabs Rudder.podspec.json --allow-warnings --local-only
+
+      - name: 'Create private Specs PR'
+        env:
+          GH_TOKEN: ${{ steps.generate-token.outputs.token }}
+        run: |
+          set -euo pipefail
+
+          pod_version="$(jq -r .version package.json)"
+          pr_title="deploy: Rudder ${pod_version}"
+          specs_repo="${HOME}/.cocoapods/repos/rudderlabs"
+
+          cd "$specs_repo"
+
+          if ! git diff --quiet origin/master...HEAD; then
+            existing_pr="$(gh pr list --repo rudderlabs/Specs --state open --json title,url | jq -r --arg title "$pr_title" '.[] | select(.title == $title) | .url' | head -n 1)"
+            if [ -n "$existing_pr" ]; then
+              echo "A Specs PR already exists for Rudder ${pod_version}: $existing_pr"
+              exit 0
+            fi
+
+            branch_name="deploy/rudder-${pod_version}-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
+            git checkout -B "$branch_name"
+            git push origin "HEAD:refs/heads/${branch_name}"
+
+            gh pr create \
+              --repo rudderlabs/Specs \
+              --base master \
+              --head "$branch_name" \
+              --title "$pr_title" \
+              --body "Adds Rudder ${pod_version} to the private CocoaPods Specs repo.
+
+          Created by ${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}. A human review is required by the Specs repository ruleset before merge."
+          else
+            echo "No private Specs changes detected for Rudder ${pod_version}."
+          fi

--- a/.github/workflows/draft-new-beta-release.yml
+++ b/.github/workflows/draft-new-beta-release.yml
@@ -126,6 +126,41 @@ jobs:
         run: |
           pod repo add rudderlabs https://x-access-token:${GH_TOKEN}@github.com/rudderlabs/Specs.git
 
-      - name: 'Add Podspec to repo'
+      - name: 'Add Podspec to local private Spec repo'
         run: |
-          pod repo push rudderlabs Rudder.podspec.json
+          pod repo push rudderlabs Rudder.podspec.json --allow-warnings --local-only
+
+      - name: 'Create private Specs PR'
+        env:
+          GH_TOKEN: ${{ steps.generate-token.outputs.token }}
+        run: |
+          set -euo pipefail
+
+          pod_version="$(jq -r .version package.json)"
+          pr_title="deploy: Rudder ${pod_version}"
+          specs_repo="${HOME}/.cocoapods/repos/rudderlabs"
+
+          cd "$specs_repo"
+
+          if ! git diff --quiet origin/master...HEAD; then
+            existing_pr="$(gh pr list --repo rudderlabs/Specs --state open --json title,url | jq -r --arg title "$pr_title" '.[] | select(.title == $title) | .url' | head -n 1)"
+            if [ -n "$existing_pr" ]; then
+              echo "A Specs PR already exists for Rudder ${pod_version}: $existing_pr"
+              exit 0
+            fi
+
+            branch_name="deploy/rudder-${pod_version}-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
+            git checkout -B "$branch_name"
+            git push origin "HEAD:refs/heads/${branch_name}"
+
+            gh pr create \
+              --repo rudderlabs/Specs \
+              --base master \
+              --head "$branch_name" \
+              --title "$pr_title" \
+              --body "Adds Rudder ${pod_version} to the private CocoaPods Specs repo.
+
+          Created by ${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}. A human review is required by the Specs repository ruleset before merge."
+          else
+            echo "No private Specs changes detected for Rudder ${pod_version}."
+          fi

--- a/.github/workflows/draft-new-beta-release.yml
+++ b/.github/workflows/draft-new-beta-release.yml
@@ -134,33 +134,4 @@ jobs:
         env:
           GH_TOKEN: ${{ steps.generate-token.outputs.token }}
         run: |
-          set -euo pipefail
-
-          pod_version="$(jq -r .version package.json)"
-          pr_title="deploy: Rudder ${pod_version}"
-          specs_repo="${HOME}/.cocoapods/repos/rudderlabs"
-
-          cd "$specs_repo"
-
-          if ! git diff --quiet origin/master...HEAD; then
-            existing_pr="$(gh pr list --repo rudderlabs/Specs --state open --json title,url | jq -r --arg title "$pr_title" '.[] | select(.title == $title) | .url' | head -n 1)"
-            if [ -n "$existing_pr" ]; then
-              echo "A Specs PR already exists for Rudder ${pod_version}: $existing_pr"
-              exit 0
-            fi
-
-            branch_name="deploy/rudder-${pod_version}-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
-            git checkout -B "$branch_name"
-            git push origin "HEAD:refs/heads/${branch_name}"
-
-            gh pr create \
-              --repo rudderlabs/Specs \
-              --base master \
-              --head "$branch_name" \
-              --title "$pr_title" \
-              --body "Adds Rudder ${pod_version} to the private CocoaPods Specs repo.
-
-          Created by ${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}. A human review is required by the Specs repository ruleset before merge."
-          else
-            echo "No private Specs changes detected for Rudder ${pod_version}."
-          fi
+          bash Scripts/create-private-specs-pr.sh

--- a/Scripts/create-private-specs-pr.sh
+++ b/Scripts/create-private-specs-pr.sh
@@ -4,15 +4,18 @@ set -euo pipefail
 pod_version="$(jq -r .version package.json)"
 pr_title="deploy: Rudder ${pod_version}"
 specs_repo="${SPECS_REPO_PATH:-${HOME}/.cocoapods/repos/rudderlabs}"
+specs_gh_repo="rudderlabs/Specs"
 
 cd "$specs_repo"
+
+git fetch origin +refs/heads/master:refs/remotes/origin/master
 
 if git diff --quiet origin/master...HEAD; then
   echo "No private Specs changes detected for Rudder ${pod_version}."
   exit 0
 fi
 
-existing_pr="$(gh pr list --repo rudderlabs/Specs --state open --json title,url --limit 100 | jq -r --arg title "$pr_title" 'map(select(.title == $title))[0].url // empty')"
+existing_pr="$(gh pr list --repo "$specs_gh_repo" --state open --json title,url --limit 100 | jq -r --arg title "$pr_title" 'map(select(.title == $title))[0].url // empty')"
 if [ -n "$existing_pr" ]; then
   echo "A Specs PR already exists for Rudder ${pod_version}: $existing_pr"
   exit 0
@@ -30,7 +33,7 @@ BODY
 )"
 
 gh pr create \
-  --repo rudderlabs/Specs \
+  --repo "$specs_gh_repo" \
   --base master \
   --head "$branch_name" \
   --title "$pr_title" \

--- a/Scripts/create-private-specs-pr.sh
+++ b/Scripts/create-private-specs-pr.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+pod_version="$(jq -r .version package.json)"
+pr_title="deploy: Rudder ${pod_version}"
+specs_repo="${SPECS_REPO_PATH:-${HOME}/.cocoapods/repos/rudderlabs}"
+
+cd "$specs_repo"
+
+if git diff --quiet origin/master...HEAD; then
+  echo "No private Specs changes detected for Rudder ${pod_version}."
+  exit 0
+fi
+
+existing_pr="$(gh pr list --repo rudderlabs/Specs --state open --json title,url --limit 100 | jq -r --arg title "$pr_title" 'map(select(.title == $title))[0].url // empty')"
+if [ -n "$existing_pr" ]; then
+  echo "A Specs PR already exists for Rudder ${pod_version}: $existing_pr"
+  exit 0
+fi
+
+branch_name="deploy/rudder-${pod_version}-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
+git checkout -B "$branch_name"
+git push origin "HEAD:refs/heads/${branch_name}"
+
+pr_body="$(cat <<BODY
+Adds Rudder ${pod_version} to the private CocoaPods Specs repo.
+
+Created by ${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}. A human review is required by the Specs repository ruleset before merge.
+BODY
+)"
+
+gh pr create \
+  --repo rudderlabs/Specs \
+  --base master \
+  --head "$branch_name" \
+  --title "$pr_title" \
+  --body "$pr_body"


### PR DESCRIPTION
## Summary

Fixes SDK-4937 by changing private CocoaPods Specs publishing to respect the `rudderlabs/Specs` branch ruleset.

## What changed

- `deploy-private-pod.yml` now runs `pod repo push ... --local-only`, then pushes a `deploy/rudder-<version>-<run>` branch to `rudderlabs/Specs` and opens a PR against `Specs/master`.
- `draft-new-beta-release.yml` uses the same local-only + Specs PR flow for beta podspecs.
- The release App token in `deploy-private-pod.yml` now requests `pull-requests: write` for `Specs` so it can create the Specs PR.
- Beta private pod publishing now uses `--allow-warnings`, matching the GA private mirror path and allowing the workflow to reach the Specs PR handoff on current Xcode warnings.

## Why

`pod repo push` performs a direct `git push origin HEAD`, which maps to `Specs/master`. That now fails with `GH013` because `rudderlabs/Specs` requires changes through PRs with review.

This keeps the Specs ruleset intact and makes the workflow create the human-approved PR that the ruleset expects.

## Validation

- Parsed both changed workflow YAML files with Ruby YAML.
- Ran `bash -n` over the new `Create private Specs PR` shell blocks.
- Ran `git diff --check`.

## Notes for reviewers

This PR targets `develop`, matching the repo default branch. The fix needs to reach `master` before the next release PR opens for the `Deploy to Private Pod` workflow on `master` to use the new behavior.