### PR TITLE
chore(codeowners): set sdk_team as code owners

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -3,7 +3,7 @@ name: Bug report
 about: Create a report to help us improve
 title: "BUG : <Title>"
 labels: bug, open source
-assignees: "@rudderlabs/sdk-ios"
+assignees: []
 ---
 
 **Describe the bug**

--- a/.github/workflows/draft-new-release-v2.yml
+++ b/.github/workflows/draft-new-release-v2.yml
@@ -120,4 +120,4 @@ jobs:
           github_token: ${{ steps.generate-token.outputs.token }}
           pr_title: "chore(release): pulling ${{ steps.create-release.outputs.branch_name }} into master"
           pr_body: ":crown: *An automated PR*\n\n${{ steps.finish-release.outputs.commit_summary }}"
-          pr_reviewer: "@rudderlabs/sdk-ios"
+          pr_reviewer: "@rudderlabs/sdk_team"

--- a/.github/workflows/draft-new-release.yml
+++ b/.github/workflows/draft-new-release.yml
@@ -121,4 +121,4 @@ jobs:
           github_token: ${{ steps.generate-token.outputs.token }}
           pr_title: "chore(release): pulling ${{ steps.create-release.outputs.branch_name }} into master"
           pr_body: ":crown: *An automated PR*\n\n${{ steps.finish-release.outputs.commit_summary }}"
-          pr_reviewer: "@rudderlabs/sdk-ios"
+          pr_reviewer: "@rudderlabs/sdk_team"

--- a/.github/workflows/publish-new-release.yml
+++ b/.github/workflows/publish-new-release.yml
@@ -68,7 +68,7 @@ jobs:
           github_token: ${{ steps.generate-token.outputs.token }}
           pr_title: "chore(release): pulling master into develop post release v${{ steps.extract-version.outputs.release_version }}"
           pr_body: ":crown: *An automated PR*"
-          pr_reviewer: "@rudderlabs/sdk-ios"
+          pr_reviewer: "@rudderlabs/sdk_team"
 
       - name: Delete hotfix release branch
         uses: koj-co/delete-merged-action@63a03c35810a8a7d4840d18793c0f68ff8b59450 # master

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,1 @@
-* @rudderlabs/sdk-ios
+* @rudderlabs/sdk_team


### PR DESCRIPTION
# Description

Replaces `@rudderlabs/sdk-ios` with `@rudderlabs/sdk_team` as the repo's code owners so any SDK team member's review can unblock chore PRs (Dependabot merges, CI fixes). Also updates the release workflows' `pr_reviewer` to the same team and clears the non-functional team assignee from the bug-report issue template. Brings this repo in line with the other SDK repos already migrated.

Fixes [SDK-5170](https://linear.app/rudderstack/issue/SDK-5170/set-sdk-team-as-code-owners-in-rudder-sdk-ios)
