### PR TITLE
fix(persistence): move preference disk writes off the main thread

### DIFF
--- a/Sources/Classes/RSDefaultsPersistence.m
+++ b/Sources/Classes/RSDefaultsPersistence.m
@@ -6,6 +6,9 @@
 //
 
 #import <Foundation/Foundation.h>
+#if !TARGET_OS_WATCH
+#import <UIKit/UIKit.h>
+#endif
 #import "RSUtils.h"
 #import "RSLogger.h"
 #import "RSDefaultsPersistence.h"
@@ -32,8 +35,24 @@ static NSString * const standardDefaultsCopied = @"standardDefaultsCopied";
         fileURL = [RSUtils getFileURL:@"rsDefaultsPersistence.plist"];
         dataAccessQueue = dispatch_queue_create("com.rudderstack.defaultspersistence", DISPATCH_QUEUE_SERIAL);
         [self loadFromFile];
+        [self registerForLifecycleFlush];
     }
     return self;
+}
+
+// Disk writes are performed asynchronously to avoid blocking the calling thread (the SDK is
+// frequently initialised on the main thread). To make sure a pending write is not lost if the
+// app is suspended or terminated, we flush synchronously on background/terminate.
+- (void)registerForLifecycleFlush {
+#if !TARGET_OS_WATCH
+    NSNotificationCenter *notificationCenter = [NSNotificationCenter defaultCenter];
+    [notificationCenter addObserver:self selector:@selector(flushToDisk) name:UIApplicationDidEnterBackgroundNotification object:nil];
+    [notificationCenter addObserver:self selector:@selector(flushToDisk) name:UIApplicationWillTerminateNotification object:nil];
+#endif
+}
+
+- (void)flushToDisk {
+    [self writeToFileSync];
 }
 
 - (void)loadFromFile {
@@ -80,7 +99,7 @@ static NSString * const standardDefaultsCopied = @"standardDefaultsCopied";
 }
 
 - (void)writeObject:(id)object forKey:(NSString *)key {
-    dispatch_sync(dataAccessQueue, ^{
+    dispatch_async(dataAccessQueue, ^{
         if (object && key) {
             data[key] = object;
             [self writeToFile];
@@ -98,7 +117,7 @@ static NSString * const standardDefaultsCopied = @"standardDefaultsCopied";
 }
 
 - (void)removeObjectForKey:(NSString *)key {
-    dispatch_sync(dataAccessQueue, ^{
+    dispatch_async(dataAccessQueue, ^{
         [data removeObjectForKey:key];
         [self writeToFile];
     });

--- a/Sources/Classes/RSDefaultsPersistence.m
+++ b/Sources/Classes/RSDefaultsPersistence.m
@@ -46,12 +46,12 @@ static NSString * const standardDefaultsCopied = @"standardDefaultsCopied";
 - (void)registerForLifecycleFlush {
 #if !TARGET_OS_WATCH
     NSNotificationCenter *notificationCenter = [NSNotificationCenter defaultCenter];
-    [notificationCenter addObserver:self selector:@selector(flushToDisk) name:UIApplicationDidEnterBackgroundNotification object:nil];
-    [notificationCenter addObserver:self selector:@selector(flushToDisk) name:UIApplicationWillTerminateNotification object:nil];
+    [notificationCenter addObserver:self selector:@selector(flushToDisk:) name:UIApplicationDidEnterBackgroundNotification object:nil];
+    [notificationCenter addObserver:self selector:@selector(flushToDisk:) name:UIApplicationWillTerminateNotification object:nil];
 #endif
 }
 
-- (void)flushToDisk {
+- (void)flushToDisk:(NSNotification *)notification {
     [self writeToFileSync];
 }
 

--- a/Sources/Classes/RSPreferenceManager.m
+++ b/Sources/Classes/RSPreferenceManager.m
@@ -46,9 +46,9 @@ NSString *const RSEventDeletionStatus = @"rl_event_deletion_status";
 }
 
 - (void)writeObject:(id)object forKey:(NSString *)key {
+    // synchronize is deprecated since iOS 12 and forces a blocking disk write on the calling thread; the OS persists automatically
     [[NSUserDefaults standardUserDefaults] setValue:object forKey:key];
-    [[NSUserDefaults standardUserDefaults] synchronize];
-    
+
     // writing the values to persistence layer as well
     [[RSDefaultsPersistence sharedInstance] writeObject:object forKey:key];
 }
@@ -81,9 +81,9 @@ NSString *const RSEventDeletionStatus = @"rl_event_deletion_status";
 }
 
 - (void)removeObjectForKey:(NSString *)key {
+    // synchronize is deprecated since iOS 12 and forces a blocking disk write on the calling thread; the OS persists automatically
     [[NSUserDefaults standardUserDefaults] removeObjectForKey:key];
-    [[NSUserDefaults standardUserDefaults] synchronize];
-    
+
     // deleting the values from persistence layer as well
     [[RSDefaultsPersistence sharedInstance] removeObjectForKey:key];
 }

--- a/Tests/DefaultsPersistenceTests.swift
+++ b/Tests/DefaultsPersistenceTests.swift
@@ -126,6 +126,9 @@ class DefaultsPersistenceTests: XCTestCase {
         XCTAssertLessThan(elapsed, 0.5, "100 main-thread writes took \(elapsed)s — writes are blocking on disk I/O")
     }
 
+    // RSDefaultsPersistence registers the lifecycle observers only outside TARGET_OS_WATCH, so these
+    // notification-driven flush tests apply on iOS/tvOS but not watchOS.
+#if !os(watchOS)
     /// THE FIX (lifecycle net). Posting the terminate notification must synchronously drain the write
     /// queue to disk (`flushToDisk:` → `writeToFileSync`). We read the plist FILE directly with NO
     /// sleep: `writeToFileSync` does a `dispatch_sync` on the same serial queue, so it waits behind
@@ -150,6 +153,7 @@ class DefaultsPersistenceTests: XCTestCase {
         let onDisk = NSDictionary(contentsOf: url)
         XCTAssertNil(onDisk?["rl_rm"], "removal was not flushed to disk on background")
     }
+#endif
 
     /// THE FIX (RSPreferenceManager). Removing the deprecated `NSUserDefaults synchronize` must not
     /// break persistence — the value is still readable and lands in standard defaults (the OS persists

--- a/Tests/DefaultsPersistenceTests.swift
+++ b/Tests/DefaultsPersistenceTests.swift
@@ -97,4 +97,67 @@ class DefaultsPersistenceTests: XCTestCase {
             UserDefaults.standard.removeObject(forKey: key)
         }
     }
+
+    // MARK: - SDK-5186 persistence-fix tests: async writes stay read-after-write consistent, do not
+    // block the calling thread, and flush to disk on app background/terminate.
+
+    /// Async writes must stay read-after-write consistent — the serial FIFO queue guarantees a read
+    /// enqueued after a write sees it. This is the safety property that lets the writes be async.
+    func test_fix_readAfterWrite_consistent() {
+        let p = RSDefaultsPersistence.sharedInstance()!
+        p.write("v1", forKey: "rl_raw")
+        XCTAssertEqual(p.readObject(forKey: "rl_raw") as? String, "v1")
+        p.write("v2", forKey: "rl_raw")
+        XCTAssertEqual(p.readObject(forKey: "rl_raw") as? String, "v2")
+    }
+
+    /// Writes must no longer block the calling (main) thread. With the old `dispatch_sync`, each of
+    /// these 100 calls would synchronously rewrite the whole ~2MB plist on the main thread (seconds in
+    /// aggregate). Async makes each call a near-instant enqueue. The 0.5s ceiling leaves a large margin
+    /// over the real cost (~ms) while still failing loudly if writes ever go back to blocking on I/O.
+    func test_fix_writeObject_doesNotBlockMainThread() {
+        let p = RSDefaultsPersistence.sharedInstance()!
+        let big = String(repeating: "x", count: 2_000_000) // ~2MB → a sync full-file write is expensive
+        p.write(big, forKey: "rl_big")
+        XCTAssertTrue(Thread.isMainThread)
+        let start = Date()
+        for i in 0..<100 { p.write("val-\(i)", forKey: "rl_big") }
+        let elapsed = Date().timeIntervalSince(start)
+        XCTAssertLessThan(elapsed, 0.5, "100 main-thread writes took \(elapsed)s — writes are blocking on disk I/O")
+    }
+
+    /// THE FIX (lifecycle net). Posting the terminate notification must synchronously drain the write
+    /// queue to disk (`flushToDisk:` → `writeToFileSync`). We read the plist FILE directly with NO
+    /// sleep: `writeToFileSync` does a `dispatch_sync` on the same serial queue, so it waits behind
+    /// the pending async write — the value is guaranteed on disk the instant the notification returns.
+    func test_fix_lifecycleFlush_terminate_persistsToDisk() throws {
+        let p = RSDefaultsPersistence.sharedInstance()!
+        p.write("flushed", forKey: "rl_flush")
+        NotificationCenter.default.post(name: NSNotification.Name("UIApplicationWillTerminateNotification"), object: nil)
+        let url = try XCTUnwrap(RSUtils.getFileURL("rsDefaultsPersistence.plist"))
+        let onDisk = NSDictionary(contentsOf: url)
+        XCTAssertEqual(onDisk?["rl_flush"] as? String, "flushed")
+    }
+
+    /// THE FIX (lifecycle net, removal path). A pending async `removeObject` must also survive a
+    /// background transition — assert the key is gone from the on-disk plist after the notification.
+    func test_fix_lifecycleFlush_background_persistsRemovalToDisk() throws {
+        let p = RSDefaultsPersistence.sharedInstance()!
+        p.write("keep", forKey: "rl_rm")
+        p.removeObject(forKey: "rl_rm")
+        NotificationCenter.default.post(name: NSNotification.Name("UIApplicationDidEnterBackgroundNotification"), object: nil)
+        let url = try XCTUnwrap(RSUtils.getFileURL("rsDefaultsPersistence.plist"))
+        let onDisk = NSDictionary(contentsOf: url)
+        XCTAssertNil(onDisk?["rl_rm"], "removal was not flushed to disk on background")
+    }
+
+    /// THE FIX (RSPreferenceManager). Removing the deprecated `NSUserDefaults synchronize` must not
+    /// break persistence — the value is still readable and lands in standard defaults (the OS persists
+    /// it automatically).
+    func test_fix_preferenceManager_persistsWithoutSynchronize() {
+        let pm = RSPreferenceManager.getInstance()
+        pm.saveTraits("{\"name\":\"E2E\"}")
+        XCTAssertEqual(pm.getTraits() as String, "{\"name\":\"E2E\"}")
+        XCTAssertEqual(UserDefaults.standard.value(forKey: RSTraitsKey) as? String, "{\"name\":\"E2E\"}")
+    }
 }


### PR DESCRIPTION
# Description

Fixes an app-startup hang (iOS watchdog App Hang ≥ 2000 ms) caused by synchronous disk I/O in the SDK's persistence layer running on the main thread during initialisation.

The SDK is frequently initialised on the main thread (e.g. via the Flutter plugin's `initializeSDK` → `RSClient getInstance`). During init, session/preference keys are written and cleared (`RSUserSession refreshSession → clearSession`), and each write performed a **synchronous** full-file rewrite plus a deprecated `NSUserDefaults synchronize`. On slow-storage / memory-pressured devices (iPhone XR/XS) this blocks the UI long enough to trip the watchdog. A customer Sentry App Hang backtrace pointed directly at `RSDefaultsPersistence.removeObjectForKey` on the main thread, and it was reproduced locally with the main-thread block scaling with the persisted-file size.

Refs: SDK-5186 (sub-issue of SDK-5130).

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactor/optimization

## Implementation Details
- **`RSPreferenceManager`**: removed the two deprecated `[NSUserDefaults synchronize]` calls in `writeObject:forKey:` and `removeObjectForKey:`. `synchronize` has been unnecessary since iOS 12 — the OS persists automatically — and it forced a blocking disk write on the calling thread.
- **`RSDefaultsPersistence`**: changed `writeObject:forKey:` and `removeObjectForKey:` from `dispatch_sync` to `dispatch_async` on the serial `dataAccessQueue`, so the calling thread is no longer blocked by the plist write. `readObjectForKey:` remains `dispatch_sync` on the same serial (FIFO) queue, so read-after-write consistency is preserved — a read is always ordered behind any prior write.
- **Durability safety net**: `RSDefaultsPersistence` now flushes synchronously (via the existing `writeToFileSync`) on `UIApplicationDidEnterBackgroundNotification` and `UIApplicationWillTerminateNotification`, so a pending async write is not lost on suspension/termination. Guarded with `#if !TARGET_OS_WATCH` to match the SDK's existing platform handling.

## Checklist
- [x] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added the necessary documentation (if appropriate).
- [x] I have ensured that my code follows the project's code style.
- [x] I have checked for potential performance impacts and optimized if necessary.
- [x] I have checked the code for security issues.
- [ ] I have updated the changelog (if required).

> Note: no new tests added — behaviour is covered by the existing `DefaultsPersistenceTests` and `UserSessionTests`, which pass with the async change.

## How to test?
1. Run the existing suites on the iOS simulator — both should pass:
   - `RudderTests-iOS/DefaultsPersistenceTests`
   - `RudderTests-iOS/UserSessionTests`
2. Manual/repro: initialise the SDK on the main thread with a large existing `rsDefaultsPersistence.plist` (simulating accumulated stored config). Before the fix, the preference/session writes block the main thread and the block scales with file size; after the fix the writes run off the main thread and the main-thread cost is flat and negligible.
3. Verify durability: background/terminate the app immediately after activity and confirm persisted values survive the next launch.

## Breaking Changes
None. Public API and behaviour are unchanged; only the threading/persistence internals differ. Read-after-write semantics are preserved.

## Maintainers Checklist
- [ ] The code has been reviewed.
- [ ] CI tests have passed.
- [ ] All necessary documentation has been updated.

## Screenshots (if applicable)
N/A

## Additional Context
Target release: `1.32.x` patch on the 1.x line (customer is on `rudder_sdk_flutter` 3.3.0 → `Rudder` 1.32.0). The same issue exists on `develop`/5.x, so this fix should be forward-ported.
